### PR TITLE
feat: avoid image bug for tiny screens

### DIFF
--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -417,7 +417,6 @@ export default {
 				{ width: 416, viewSize: 480 },
 				{ width: 374, viewSize: 414 },
 				{ width: 335, viewSize: 375 },
-				{ width: 300 },
 			];
 		},
 		loanCallouts() {


### PR DESCRIPTION
- removing smallest image size option to avoid image bug in tiny screens and zoomed out desktop version
<img width="528" alt="Screenshot 2023-07-05 at 16 49 36" src="https://github.com/kiva/kv-ui-elements/assets/94026278/758d6c31-f20f-4bca-b0b8-28f6e18d46d1">
<img width="483" alt="Screenshot 2023-07-05 at 16 50 24" src="https://github.com/kiva/kv-ui-elements/assets/94026278/ae4e5949-9a0b-4e40-bb1b-10543e571f91">
<img width="406" alt="Screenshot 2023-07-06 at 9 10 36" src="https://github.com/kiva/kv-ui-elements/assets/94026278/5713b12c-c64f-484f-9a81-673489c79aea">

Fixed example
<img width="477" alt="Screenshot 2023-07-06 at 9 14 44" src="https://github.com/kiva/kv-ui-elements/assets/94026278/08e04aca-0d75-4137-bc48-ec3bf0db27d1">
