### PR TITLE
fix: ensure ref is defined in exported methods

### DIFF
--- a/@kiva/kv-components/vue/KvTextInput.vue
+++ b/@kiva/kv-components/vue/KvTextInput.vue
@@ -240,6 +240,7 @@ export default {
 			styles,
 			inputAttrs,
 			inputListeners,
+			textInputRef,
 		};
 	},
 };


### PR DESCRIPTION
- Without this exposed ref, the same ref in the exposed methods appears to not be reactive
- Tested and verified locally in CPS using code in `node_modules`