### PR TITLE
feat: add tailored emit event for MARS-199 experiment in kvLightbox

### DIFF
--- a/@kiva/kv-components/vue/KvLightbox.vue
+++ b/@kiva/kv-components/vue/KvLightbox.vue
@@ -206,7 +206,6 @@ export default {
 	},
 	emits: [
 		'lightbox-closed',
-		'lightbox-closed-click-outside',
 	],
 	setup(props, { emit }) {
 		const {


### PR DESCRIPTION
This pr modifies `lightbox-closed` event function for the purpose of tracking when a user clicks outside the modal to close it. With this, experiment MARS-199 should be able to track this click event.