### PR TITLE
fix: regex to get cookie by name

### DIFF
--- a/@kiva/kv-shop/src/basket.ts
+++ b/@kiva/kv-shop/src/basket.ts
@@ -2,7 +2,7 @@
 const getCookieValue = (name: string) => {
 	if (typeof document !== undefined) {
 		// From: https://stackoverflow.com/a/25490531
-		return document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)/`)?.pop() || '';
+		return document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || '';
 	}
 };
 


### PR DESCRIPTION
Current method was returning always undefined due to an extra slash (`/`) in regex

<img width="469" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/56947778/fd6bf2a4-4ec6-4598-b087-2177ebe19d48">
