### PR TITLE
Added npm engine and engine-stict option to package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   "license": "ISC",
   "lint-staged": {
     "*.{js,vue}": "eslint --cache --fix"
+  },
+  "engines": {
+    "node": ">= 15.13.0",
+    "npm": ">= 7.7.6"
   }
 }


### PR DESCRIPTION
This isn't exactly working as advertised for me. But better than nothing. It warns accordingly for an older version of node, but doesnt seem to warn for node 15.3 vs 15.13 but maybe people will get the hint to check here if something isn't working