### PR TITLE
feat: add additional border widths

### DIFF
--- a/@kiva/kv-tokens/configs/tailwind.config.cjs
+++ b/@kiva/kv-tokens/configs/tailwind.config.cjs
@@ -79,8 +79,8 @@ module.exports = {
 			DEFAULT: rem(borderWidths.default),
 			0: '0px',
 			2: '2px',
-			// 4: '4px',
-			// 8: '8px',
+			4: '4px',
+			8: '8px',
 		},
 		borderRadius: {
 			none: '0px',


### PR DESCRIPTION
Adding these border widths back, not sure why they were disabled in the first place. This enables us to use `tw-border-4` and `tw-border-8`