### PR TITLE
fix: turn off pre-wrap whitespace for KvExpandableQuestion and prose …

### DIFF
--- a/@kiva/kv-components/vue/KvExpandableQuestion.vue
+++ b/@kiva/kv-components/vue/KvExpandableQuestion.vue
@@ -1,7 +1,7 @@
 <template>
-	<div>
+	<div class="tw-whitespace-normal">
 		<button
-			class="tw-w-full tw-py-2 tw-flex tw-justify-between"
+			class="tw-w-full tw-py-2 tw-flex tw-justify-between tw-not-prose"
 			@click="toggleFAQ"
 		>
 			<h3 class="tw-text-subhead tw-text-left">

--- a/@kiva/kv-components/vue/stories/KvExpandableQuestion.stories.js
+++ b/@kiva/kv-components/vue/stories/KvExpandableQuestion.stories.js
@@ -84,3 +84,46 @@ const SlotContentTemplate = () => ({
 });
 
 export const SlotContent = SlotContentTemplate.bind({});
+
+const ProseWrappedTemplate = () => ({
+	components: { KvExpandableQuestion },
+	template: `
+		<div class="rich-text-content tw-prose tw-whitespace-pre-wrap tw-mb-2 md:tw-mb-3" data-testid="rich-text-container">
+			<h4><!--[-->Our commitment<!--]--></h4>
+			<h2><!--[--><!--[-->100% of your loan goes toward <!--]--><!--[--><b><!--[-->supporting borrowers.<!--]--></b><!--]--><!--]--></h2>
+			<section class="tw-relative tw-w-full">
+				<div class="tw-pt-4 tw-pb-4 lg:tw-pt-8 lg:tw-pb-8 tw-relative tw-w-full tw-overflow-hidden tw-z-1 tw-top-0">
+					<div>
+						<div style="">
+							<div class="tw-divide-y tw-whitespace-normal">
+								<kv-expandable-question
+									id="expandable-question-test"
+									title="Why Lending?"
+								>
+									<p>If you needed to buy a delivery truck for your business, you probably wouldn’t ask for donations; you’d apply for a loan.</p><p>But what about the  billion people without access to traditional finance? That's where you—and Kiva—come in. Kiva loans give people the power and resources to build the life they choose. By crowdfunding smaller amounts—called microloans—we can help more borrowers get funded.</p><p>With Kiva, you can use the same dollars again and again, helping a new borrower each time your loan is repaid. Your same $25 could help someone open a salon, support a child’s education, invest in community solar panels, and so on!</p>
+								</kv-expandable-question>
+								<kv-expandable-question
+									id="expandable-question-test"
+									title="How does Kiva make money ?"
+								>
+									<p>We cover most of our operating costs through voluntary donations made by Kiva lenders. As a 501(c)3 U.S. nonprofit, the remainder of our costs are covered through grants and donations from foundations and supporters. Additionally, select lending partners contribute small platform fees as we continue building innovative technologies that help create a more financially inclusive world.</p>
+									<p>Kiva never takes a fee from lenders. 100% of funds lent on Kiva go to funding loans.</p>
+								</kv-expandable-question>
+								<kv-expandable-question
+									id="expandable-question-test"
+									title="Do Kiva borrowers pay any interest on their loans?"
+								>
+									<p>Kiva partners with microfinance institutions, nonprofits, and other organizations to disburse loans in the communities we serve.</p>
+									<p>Most borrowers do pay interest to these local lending partners to help cover their operation costs. We verify that these rates are appropriate for the region and we only choose partners who have fair, non-predatory lending practices and prioritize social good.</p>
+									<p>Some borrowers funded through Kiva do receive 0% interest loans, including most direct loans, which are loans not made through a local lending partner.</p>
+								</kv-expandable-question>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
+	`,
+});
+
+export const ProseWrappedQuestion = ProseWrappedTemplate.bind({});


### PR DESCRIPTION
…for the title of the component

When these are embedded in a Rich Text Editor a wrapping parent div includes tw-prose and tw-whitespace-pre-wrap which creates a lot of extra unwanted padding around the elements.

The updates prevent that from applying where it shouldn't be.

Before:
![image](https://user-images.githubusercontent.com/1862756/195926459-f1cea166-3507-4a19-a8f4-4122ae789d40.png)

After:
![image](https://user-images.githubusercontent.com/1862756/195926482-4c2ad119-bcea-4a74-80f0-bb71623c89d8.png)
