### PR TITLE
Update Tailwind, use JIT

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -15,7 +15,6 @@
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/addon-storysource": "^6.3.2",
     "@storybook/vue": "^6.3.2",
-    "@tailwindcss/postcss7-compat": "^2.1.0",
     "autoprefixer": "^9.8.6",
     "babel-loader": "^8.2.2",
     "chromatic": "^5.9.2",
@@ -24,7 +23,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-vue": "^7.9.0",
     "postcss": "^7.0.35",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0",
+    "tailwindcss": "^2.2.4",
     "vue-loader": "^15.9.6",
     "vue-template-compiler": "^2.6.12"
   },

--- a/@kiva/kv-components/tailwind.config.js
+++ b/@kiva/kv-components/tailwind.config.js
@@ -1,5 +1,11 @@
 const sharedConfig = require('@kiva/kv-tokens/configs/tailwind.config');
 
 module.exports = {
+	mode: 'jit',
 	presets: [sharedConfig],
+	purge: [
+		'./vue/**/*.vue',
+		'./vue/stories/**/*.stories.js',
+		'./utils/**/*.js',
+	],
 };

--- a/@kiva/kv-components/tailwind.config.js
+++ b/@kiva/kv-components/tailwind.config.js
@@ -1,11 +1,57 @@
+const resolveConfig = require('tailwindcss/resolveConfig'); // eslint-disable-line import/no-extraneous-dependencies
 const sharedConfig = require('@kiva/kv-tokens/configs/tailwind.config');
+const { textStyles } = require('@kiva/kv-tokens/configs/kivaTypography');
+const { headerNumberCase, kebabCase, buildTailwindClassName } = require('./utils/themeUtils');
+
+const config = resolveConfig(sharedConfig);
+const { theme } = config;
+const themePrefix = config.prefix;
+
+function buildValuesFromThemeObj(initialObj) {
+	const arr = [];
+	const iterate = (obj, prefix = '') => {
+		Object.keys(obj).forEach((key) => {
+			if (typeof obj[key] === 'object') {
+				iterate(obj[key], key);
+			} else {
+				const niceKey = prefix ? `${prefix}-${key}` : key;
+				arr.push(niceKey);
+			}
+		});
+	};
+	iterate(initialObj);
+	return arr;
+}
+
+// Safelist classes used on our Styleguide Primitives story since it gets
+// generated dynamically and JIT purge won't see those class names.
+const colors = buildValuesFromThemeObj(theme.colors);
+const space = buildValuesFromThemeObj(theme.spacing);
+const kivaTypography = Object.keys(textStyles).map((key) => headerNumberCase(kebabCase(key)).replace('text-', ''));
+const fontWeight = buildValuesFromThemeObj(theme.fontWeight);
+const radii = buildValuesFromThemeObj(theme.borderRadius);
+const opacity = buildValuesFromThemeObj(theme.opacity);
+const zIndices = buildValuesFromThemeObj(theme.zIndex);
+
+const safelist = [
+	...colors.map((color) => buildTailwindClassName(`${themePrefix}bg`, color)),
+	...space.map((spaceVal) => buildTailwindClassName(`${themePrefix}w`, spaceVal)),
+	...kivaTypography.map((type) => buildTailwindClassName(`${themePrefix}text`, type)),
+	...fontWeight.map((weight) => buildTailwindClassName(`${themePrefix}font`, weight)),
+	...radii.map((radius) => buildTailwindClassName(`${themePrefix}radius`, radius)),
+	...opacity.map((opacityVal) => buildTailwindClassName(`${themePrefix}opacity`, opacityVal)),
+	...zIndices.map((zIndex) => buildTailwindClassName(`${themePrefix}z`, zIndex)),
+];
 
 module.exports = {
 	mode: 'jit',
 	presets: [sharedConfig],
-	purge: [
-		'./vue/**/*.vue',
-		'./vue/stories/**/*.stories.js',
-		'./utils/**/*.js',
-	],
+	purge: {
+		content: [
+			'./vue/**/*.vue',
+			'./vue/stories/**/*.stories.js',
+			'./utils/**/*.js',
+		],
+		safelist,
+	},
 };

--- a/@kiva/kv-components/utils/themeUtils.js
+++ b/@kiva/kv-components/utils/themeUtils.js
@@ -1,0 +1,26 @@
+const headerNumberCase = (str) => str
+	.replace('h-1', 'h1')
+	.replace('h-2', 'h2')
+	.replace('h-3', 'h3')
+	.replace('h-4', 'h4')
+	.replace('h-5', 'h5');
+
+const buildTailwindClassName = (prefix, value) => {
+	let name = `${prefix}-${value}`;
+	name = name.replace('-DEFAULT', '');
+	return name;
+};
+
+const kebabCase = (str) => str.split('').map((letter, idx) => (letter.toUpperCase() === letter
+	? `${idx !== 0 ? '-' : ''}${letter.toLowerCase()}`
+	: letter)).join('');
+
+const removeObjectProperty = (object, key) => {
+	const ret = { ...object };
+	delete ret[key];
+	return ret;
+};
+
+module.exports = {
+	buildTailwindClassName, headerNumberCase, kebabCase, removeObjectProperty,
+};

