### PR TITLE
VUE-591: KvMaterialIcon, alternate version

### DIFF
--- a/kv-components/package.json
+++ b/kv-components/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .js,.vue ./"
   },
   "dependencies": {
+    "@mdi/js": "^5.9.55",
     "kv-tokens": "^0.0.1",
     "vue": "^2.6.12"
   }

--- a/kv-components/vue/KvMaterialIcon.vue
+++ b/kv-components/vue/KvMaterialIcon.vue
@@ -1,0 +1,31 @@
+<template>
+	<span
+		class="inline-flex"
+		aria-hidden="true"
+		role="img"
+	>
+		<svg
+			class="w-full h-full fill-current"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<path :d="icon" />
+		</svg>
+	</span>
+</template>
+
+<script>
+export default {
+	props: {
+		/**
+		 * SVG path data passed in from an imported @mdi/js module.
+		 * E.g., import { mdiAccount } from '@mdi/js'; <kv-material-icon :icon="mdiAccount" />
+		 * */
+		icon: {
+			type: String,
+			default: '',
+		},
+	},
+};
+</script>

--- a/kv-components/vue/KvMaterialIcon.vue
+++ b/kv-components/vue/KvMaterialIcon.vue
@@ -16,11 +16,27 @@
 </template>
 
 <script>
+/**
+ * This component takes path data as a prop from an imported @mdi/js module and
+ * renders the icon as an SVG.
+ *
+ * Find your icon name from https://materialdesignicons.com/,
+ * The module name to import will be 'mdiPascalCaseIconName'. `account-cowboy-hat` would be
+ * `import { mdiAccountCowboyHat } from '@mdi/js'`;
+ *
+ * These icons do not announce to screenreaders. If you are using a non-decorative icon, be sure
+ * to include screen reader text. E.g.,
+ * `<button>
+ * 	  <kv-material-icon :icon="mdiClose" />
+ * 	  <span class="sr-only">Close modal</span>
+ *  </button>`
+ */
+
 export default {
 	props: {
 		/**
 		 * SVG path data passed in from an imported @mdi/js module.
-		 * E.g., import { mdiAccount } from '@mdi/js'; <kv-material-icon :icon="mdiAccount" />
+		 * E.g., `import { mdiAccount } from '@mdi/js'; <kv-material-icon :icon="mdiAccount" />`
 		 * */
 		icon: {
 			type: String,

--- a/kv-components/vue/stories/KvMaterialIcon.stories.js
+++ b/kv-components/vue/stories/KvMaterialIcon.stories.js
@@ -1,0 +1,201 @@
+import {
+	mdiAlertCircleOutline,
+	mdiArrowDown,
+	mdiArrowBottomLeft,
+	mdiArrowLeft,
+	mdiArrowTopLeft,
+	mdiArrowUp,
+	mdiArrowTopRight,
+	mdiArrowRight,
+	mdiArrowBottomRight,
+	mdiCart,
+	mdiCheck,
+	mdiChevronLeft,
+	mdiChevronRight,
+	mdiChevronDown,
+	mdiChevronUp,
+	mdiClose,
+	mdiMagnify,
+	mdiStar,
+	mdiStarOutline,
+} from '@mdi/js';
+
+import KvMaterialIcon from '../KvMaterialIcon.vue';
+
+export default {
+	title: 'KvMaterialIcon',
+	component: KvMaterialIcon,
+	argTypes: {
+		icon: {
+			control: {
+				disable: true,
+			},
+		},
+	},
+};
+
+const DefaultTemplate = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<kv-material-icon
+			:icon="icon"
+		/>`,
+});
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+	icon: mdiCart,
+};
+
+export const Common = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<div class="flex gap-1">
+			<kv-material-icon
+				v-for="(icon, i) in [
+					mdiAlertCircleOutline,
+					mdiArrowDown,
+					mdiArrowBottomLeft,
+					mdiArrowLeft,
+					mdiArrowTopLeft,
+					mdiArrowUp,
+					mdiArrowTopRight,
+					mdiArrowRight,
+					mdiArrowBottomRight,
+					mdiChevronLeft,
+					mdiChevronRight,
+					mdiChevronDown,
+					mdiChevronUp,
+					mdiClose,
+					mdiMagnify,
+				]"
+				:key="i"
+				:icon="icon"
+			/>
+		</div>
+	`,
+	data() {
+		return {
+			mdiAlertCircleOutline,
+			mdiArrowDown,
+			mdiArrowBottomLeft,
+			mdiArrowLeft,
+			mdiArrowTopLeft,
+			mdiArrowUp,
+			mdiArrowTopRight,
+			mdiArrowRight,
+			mdiArrowBottomRight,
+			mdiChevronLeft,
+			mdiChevronRight,
+			mdiChevronDown,
+			mdiChevronUp,
+			mdiClose,
+			mdiMagnify,
+		};
+	},
+});
+
+export const Colored = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<div>
+			<p class="mb-2">Use text-color to set the icon color</p>
+			<kv-material-icon
+				:icon="mdiCheck"
+				class="text-brand-500"
+			/>
+			<kv-material-icon
+				:icon="mdiAlertCircleOutline"
+				class="text-danger"
+			/>
+		</div>`,
+	data() {
+		return {
+			mdiAlertCircleOutline,
+			mdiCheck,
+		};
+	},
+});
+
+export const InlineWithText = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<a href="#" class="inline-flex">
+			<span class="text-h4">He went thataway</span>
+			<kv-material-icon class="w-2.5" :icon="mdiChevronRight" />
+		</a>`,
+	data() {
+		return {
+			mdiChevronRight,
+		};
+	},
+});
+
+export const Sizing = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<div>
+			<p class="mb-2">Icons can be sized using any of the standard sizing classes (.w-2, .w-3, .w-full, etc.). By default they are 24 x 24 (.w-3).</p>
+			<kv-material-icon class="bg-gray-100 w-2" :icon="mdiChevronRight" />
+			<kv-material-icon class="bg-gray-100 w-4" :icon="mdiChevronRight" />
+			<kv-material-icon class="bg-gray-100 w-8" :icon="mdiChevronRight" />
+			<kv-material-icon class="bg-gray-100 w-16" :icon="mdiChevronRight" />
+		</div>`,
+	data() {
+		return {
+			mdiChevronRight,
+		};
+	},
+});
+
+export const WithAccessibleText = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<div>
+			<p class="mb-2">If you don't include text and your icon is not decorative, be sure to include screen-reader text</p>
+			<button class="rounded-sm bg-gray-100 hover:bg-gray-300 p-1 inline-flex">
+				<kv-material-icon class="w-3" :icon="mdiClose" />
+				<span class="sr-only">Close modal</span>
+			</button>
+		</div>`,
+	data() {
+		return {
+			mdiClose,
+		};
+	},
+});
+
+export const StarsDemo = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvMaterialIcon },
+	template: `
+		<div class="flex">
+			<button
+				v-for="i in 5"
+				:key="i"
+				@click="rating = i"
+				class="text-black hover:text-action-700"
+			>
+				<kv-material-icon :icon="getStarIcon(i)"/>
+				<span class="sr-only">Set rating to {{i}}</span>
+			</button>
+		</div>`,
+	data() {
+		return {
+			rating: 2,
+			mdiStar,
+			mdiStarOutline,
+		};
+	},
+	methods: {
+		getStarIcon(index) {
+			return this.rating >= index ? this.mdiStar : this.mdiStarOutline;
+		},
+	},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
     "kv-components": {
       "version": "0.0.1",
       "dependencies": {
+        "@mdi/js": "^5.9.55",
         "kv-tokens": "^0.0.1",
         "vue": "^2.6.12"
       },
@@ -2178,6 +2179,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
+    },
+    "node_modules/@mdi/js": {
+      "version": "5.9.55",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.9.55.tgz",
+      "integrity": "sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A=="
     },
     "node_modules/@mdx-js/loader": {
       "version": "1.6.22",
@@ -25404,6 +25410,11 @@
         }
       }
     },
