### PR TITLE
fix(KvButton): pass through click event for parent

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import addVueRouter from '../../utils/addVueRouter';
 import KvButton from '../../../../vue/KvButton.vue';
@@ -50,6 +51,29 @@ describe('Default Button', () => {
 		const btnEl = getByText('Test Button');
 		await fireEvent.click(btnEl);
 		getByTestId('ripple');
+	});
+
+	it('passes through click events', async () => {
+		const onClick = jest.fn();
+		const { getByText } = render({
+			template: `<div>
+				<KvButton @click.prevent="onClick">Button tag</KvButton>
+				<KvButton href="#test" @click.prevent="onClick">Anchor tag</KvButton>
+				<KvButton to="/test" @click.native.prevent="onClick">Router-link</KvButton>
+			</div>`,
+			components: {
+				KvButton,
+			},
+			methods: {
+				onClick,
+			},
+		}, addVueRouter());
+
+		// Click all the buttons and expect the onClick method to have been called 3 times
+		await userEvent.click(getByText('Button tag'));
+		await userEvent.click(getByText('Anchor tag'));
+		await userEvent.click(getByText('Router-link'));
+		expect(onClick.mock.calls.length).toBe(3);
 	});
 
 	it('when passed a loading prop, the button is disabled', () => {

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -242,13 +242,8 @@ export default {
 		};
 
 		const onClick = (event) => {
-			// emit a vue event and prevent native event
-			// so we don't have to write @click.native in our templates
-			if (tag.value === 'button' && type.value !== 'submit') {
-				event.preventDefault();
-				emit('click', event);
-			}
-
+			// Pass-through native click event to parent while adding ripple effect
+			emit('click', event);
 			createRipple(event);
 		};
 


### PR DESCRIPTION
The `.native` modifier [has been removed in Vue 3](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html). Because KvButton declares that it will emit the `click` event, the click event handlers will not be applied to the button element. This means that KvButton must always emit the native click event when a click happens so that parent components can have access to the native event.