### PR TITLE
feat: adding new option to the loan progress bar bg

### DIFF
--- a/@kiva/kv-components/vue/KvProgressBar.vue
+++ b/@kiva/kv-components/vue/KvProgressBar.vue
@@ -2,8 +2,8 @@
 	<div
 		class="
 			tw-h-1 tw-w-full tw-rounded-full tw-overflow-hidden tw-relative
-			tw-bg-secondary
 		"
+		:class="backgroundVariant"
 		role="progressbar"
 		:aria-label="ariaLabel"
 		:aria-valuemin="min"
@@ -77,6 +77,17 @@ export default {
 				return ['primary', 'ghost', 'danger', 'caution'].includes(value);
 			},
 		},
+		/**
+		 * Appearance of the progress bar background
+		 * `secondary (default), tertiary
+		 * */
+		bgVariant: {
+			type: String,
+			default: 'secondary',
+			validator(value) {
+				return ['secondary', 'tertiary'].includes(value);
+			},
+		},
 	},
 	setup(props) {
 		const {
@@ -84,6 +95,7 @@ export default {
 			max,
 			value,
 			variant,
+			bgVariant,
 		} = toRefs(props);
 		const loaded = ref(false);
 
@@ -107,6 +119,15 @@ export default {
 			}
 		});
 
+		const backgroundVariant = computed(() => {
+			switch (bgVariant.value) {
+				case 'tertiary':
+					return 'tw-bg-tertiary';
+				default:
+					return 'tw-bg-secondary';
+			}
+		});
+
 		const animateProgressBar = () => {
 			loaded.value = true;
 		};
@@ -121,6 +142,7 @@ export default {
 			percent,
 			animateProgressBar,
 			variantClass,
+			backgroundVariant,
 		};
 	},
 };

--- a/@kiva/kv-components/vue/stories/KvProgressBar.stories.js
+++ b/@kiva/kv-components/vue/stories/KvProgressBar.stories.js
@@ -9,6 +9,7 @@ export default {
 		value: 50,
 		ariaLabel: 'Amount the loan has fundraised',
 		variant: 'primary',
+		bgVariant: 'secondary',
 	},
 };
 
@@ -22,6 +23,7 @@ const Template = (args, { argTypes }) => ({
 			:max="max"
 			:value="value"
 			:variant="variant"
+			:bg-variant="bgVariant"
 
 		></kv-progress-bar>`,
 });
@@ -43,4 +45,9 @@ VariantDanger.args = {
 export const VariantGhost = Template.bind({});
 VariantGhost.args = {
 	variant: 'ghost',
+};
+
+export const BgVariantTertiary = Template.bind({});
+BgVariantTertiary.args = {
+	bgVariant: 'tertiary',
 };


### PR DESCRIPTION
On mobile (Borrower Profile page), progress bar background is not visible b/c it has the same color that the page background. For instance:

<img width="314" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/56947778/5e5fe0a9-7975-4e1e-92e2-d2f0fb881ba7">

We added a new variant option for the background to set a darker one: `tertiary`

<img width="315" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/56947778/0d6b30c5-178b-4f61-aa55-ec7ac11c56e7">
