### PR TITLE
fix: remove margin top from figcaption prose

### DIFF
--- a/@kiva/kv-components/vue/KvContentfulImg.vue
+++ b/@kiva/kv-components/vue/KvContentfulImg.vue
@@ -1,7 +1,7 @@
 <template>
 	<figure
 		v-if="(width || height) && contentfulSrc"
-		class="tw-inline-block"
+		class="tw-inline-block tw-not-prose"
 	>
 		<picture>
 			<!-- Set of image sources -->


### PR DESCRIPTION
- Remove extra top margin from figcaption

<img width="466" alt="image" src="https://user-images.githubusercontent.com/56947778/191620676-665126f9-11dd-4c9f-8337-a38d443170e3.png">
