### PR TITLE
fix(KvLightbox): allow for an empty lightbox body

### DIFF
--- a/@kiva/kv-components/vue/KvLightbox.vue
+++ b/@kiva/kv-components/vue/KvLightbox.vue
@@ -104,7 +104,7 @@
 							"
 						>
 							<!-- @slot default -->
-							<slot>Lightbox body</slot>
+							<slot></slot>
 						</div>
 
 						<!-- controls -->


### PR DESCRIPTION
Useful when you have an alert that's just a lightbox title + 2 buttons

![image](https://user-images.githubusercontent.com/187937/141021251-acc25bd6-c1a2-49c1-a03e-c77869d4850e.png)
