### PR TITLE
build(deps): upgrade autoprefixer to v10

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -20,7 +20,7 @@
     "@testing-library/dom": "^8.1.0",
     "@testing-library/user-event": "^13.2.1",
     "@testing-library/vue": "^5.8.1",
-    "autoprefixer": "^9.8.6",
+    "autoprefixer": "^10.4.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
There is a mismatch between the version of autoprefixer used by kv-components and the one used by the tailwind dependency. That causes errors when attempting to install new packages:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @kiva/kv-components@1.2.2
npm ERR! Found: autoprefixer@9.8.8
npm ERR! node_modules/autoprefixer
npm ERR!   dev autoprefixer@"^9.8.6" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer autoprefixer@"^10.0.2" from tailwindcss@2.2.15
npm ERR! node_modules/tailwindcss
npm ERR!   dev tailwindcss@"2.2.15" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

This fixes that issue by upgrading to autoprefixer v10 to match tailwindcss.