### PR TITLE
feat: lend amount CTA double event stop

### DIFF
--- a/@kiva/kv-components/vue/KvLendCta.vue
+++ b/@kiva/kv-components/vue/KvLendCta.vue
@@ -66,7 +66,7 @@
 						style="border-radius: 14px 0 0 14px;"
 						aria-label="Lend amount"
 						@update:modelValue="trackLendAmountSelection"
-						@click.native="clickDropdown"
+						@click.native.stop="clickDropdown"
 					>
 						<option
 							v-for="priceOption in prices"


### PR DESCRIPTION
- The new loan card dropdown was doubling the click event
- Not a good way to test this locally, but hopefully this solves it