### PR TITLE
fix: Fix lightboxes being cut off vertically on mobile

### DIFF
--- a/@kiva/kv-components/vue/KvLightbox.vue
+++ b/@kiva/kv-components/vue/KvLightbox.vue
@@ -18,6 +18,7 @@
 				tw-bg-opacity-[75%]
 			"
 			:class="{'tw-min-h-screen' : variant === 'lightbox'}"
+			:style="webkitCSSFix"
 			@click.stop.prevent="onScreenClick"
 		>
 			<focus-lock
@@ -44,17 +45,19 @@
 							tw-bg-primary
 							tw-flex tw-flex-col
 							tw-mx-auto md:tw-my-auto
+
 						"
 						:class="{
+							'tw-w-full md:tw-w-auto' : variant === 'lightbox',
 							'tw-mt-auto md:tw-my-auto' : variant === 'lightbox',
 							'tw-min-h-half-screen md:tw-min-h-0' : variant === 'lightbox',
 							'tw-rounded-t md:tw-rounded' : variant === 'lightbox',
 							'tw-my-auto tw-rounded' : variant === 'alert',
 						}"
-						style="max-width: 55.55rem; max-height: 90vh"
+						style="max-width: 55.55rem; max-height: 90%"
 						aria-modal="true"
 						:aria-label="title ? title : null"
-						:aria-describedby="variant === 'alert' ? kvLightboxBody : null"
+						:aria-describedby="variant === 'alert' ? 'kvLightboxBody' : null"
 						:role="role"
 						@click.stop
 					>
