### PR TITLE
Vue 1337

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvExpandableQuestion.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvExpandableQuestion.spec.js
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/vue';
+// import { axe } from 'jest-axe';
+import KvExpandableQuestion from '../../../../vue/KvExpandableQuestion.vue';
+
+screen.debug();
+
+describe('KvExpandableQuestion', () => {
+	it('renders KvExpandableQuestion that opens and closes when clicking the title', async () => {
+		const { getByText } = render(KvExpandableQuestion, {
+			props: {
+				title: 'Kv Expandable Question',
+				id: 'kv-expandable-question',
+			},
+			slots: { default: 'Test Question' },
+		});
+		const titleContent = getByText('Kv Expandable Question');
+		expect(titleContent).toBeDefined();
+		expect(getByText('Test Question')).not.toBeVisible();
+		await fireEvent.click(titleContent);
+		expect(getByText('Test Question')).toBeVisible();
+		await fireEvent.click(titleContent);
+		expect(getByText('Test Question')).not.toBeVisible();
+	});
+
+	it('renders KvExpandableQuestion that opens and closes when clicking the arrow', async () => {
+		const { container } = render(KvExpandableQuestion, {
+			props: {
+				title: 'Kv Expandable Question',
+				id: 'kv-expandable-question',
+				testid: 'test-expandable',
+			},
+			slots: { default: 'Test Question' },
+		});
+		const spanEl = container.querySelector("[role='img']");
+		const svgEl = container.querySelector("[viewBox= '0 0 24 24']");
+		// const displaySVG = screen.getByDisplayValue
+		console.log(spanEl);
+		console.log(svgEl);
+		expect(spanEl.classList.toString()).toContain('tw-inline-flex');
+		expect(svgEl.classList.toString()).toContain('tw-w-full');
+		expect(svgEl).toBeVisible();
+		await fireEvent.click(svgEl);
+		expect(svgEl).toBeInTheDocument();
+		// fireEvent.change
+		/* expect(svgEl).not.toBeVisible();
+		await fireEvent.click(svgEl);
+		expect(svgEl).toBeVisible(); */
+
+		// const arrowIcon = getByRole('button');
+		// expect(arrowIcon.find('span')).toBeDefined();
+
+		// expect(arrowIcon.find('span')).not.toBeVisible();
+		// await fireEvent.click(titleContent);
+		// expect(getByText('Test Question')).toBeVisible();
+		// await fireEvent.click(titleContent);
+		// expect(getByText('Test Question')).not.toBeVisible();
+	});
+	/* it('can\'t be toggled when the disabled prop is true', async () => {
+		const { getByLabelText } = render(KvExpandableQuestion, {
+			props: { disabled: true },
+			slots: { default: 'Test Question' },
+		});
+		const questionEl = getByLabelText('Test Question');
+
+		expect(questionEl.checked).toEqual(false);
+		await questionEl.click();
+		expect(questionEl.checked).toEqual(false);
+	}); */
+
+	/* it('has no automated accessibility violations', async () => {
+		const { container } = render(KvExpandableQuestion, {
+			props: {
+				title: 'Kv Expandable Question',
+				id: 'kv-expandable-question',
+			},
+			slots: { default: 'Test Question' },
+		});
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	}); */
+});

--- a/@kiva/kv-components/tests/unit/specs/components/KvExpandableQuestion.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvExpandableQuestion.spec.js
@@ -1,8 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/vue';
-// import { axe } from 'jest-axe';
+import { fireEvent, render } from '@testing-library/vue';
 import KvExpandableQuestion from '../../../../vue/KvExpandableQuestion.vue';