--- a/@kiva/kv-components/vue/stories/Styleguide.stories.js
+++ b/@kiva/kv-components/vue/stories/Styleguide.stories.js
@@ -4,10 +4,12 @@ import { textStyles } from '@kiva/kv-tokens/configs/kivaTypography';
 import KvGrid from '../KvGrid.vue';
 import KvPageContainer from '../KvPageContainer.vue';
 
+const { headerNumberCase, kebabCase, removeObjectProperty } = require('../../utils/themeUtils');
+
 const config = resolveConfig(tailwindConfig);
 const { theme } = config;
 
-const buildValuesFromThemeObj = (initialObj) => {
+function buildValuesFromThemeObj(initialObj) {
 	const arr = [];
 	const iterate = (obj, prefix = '') => {
 		Object.keys(obj).forEach((key) => {
@@ -21,24 +23,7 @@ const buildValuesFromThemeObj = (initialObj) => {
 	};
 	iterate(initialObj);
 	return arr;
-};
-
-const kebabCase = (str) => str.split('').map((letter, idx) => (letter.toUpperCase() === letter
-	? `${idx !== 0 ? '-' : ''}${letter.toLowerCase()}`
-	: letter)).join('');
-
-const headerNumberCase = (str) => str
-	.replace('h-1', 'h1')
-	.replace('h-2', 'h2')
-	.replace('h-3', 'h3')
-	.replace('h-4', 'h4')
-	.replace('h-5', 'h5');
-
-const removeObjectProperty = (object, key) => {
-	const ret = { ...object };
-	delete ret[key];
-	return ret;
-};
+}
 
 export default {
 	title: 'BaseStyling',

--- a/@kiva/kv-tokens/configs/tailwind.config.js
+++ b/@kiva/kv-tokens/configs/tailwind.config.js
@@ -171,11 +171,6 @@ module.exports = {
 			},
 		},
 	},
-	variants: {
-		extend: {
-			opacity: ['disabled'],
-		},
-	},
 	plugins: [
 		typographyPlugin, // prose plugin. See overrides in theme.extend.typography
 		plugin(({ addBase, addUtilities }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,9 @@
       }
     },
     "@kiva/kv-components": {
-      "version": "0.7.4",
+      "version": "0.8.0",
       "dependencies": {
-        "@kiva/kv-tokens": "^0.3.3",
+        "@kiva/kv-tokens": "^0.4.0",
         "@mdi/js": "^5.9.55",
         "aria-hidden": "^1.1.3",
         "vue": "^2.6.12",
@@ -46,7 +46,6 @@
         "@storybook/addon-postcss": "^2.0.0",
         "@storybook/addon-storysource": "^6.3.2",
         "@storybook/vue": "^6.3.2",
-        "@tailwindcss/postcss7-compat": "^2.1.0",
         "autoprefixer": "^9.8.6",
         "babel-loader": "^8.2.2",
         "chromatic": "^5.9.2",
@@ -55,13 +54,13 @@
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-vue": "^7.9.0",
         "postcss": "^7.0.35",
-        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0",
+        "tailwindcss": "^2.2.4",
         "vue-loader": "^15.9.6",
         "vue-template-compiler": "^2.6.12"
       }
     },
     "@kiva/kv-tokens": {
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.4.0",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"
@@ -6787,175 +6786,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.4.tgz",
-      "integrity": "sha512-lFIBdD1D2w3RgHFg7kNB7U5LOlfbd+KXTzcLyC/RlQ9eVko6GjNCKpN/kdmfF9wiGxbSDT/3mousXeMZdOOuBg==",
-      "dev": true,
-      "dependencies": {
-        "@fullhuman/postcss-purgecss": "^3.1.3",
-        "arg": "^5.0.0",
-        "autoprefixer": "^9",
-        "bytes": "^3.0.0",
-        "chalk": "^4.1.1",
-        "chokidar": "^3.5.2",
-        "color": "^3.1.3",
-        "cosmiconfig": "^7.0.0",
-        "detective": "^5.2.0",
-        "didyoumean": "^1.2.1",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.2.5",
-        "fs-extra": "^10.0.0",
-        "glob-parent": "^6.0.0",
-        "html-tags": "^3.1.0",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
-        "lodash.topath": "^4.5.2",
-        "modern-normalize": "^1.1.0",
-        "node-emoji": "^1.8.1",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^2.2.0",
-        "postcss": "^7",
-        "postcss-functions": "^3",
-        "postcss-js": "^2",
-        "postcss-load-config": "^3.1.0",
-        "postcss-nested": "^4",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "quick-lru": "^5.1.1",
-        "reduce-css-calc": "^2.1.8",
-        "resolve": "^1.20.0",
-        "tmp": "^0.2.1"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/glob-parent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
-      "integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@tailwindcss/postcss7-compat/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -31047,7 +30877,7 @@
       "requires": {
         "@babel/core": "^7.13.15",
         "@babel/eslint-parser": "^7.13.14",
-        "@kiva/kv-tokens": "^0.3.3",
+        "@kiva/kv-tokens": "^0.4.0",
         "@mdi/js": "^5.9.55",
         "@storybook/addon-a11y": "^6.3.2",
         "@storybook/addon-actions": "^6.3.2",
@@ -31056,7 +30886,6 @@
         "@storybook/addon-postcss": "^2.0.0",
         "@storybook/addon-storysource": "^6.3.2",
         "@storybook/vue": "^6.3.2",
-        "@tailwindcss/postcss7-compat": "^2.1.0",
         "aria-hidden": "^1.1.3",
         "autoprefixer": "^9.8.6",
         "babel-loader": "^8.2.2",
@@ -31066,7 +30895,7 @@
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-vue": "^7.9.0",
         "postcss": "^7.0.35",
-        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0",
+        "tailwindcss": "^2.2.4",
         "vue": "^2.6.12",
         "vue-focus-lock": "^1.4.1",
         "vue-loader": "^15.9.6",
@@ -32305,7 +32134,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -32536,7 +32366,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.3.7",
@@ -32815,7 +32646,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-2.0.0.tgz",
       "integrity": "sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@storybook/addon-postcss": {
       "version": "2.0.0",
@@ -34259,134 +34091,6 @@
         }
       }
     },
-    "@tailwindcss/postcss7-compat": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.4.tgz",
-      "integrity": "sha512-lFIBdD1D2w3RgHFg7kNB7U5LOlfbd+KXTzcLyC/RlQ9eVko6GjNCKpN/kdmfF9wiGxbSDT/3mousXeMZdOOuBg==",
-      "dev": true,
-      "requires": {
-        "@fullhuman/postcss-purgecss": "^3.1.3",
-        "arg": "^5.0.0",
-        "autoprefixer": "^9",
-        "bytes": "^3.0.0",
-        "chalk": "^4.1.1",
-        "chokidar": "^3.5.2",
-        "color": "^3.1.3",
-        "cosmiconfig": "^7.0.0",
-        "detective": "^5.2.0",
-        "didyoumean": "^1.2.1",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.2.5",
-        "fs-extra": "^10.0.0",
-        "glob-parent": "^6.0.0",
-        "html-tags": "^3.1.0",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
-        "lodash.topath": "^4.5.2",
-        "modern-normalize": "^1.1.0",
-        "node-emoji": "^1.8.1",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^2.2.0",
-        "postcss": "^7",
-        "postcss-functions": "^3",
-        "postcss-js": "^2",
-        "postcss-load-config": "^3.1.0",
-        "postcss-nested": "^4",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "quick-lru": "^5.1.1",
-        "reduce-css-calc": "^2.1.8",
-        "resolve": "^1.20.0",
-        "tmp": "^0.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
-          "integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "quick-lru": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
-      }
-    },
     "@tailwindcss/typography": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.4.1.tgz",
@@ -35149,7 +34853,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -35249,13 +34954,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -35747,7 +35454,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-loader": {
       "version": "8.2.2",
@@ -43923,7 +43631,8 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",
@@ -46106,13 +45815,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -46788,7 +46499,8 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.2.3.tgz",
       "integrity": "sha512-lAge4syxosZg9SX8fJiwOLd9ZJSW3poPBtypnz1aMiFoHsRnK5G3+INGGx9DGtsrso4h5uFYbiFpjAfWyK3Kag==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "11.0.4",
@@ -50592,7 +50304,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -51711,7 +51424,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.0",


### PR DESCRIPTION
I've been running into some issues matching designs when arbitrary widths are used (like 550px) inside of a media query. Since it's inside a media query, inline styles can't be used to fudge it.

Since v2.1 Tailwind introduced JIT mode which among other things,
> Generate arbitrary styles without writing custom CSS. Ever needed some ultra-specific value that wasn’t part of your design system, like top: -113px for a quirky background image? Since styles are generated on demand, you can just generate a utility for this as needed using square bracket notation like top-[-113px]. Works with variants too, like md:top-[-113px].

https://tailwindcss.com/docs/just-in-time-mode

The other thing I like a lot is the purge settings are the same in dev or prod mode. So if something's broken in dev because of purge you'll see it there first.

It does still say JIT mode is in "preview", thought they've released a minor and several patches since. I didn't notice any issues on here or on UI.
