### PR TITLE
fix: allow buttons to inherit font weights

### DIFF
--- a/@kiva/kv-tokens/configs/tailwind.config.js
+++ b/@kiva/kv-tokens/configs/tailwind.config.js
@@ -174,7 +174,7 @@ module.exports = {
 					'-moz-osx-font-smoothing': 'grayscale',
 					'text-rendering': 'optimizeLegibility',
 				},
-				button: { fontWeight: fontWeights.book },
+				button: { fontWeight: 'inherit' },
 				h1: textStyles.textH1,
 				h2: textStyles.textH2,
 				h3: textStyles.textH3,


### PR DESCRIPTION
Allows you to do
```
<ul class="tw-font-medium">
   <li><button>text</button></li>
   <li><button>text</button></li>
   <li><button>text</button></li>
   <li><button>text</button></li>
</ul>
```
instead of 
```
<ul>
   <li><button class="tw-font-medium">text</button></li>
   <li><button class="tw-font-medium">text</button></li>
   <li><button class="tw-font-medium">text</button></li>
   <li><button class="tw-font-medium">text</button></li>
</ul>