### PR TITLE
refactor: use slideIndicator to hide carousel controls 

### DIFF
--- a/@kiva/kv-components/vue/KvCarousel.vue
+++ b/@kiva/kv-components/vue/KvCarousel.vue
@@ -28,6 +28,7 @@
 		</div>
 		<!-- Carousel Controls -->
 		<div
+			v-if="slideIndicatorCount > 1"
 			class="tw-flex
 			tw-justify-between md:tw-justify-center tw-items-center
 			tw-mt-4 tw-w-full"


### PR DESCRIPTION
This pr aims to hide carousel controls when there is only 1 page to display.