+    "@mdi/js": {
+      "version": "5.9.55",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.9.55.tgz",
+      "integrity": "sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A=="
+    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -25487,7 +25498,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -25769,7 +25781,6 @@
       "integrity": "sha512-qOtwgiqI3LMqT0eXYNV6ykp7qSu0LQGeXxy3wOBGuDDqAizfgnAjomYEWGFcyKp5ahV7HCRCjxbixAklFPUmyw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.12.10",
         "@babel/generator": "^7.12.11",
         "@babel/parser": "^7.12.11",
         "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -27988,7 +27999,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -28062,13 +28074,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -28494,7 +28508,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-loader": {
       "version": "8.2.2",
@@ -34595,6 +34610,7 @@
       "requires": {
         "@babel/core": "^7.13.15",
         "@babel/eslint-parser": "^7.13.14",
+        "@mdi/js": "^5.9.55",
         "@storybook/addon-a11y": "^6.2.9",
         "@storybook/addon-actions": "^6.2.9",
         "@storybook/addon-essentials": "^6.2.9",
@@ -35457,7 +35473,8 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.2.tgz",
       "integrity": "sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",
@@ -37094,13 +37111,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -37698,7 +37717,8 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.1.4.tgz",
       "integrity": "sha512-WOEpRNz8Oo2SEU4eYQ279jEKFSjpFPa9Vi2U/K0DGwP9wOQ8wYkJcNSd5Qbv1L8OFvyKDCbWekjftXaU5mbmtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "11.0.4",
@@ -41021,7 +41041,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -41992,7 +42013,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.0",


### PR DESCRIPTION
This version imports SVG path data from a material icons library. You pass then pass the path data as a prop to KvMaterialIcon component which renders the SVG.

This is in contrast to #40 which imports SFC Vue Components.

The way you set color and size is the same (tailwind classes).