-
-screen.debug();
 
 describe('KvExpandableQuestion', () => {
 	it('renders KvExpandableQuestion that opens and closes when clicking the title', async () => {
@@ -23,59 +20,36 @@ describe('KvExpandableQuestion', () => {
 	});
 
 	it('renders KvExpandableQuestion that opens and closes when clicking the arrow', async () => {
-		const { container } = render(KvExpandableQuestion, {
+		const { container, getByText } = render(KvExpandableQuestion, {
 			props: {
 				title: 'Kv Expandable Question',
 				id: 'kv-expandable-question',
 				testid: 'test-expandable',
 			},
-			slots: { default: 'Test Question' },
+			// establish some multi line content
+			slots: { default: '<p>renders KvExpandableQuestion that opens and closes when clicking the arrow renders KvExpandableQuestion</p> <p>that opens and closes when clicking the arrow</p> <p>Test Question</p>' },
 		});
 		const spanEl = container.querySelector("[role='img']");
 		const svgEl = container.querySelector("[viewBox= '0 0 24 24']");
-		// const displaySVG = screen.getByDisplayValue
-		console.log(spanEl);
-		console.log(svgEl);
-		expect(spanEl.classList.toString()).toContain('tw-inline-flex');
-		expect(svgEl.classList.toString()).toContain('tw-w-full');
+
+		// Check State prior to clicking Icon
 		expect(svgEl).toBeVisible();
-		await fireEvent.click(svgEl);
-		expect(svgEl).toBeInTheDocument();
-		// fireEvent.change
-		/* expect(svgEl).not.toBeVisible();
-		await fireEvent.click(svgEl);
-		expect(svgEl).toBeVisible(); */
+		expect(getByText('Test Question')).not.toBeVisible();
 
-		// const arrowIcon = getByRole('button');
-		// expect(arrowIcon.find('span')).toBeDefined();
+		// Click icon to open expandable and check content visibility
+		await fireEvent.click(spanEl);
+		const firstLineOpen = getByText('renders KvExpandableQuestion that opens and closes when clicking the arrow renders KvExpandableQuestion');
+		expect(firstLineOpen).toBeVisible();
 
-		// expect(arrowIcon.find('span')).not.toBeVisible();
-		// await fireEvent.click(titleContent);
-		// expect(getByText('Test Question')).toBeVisible();
-		// await fireEvent.click(titleContent);
-		// expect(getByText('Test Question')).not.toBeVisible();
+		const lastLineOpen = getByText('Test Question');
+		expect(lastLineOpen).toBeVisible();
+
+		// Click icon and check content visibility
+		await fireEvent.click(spanEl);
+		const firstLineClosed = getByText('renders KvExpandableQuestion that opens and closes when clicking the arrow renders KvExpandableQuestion');
+		expect(firstLineClosed).not.toBeVisible();
+
+		const lastLineClosed = getByText('Test Question');
+		expect(lastLineClosed).not.toBeVisible();
 	});
-	/* it('can\'t be toggled when the disabled prop is true', async () => {
-		const { getByLabelText } = render(KvExpandableQuestion, {
-			props: { disabled: true },
-			slots: { default: 'Test Question' },
-		});
-		const questionEl = getByLabelText('Test Question');
-
-		expect(questionEl.checked).toEqual(false);
-		await questionEl.click();
-		expect(questionEl.checked).toEqual(false);
-	}); */
-
-	/* it('has no automated accessibility violations', async () => {
-		const { container } = render(KvExpandableQuestion, {
-			props: {
-				title: 'Kv Expandable Question',
-				id: 'kv-expandable-question',
-			},
-			slots: { default: 'Test Question' },
-		});
-		const results = await axe(container);
-		expect(results).toHaveNoViolations();
-	}); */
 });

--- a/@kiva/kv-components/vue/KvExpandableQuestion.vue
+++ b/@kiva/kv-components/vue/KvExpandableQuestion.vue
@@ -10,7 +10,7 @@
 			<kv-material-icon
 				class="tw-w-4 tw-h-4"
 				:icon="open ? mdiChevronUp : mdiChevronDown"
-				@click="toggleFAQ"
+				@click.stop="toggleFAQ"
 			/>
 		</button>
 		<kv-expandable easing="ease-in-out">

--- a/@kiva/kv-components/vue/KvExpandableQuestion.vue
+++ b/@kiva/kv-components/vue/KvExpandableQuestion.vue
@@ -14,15 +14,14 @@
 			/>
 		</button>
 		<kv-expandable easing="ease-in-out">
-			<div
-				v-show="open"
-				class="tw-prose tw-pb-4 tw-pt-2"
-			>
-				<slot></slot>
-				<div
-					v-if="content !== ''"
-					v-html="content"
-				>
+			<div v-show="open">
+				<div class="tw-prose tw-pb-4 tw-pt-2">
+					<slot></slot>
+					<div
+						v-if="content !== ''"
+						v-html="content"
+					>
+					</div>
 				</div>
 			</div>
 		</kv-expandable>


### PR DESCRIPTION
This PR aims to fix 2 issues with the KvExpandableQuestion:

1. In a Vue3 context clicking the Chevron Icon would only partially open the expandable content. I was able to expand our tests to succeed in Vue 2 and fail in Vue 3 as we're seeing in our apps. Once this was in place, I used an [event modifier](https://vuejs.org/guide/essentials/event-handling.html#event-modifiers) `.stop` on the icon click to prevent the event from bubbling to the parent button and cancelling out the click event.
2. When clicking a KvExpandableQuestion, the transition would "jump" at first before expanding the content. To fix this, I separated our spacing and formatting styles from the div on which the transition occurs. I was able to verify the smooth transition in our [existing story](http://localhost:6006/?path=/story/kvexpandablequestion--prose-wrapped-question).