### PR TITLE
Core 1212 add view loan cta to new loan cards

### DIFF
--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -193,9 +193,12 @@
 				:is-adding="isAdding"
 				:enable-five-dollars-notes="enableFiveDollarsNotes"
 				:kv-track-function="kvTrackFunction"
+				:show-view-loan="showViewLoan"
+				:custom-loan-details="customLoanDetails"
 				class="tw-mt-auto"
 				:class="{ 'tw-w-full' : unreservedAmount <= 0 }"
 				@add-to-basket="$emit('add-to-basket', $event)"
+				@show-loan-details="clickReadMore('ViewLoan')"
 			/>
 		</div>
 	</div>
@@ -282,6 +285,10 @@ export default {
 		photoPath: {
 			type: String,
 			required: true,
+		},
+		showViewLoan: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/@kiva/kv-components/vue/KvLendCta.vue
+++ b/@kiva/kv-components/vue/KvLendCta.vue
@@ -1,7 +1,22 @@
 <template>
 	<div>
+		<kv-ui-button
+			v-if="showViewLoan"
+			:state="`${allSharesReserved ? 'disabled' : ''}`"
+			:to="customLoanDetails ? '' : `/lend/${loanId}`"
+			class="tw-mb-0"
+			@click="$emit('show-loan-details')"
+		>
+			<span class="tw-flex">
+				View loan
+				<kv-material-icon
+					class="tw-w-3 tw-h-3 tw-align-middle"
+					:icon="mdiChevronRight"
+				/>
+			</span>
+		</kv-ui-button>
 		<form
-			v-if="useFormSubmit"
+			v-else-if="useFormSubmit"
 			class="tw-w-full tw-flex"
 			@submit.prevent="addToBasket"
 		>
@@ -45,7 +60,7 @@
 
 					<!-- Lend again/lent previously button -->
 					<kv-ui-button
-						v-if="showLendAgain"
+						v-else-if="showLendAgain"
 						key="lendAgainButton"
 						class="lend-again"
 						data-testid="bp-lend-cta-lend-again-button"
@@ -109,9 +124,11 @@
 
 <script>
 import numeral from 'numeral';
+import { mdiChevronRight } from '@mdi/js';
 import KvLendAmountButton from './KvLendAmountButton.vue';
 import KvUiSelect from './KvSelect.vue';
 import KvUiButton from './KvButton.vue';
+import KvMaterialIcon from './KvMaterialIcon.vue';
 
 export default {
 	name: 'KvLendCta',
@@ -119,6 +136,7 @@ export default {
 		KvLendAmountButton,
 		KvUiButton,
 		KvUiSelect,
+		KvMaterialIcon,
 	},
 	props: {
 		loan: {
@@ -145,9 +163,18 @@ export default {
 			type: Function,
 			required: true,
 		},
+		showViewLoan: {
+			type: Boolean,
+			default: false,
+		},
+		customLoanDetails: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
+			mdiChevronRight,
 			selectedOption: this.getSelectedOption(this.loan?.unreservedAmount),
 		};
 	},

--- a/@kiva/kv-components/vue/stories/KvClassicLoanCard.stories.js
+++ b/@kiva/kv-components/vue/stories/KvClassicLoanCard.stories.js
@@ -26,6 +26,7 @@ const story = (args) => {
 					:is-bookmarked="isBookmarked"
 					:kv-track-function="kvTrackFunction"
 					:photo-path="photoPath"
+					:show-view-loan="showViewLoan"
 				/>
 			</div>
 		`,
@@ -203,4 +204,12 @@ export const FiveDollarNotes = story({
 	enableFiveDollarsNotes: true,
 	kvTrackFunction,
 	photoPath,
+});
+
+export const ViewLoan = story({
+	loanId: loan.id,
+	loan,
+	kvTrackFunction,
+	photoPath,
+	showViewLoan: true,
 });

--- a/@kiva/kv-components/vue/stories/KvLendCta.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLendCta.stories.js
@@ -18,6 +18,8 @@ const story = (args) => {
 					:is-adding="isAdding"
 					:enable-five-dollars-notes="enableFiveDollarsNotes"
 					:kv-track-function="kvTrackFunction"
+					:show-view-loan="showViewLoan"
+					:custom-loan-details="customLoanDetails"
 				/>
 			</div>
 		`,
@@ -101,4 +103,14 @@ export const LendAgain = story({
 		userProperties: { lentTo: true },
 	},
 	kvTrackFunction,
+});
+
+export const ViewLoan = story({
+	isLoading: false,
+	loan: {
+		id: 1,
+		unreservedAmount: '150.00',
+	},
+	kvTrackFunction,
+	showViewLoan: true,
 });

--- a/@kiva/kv-loan-filters/src/themes.ts
+++ b/@kiva/kv-loan-filters/src/themes.ts
@@ -4,7 +4,7 @@ import { getIdsFromQueryParam } from './queryParseUtils';
 /**
  * The themes/attributes that are always visible in the filter UI
  */
-export const visibleThemeIds = [2, 6, 8, 11, 14, 28, 29, 30, 32, 36];
+export const visibleThemeIds = [2, 6, 8, 11, 14, 28, 29, 32, 36];
 
 /**
  * Transforms filtered themes into a form usable by the filters

--- a/package-lock.json
+++ b/package-lock.json
@@ -47277,7 +47277,7 @@
         "@storybook/addon-actions": "^6.4.17",
         "@storybook/addon-essentials": "^6.4.17",
         "@storybook/addon-links": "^6.4.17",
-        "@storybook/addon-postcss": "*",
+        "@storybook/addon-postcss": "^2.0.0",
         "@storybook/addon-storysource": "^6.4.17",
         "@storybook/addons": "^6.4.17",
         "@storybook/vue": "^6.4.17",


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1212

- Added "view loan" CTA to new loan cards
- This will be used in the home page
- Included removing earth day theme (campaign is over)
- Included missing package-lock change from last PR

![image](https://user-images.githubusercontent.com/16867161/236524108-8af40ef8-a676-46f2-9e41-8eb8b994a648.png)
