### PR TITLE
fix: return additional items for access as refs in vue2

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvProgressBar.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvProgressBar.spec.js
@@ -3,7 +3,7 @@ import KvProgressBar from '../../../../vue/KvProgressBar.vue';
 
 describe('KvProgressBar', () => {
 	it('renders with a role of "progressbar"', () => {
-		const { getByRole } = render(KvProgressBar);
+		const { getByRole } = render(KvProgressBar, { props: { ariaLabel: 'progress-bar', value: 100 } });
 		const progressbarEl = getByRole('progressbar');
 
 		expect(progressbarEl).toBeDefined();

--- a/@kiva/kv-components/tests/unit/specs/components/KvTabPanel.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvTabPanel.spec.js
@@ -1,10 +1,31 @@
 import { render } from '@testing-library/vue';
 import { axe } from 'jest-axe';
+import '../../../../__mocks__/ResizeObserver';
+import KvTab from '../../../../vue/KvTab.vue';
 import KvTabPanel from '../../../../vue/KvTabPanel.vue';
+import KvTabs from '../../../../vue/KvTabs.vue';
 
 describe('KvTabPanel', () => {
 	it('has no automated accessibility violations', async () => {
-		const { container } = render(KvTabPanel);
+		const { container } = render({
+			components: { KvTabs, KvTab, KvTabPanel },
+			template: `
+				<kv-tabs>
+					<template #tabNav>
+						<kv-tab forPanel="demo-1-first">First</kv-tab>
+						<kv-tab forPanel="demo-1-second">Second</kv-tab>
+						<kv-tab forPanel="demo-1-third">Third</kv-tab>
+						<kv-tab forPanel="demo-1-forth">Fourth is longer</kv-tab>
+					</template>
+					<template #tabPanels>
+						<kv-tab-panel id="demo-1-first"><p>First Panel</p></kv-tab-panel>
+						<kv-tab-panel id="demo-1-second"><p>Second Panel has <br>longer<br>content</p></kv-tab-panel>
+						<kv-tab-panel id="demo-1-third"><p>Third Panel</p></kv-tab-panel>
+						<kv-tab-panel id="demo-1-forth"><p>Fourth Panel</p></kv-tab-panel>
+					</template>
+				</kv-tabs>
+			`,
+		});
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});

--- a/@kiva/kv-components/tests/unit/specs/components/KvTabs.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvTabs.spec.js
@@ -5,6 +5,8 @@ import '../../../../__mocks__/ResizeObserver';
 import KvTab from '../../../../vue/KvTab.vue';
 import KvTabPanel from '../../../../vue/KvTabPanel.vue';
 import KvTabs from '../../../../vue/KvTabs.vue';
+import KvButton from '../../../../vue/KvButton.vue';
+import addVueRouter from '../../utils/addVueRouter';
 
 // jsdom does not include scrollIntoView, so define it to avoid errors when switching tabs
 window.HTMLElement.prototype.scrollIntoView = () => {};
@@ -30,7 +32,6 @@ function renderOneTabSet() {
 		`,
 	});
 }
-
 describe('KvTabs', () => {
 	it('has no automated accessibility violations', async () => {
 		const { container } = renderOneTabSet();
@@ -95,5 +96,75 @@ describe('KvTabs', () => {
 		// Press home key and expect the first panel to be visible
 		userEvent.keyboard('{Home}');
 		expect(await findByText('First Panel')).toBeVisible();
+	});
+
+	it('verifies setTab method when called by a ref', async () => {
+		let selectedIndexCheck = null;
+		const {
+			getByRole,
+			getAllByRole,
+			getByText,
+		} = render({
+			components: {
+				KvTabs,
+				KvTab,
+				KvTabPanel,
+				KvButton,
+			},
+			template: `
+				<div data-testid="tabContainer">
+					<kv-tabs @tab-changed="handleTabChanged" data-testid="tabInstance" ref="tabsRef">
+						<template #tabNav>
+							<kv-tab forPanel="demo-1-first">First</kv-tab>
+							<kv-tab forPanel="demo-1-second">Second</kv-tab>
+							<kv-tab forPanel="demo-1-third">Third</kv-tab>
+							<kv-tab forPanel="demo-1-forth">Fourth is longer</kv-tab>
+						</template>
+						<template #tabPanels>
+							<kv-tab-panel id="demo-1-first"><p>First Panel</p></kv-tab-panel>
+							<kv-tab-panel id="demo-1-second"><p>Second Panel has <br>longer<br>content</p></kv-tab-panel>
+							<kv-tab-panel id="demo-1-third"><p>Third Panel</p></kv-tab-panel>
+							<kv-tab-panel id="demo-1-forth"><p>Fourth Panel</p></kv-tab-panel>
+						</template>
+					</kv-tabs>
+					<kv-button @click.native.prevent="setTabButtonClick(1)" role="tabSetButton">Set Tab</kv-button>
+				</div>
+			`,
+			methods: {
+				handleTabChanged() {
+					this.$nextTick(() => {
+						selectedIndexCheck = this?.$refs?.tabsRef?.tabContext?.selectedIndex;
+					});
+				},
+				setTabButtonClick() {
+					this?.$refs?.tabsRef?.tabContext?.setTab(0);
+				},
+			},
+		}, addVueRouter());
+
+		// check for our elements
+		expect(getByRole('tabSetButton')).toBeDefined();
+		expect(getByRole('tablist')).toBeDefined();
+		expect(getAllByRole('tab').length).toBe(4);
+
+		// Click third tab and expect the third panel to be visible
+		await fireEvent.click(getByText('Third'));
+		expect(getByText('First Panel')).not.toBeVisible();
+		expect(getByText('Third Panel')).toBeVisible();
+		// Test access and updating of property ref
+		// expect the selected index value to be set to our new tab index
+		setTimeout(() => {
+			expect(selectedIndexCheck).toBe(2);
+		}, 200);
+
+		// click the button to test our ref method
+		await userEvent.click(getByText('Set Tab'));
+		expect(getByText('Third Panel')).not.toBeVisible();
+		expect(getByText('First Panel')).toBeVisible();
+		// Test access and updating of property ref
+		// expect the selected index value to be set to our new tab index
+		setTimeout(() => {
+			expect(selectedIndexCheck).toBe(0);
+		}, 200);
 	});
 });

--- a/@kiva/kv-components/tests/unit/specs/components/KvTabs.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvTabs.spec.js
@@ -99,7 +99,6 @@ describe('KvTabs', () => {
 	});
 
 	it('verifies setTab method when called by a ref', async () => {
-		let selectedIndexCheck = null;
 		const {
 			getByRole,
 			getAllByRole,
@@ -110,6 +109,9 @@ describe('KvTabs', () => {
 				KvTab,
 				KvTabPanel,
 				KvButton,
+			},
+			data() {
+				return { selectedIndexCheck: null };
 			},
 			template: `
 				<div data-testid="tabContainer">
@@ -128,13 +130,12 @@ describe('KvTabs', () => {
 						</template>
 					</kv-tabs>
 					<kv-button @click.native.prevent="setTabButtonClick(1)" role="tabSetButton">Set Tab</kv-button>
+					<p>Tab index is {{ selectedIndexCheck }}</p>
 				</div>
 			`,
 			methods: {
 				handleTabChanged() {
-					this.$nextTick(() => {
-						selectedIndexCheck = this?.$refs?.tabsRef?.tabContext?.selectedIndex;
-					});
+					this.selectedIndexCheck = this?.$refs?.tabsRef?.tabContext?.selectedIndex;
 				},
 				setTabButtonClick() {
 					this?.$refs?.tabsRef?.tabContext?.setTab(0);
@@ -153,9 +154,7 @@ describe('KvTabs', () => {
 		expect(getByText('Third Panel')).toBeVisible();
 		// Test access and updating of property ref
 		// expect the selected index value to be set to our new tab index
-		setTimeout(() => {
-			expect(selectedIndexCheck).toBe(2);
-		}, 200);
+		expect(getByText('Tab index is 2')).toBeVisible();
 
 		// click the button to test our ref method
 		await userEvent.click(getByText('Set Tab'));
@@ -163,8 +162,6 @@ describe('KvTabs', () => {
 		expect(getByText('First Panel')).toBeVisible();
 		// Test access and updating of property ref
 		// expect the selected index value to be set to our new tab index
-		setTimeout(() => {
-			expect(selectedIndexCheck).toBe(0);
-		}, 200);
+		expect(getByText('Tab index is 0')).toBeVisible();
 	});
 });

--- a/@kiva/kv-components/vue/KvTabs.vue
+++ b/@kiva/kv-components/vue/KvTabs.vue
@@ -44,8 +44,8 @@
  * ```
  *  <kv-tabs>
  *   <template #tabNav>
- *    <kv-tab for="foo">Foo</kv-tab>
- *    <kv-tab for="bar">Bar</kv-tab>
+ *    <kv-tab for-panel="foo">Foo</kv-tab>
+ *    <kv-tab for-panel="bar">Bar</kv-tab>
  *   </template>
  *   <template #tabPanels>
  *    <kv-tab-panel id="foo">Foo content</kv-tab-panel>
@@ -163,6 +163,7 @@ export default {
 		return {
 			handleKeyDown,
 			selectedTabEl,
+			tabContext,
 		};
 	},
 };


### PR DESCRIPTION
I was able to see and access the `handleKeyDown` method from vue2 on the ref so taking the same approach with these.

I've been trying to find a way to test refs properly/successfully but haven't thus far.