@@ -206,6 +209,13 @@ export default {
 		};
 	},
 	computed: {
+		// Reference: https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/
+		webkitCSSFix() {
+			if (this.variant === 'lightbox') {
+				return 'min-height: -webkit-fill-available';
+			}
+			return '';
+		},
 		role() {
 			if (this.variant === 'alert') {
 				return 'alertdialog';

--- a/@kiva/kv-components/vue/stories/KvLightbox.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLightbox.stories.js
@@ -56,6 +56,75 @@ const DefaultTemplate = (args, { argTypes }) => ({
 	},
 });
 
+const VeryShortTemplate = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvLightbox, KvButton },
+	template: `
+		<div>
+			<kv-button @click="isLightboxVisible = true;">Show {{variant}}</kv-button>
+			<p>The lightbox is visible: {{isLightboxVisible}}</p>
+
+			<kv-lightbox
+				:visible="isLightboxVisible"
+				:title="title"
+				:variant="variant"
+				:prevent-close="preventClose"
+				@lightbox-closed="isLightboxVisible = false"
+			>
+				<p class="tw-mb-2">The lightbox content is very short.</p>
+				<template #controls>
+					<kv-button variant="secondary" @click="isLightboxVisible = false" ref="dontDoItRef">Don't do it!</kv-button>
+					<kv-button @click="isLightboxVisible = false" ref="doItRef">Do it!</kv-button>
+				</template>
+			</kv-lightbox>
+		</div>
+	`,
+	data() {
+		return {
+			isLightboxVisible: args.visible,
+		};
+	},
+});
+
+const VeryLongTemplate = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvLightbox, KvButton },
+	template: `
+		<div>
+			<kv-button @click="isLightboxVisible = true;">Show {{variant}}</kv-button>
+			<p>The lightbox is visible: {{isLightboxVisible}}</p>
+
+			<kv-lightbox
+				:visible="isLightboxVisible"
+				:title="title"
+				:variant="variant"
+				:prevent-close="preventClose"
+				@lightbox-closed="isLightboxVisible = false"
+			>
+				<p class="tw-mb-2">Lorem ipsum dolor sit amet consectetur adipisicing elit. Exercitationem voluptatum quod illum minima alias quae non architecto ipsum sunt repudiandae eius ipsa commodi adipisci nam, magni praesentium error, deleniti impedit!
+				Qui sint repudiandae incidunt odit distinctio neque repellendus, soluta culpa. Vero rem, odit laudantium autem quis facilis ratione omnis aut voluptas, velit vitae adipisci? Magni iure animi doloribus illum soluta.
+				Enim aspernatur non accusantium aut minima, quos maxime? Perferendis suscipit enim laborum, recusandae fugit praesentium fugiat animi cumque voluptatum voluptate labore dolore quaerat libero esse quasi magnam tempore id autem.
+				Nisi voluptas architecto dolores aut perspiciatis itaque, est reprehenderit tempora. Animi dicta laudantium repudiandae facere atque omnis voluptatem, incidunt ipsum, accusantium minima aspernatur modi soluta molestiae neque quam doloremque nemo.
+				Neque delectus quidem sapiente facere consequuntur maiores molestiae vel! Quidem, veniam. Libero labore voluptatibus id corporis molestias cumque magnam maiores praesentium laborum? Voluptate, porro eum. Recusandae earum rerum quis quos.
+				Cupiditate ea quas non ut adipisci illum dolorem eligendi sequi quod, doloribus suscipit assumenda ullam aliquid ad repudiandae dignissimos optio, possimus molestiae voluptate vel! Esse fuga praesentium maxime animi nihil.
+				Sint, est? Maiores commodi adipisci minus itaque nisi dolorum, velit fugiat est quia saepe ipsum quo nobis mollitia repellendus facilis, quos hic facere! Tenetur sint corporis dignissimos molestias saepe ipsa?
+				Excepturi, praesentium quisquam veritatis quaerat eligendi explicabo vitae sit minima recusandae. Dolorum molestiae, vero nulla eum sunt exercitationem dolore ipsum quos ea doloribus reprehenderit aliquam quibusdam vel veniam ex quis.
+				Corporis, neque cum pariatur saepe inventore sunt, maiores sed deserunt beatae quasi non sint vitae error incidunt odio nam amet quisquam! Mollitia, suscipit earum. Molestiae nesciunt fugit ea cupiditate rerum?
+				Placeat, atque sit unde sunt fugit reprehenderit tenetur provident similique odio accusamus, suscipit quod doloribus aliquam animi quia quae laboriosam natus aspernatur repellendus tempore itaque expedita! Optio adipisci amet excepturi!</p>
+				<template #controls>
+					<kv-button variant="secondary" @click="isLightboxVisible = false" ref="dontDoItRef">Don't do it!</kv-button>
+					<kv-button @click="isLightboxVisible = false" ref="doItRef">Do it!</kv-button>
+				</template>
+			</kv-lightbox>
+		</div>
+	`,
+	data() {
+		return {
+			isLightboxVisible: args.visible,
+		};
+	},
+});
+
 const AlertTemplate = (args, { argTypes }) => ({
 	props: Object.keys(argTypes),
 	components: { KvLightbox, KvButton },
@@ -89,6 +158,16 @@ const AlertTemplate = (args, { argTypes }) => ({
 export const Lightbox = DefaultTemplate.bind({});
 Lightbox.args = {
 	title: 'Lightbox Title',
+};
+
+export const ShortContentLightbox = VeryShortTemplate.bind({});
+ShortContentLightbox.args = {
+	title: 'Short Lightbox Title',
+};
+
+export const LongContentLightbox = VeryLongTemplate.bind({});
+LongContentLightbox.args = {
+	title: 'Long Lightbox Title',
 };
 
 export const Alert = AlertTemplate.bind({});


### PR DESCRIPTION
* Fixes lightboxes being cut off on mobile devices, also fixes alert described by error and very small lightboxes not being full width on mobile
GD-120
VUE-700

This article shows the issue we are having:
https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/

See VUE-700 

To reproduce bug, you have to use storybook story view, and it has to be on a native mobile device, the Chrome mobile emulation will not reproduce it. 

It is reproducible both in iOSSimulator and using remote debugging on my Pixel 5 