### PR TITLE
fix(KvCarousel): slidesToScroll should not be 0 MARS-248

### DIFF
--- a/@kiva/kv-components/vue/KvCarousel.vue
+++ b/@kiva/kv-components/vue/KvCarousel.vue
@@ -265,7 +265,7 @@ export default {
 					'resize',
 					throttle(() => {
 						embla.value.reInit({
-							slidesToScroll: embla.value.slidesInView(true).length,
+							slidesToScroll: embla.value.slidesInView(true).length || 'auto',
 							inViewThreshold: 0.9,
 						});
 						slides.value = embla.value.slideNodes();


### PR DESCRIPTION
Resizing the window when there is an invisible KvCarousel in the page currently causes the javascript to hang and the page to crash. The cause of the issue appears to be that slidesToScroll is set to 0 (the number of visible slides) when the carousel is reinitialized. Setting it as 'auto' instead in those cases made the issue go away in testing.