### PR TITLE
feat: cleanup unneeded code in kiva partner header

### DIFF
--- a/@kiva/kv-components/vue/KvKivaPartnerHeader.vue
+++ b/@kiva/kv-components/vue/KvKivaPartnerHeader.vue
@@ -32,13 +32,7 @@
 	</nav>
 </template>
 
-<script>
-export default {
-	setup() {},
-};
-</script>
-
-<style lang="postcss" scoped>
+<style scoped>
 .header__full {
   grid-template-areas: 'logo right';
   grid-template-columns: 1fr auto;


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CIT-229

- The `auth0` repo didn't like these (mainly the empty `setup`)