### PR TITLE
fix(build): Rename release job and skip npm access verification in lerna

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     env:
       # 'Automation' type NPM access token used for publishing packages to NPM
@@ -44,4 +44,4 @@ jobs:
 
       # Tag release and publish to NPM
       - name: Publish release
-        run: npm run publish-release -- --yes
+        run: npm run publish-release -- --yes --no-verify-access


### PR DESCRIPTION
The "Automation" token from npm that is valid for publishing is not valid for the method that Lerna uses to check npm access (see https://github.com/lerna/lerna/issues/2788 for more details about this error). The recommended workaround is using the "--no-verify-access" flag for Lerna. If there is some problem with the authentication, the npm release process will 404, so it will effectively work the same. Additionally, the release job has an earlier step to verify npm access before even installing dependencies, so that should catch any problems with the npm authentication before Lerna is run.