### PR TITLE
Exclude dependabot prs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,7 @@ on: push
 # List of jobs
 jobs:
   chromatic-deployment:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Use Node.js


### PR DESCRIPTION
Attempting to exclude dependabot prs from running chromatic tasks:
ref. https://github.com/orgs/community/discussions/26079 + https://github.com/GCTC-NTGC/gc-digital-talent/pull/2677/files + https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
