### PR TITLE
feat: add box shadows to tokens

### DIFF
--- a/@kiva/kv-tokens/configs/tailwind.config.cjs
+++ b/@kiva/kv-tokens/configs/tailwind.config.cjs
@@ -127,7 +127,7 @@ module.exports = {
 		},
 		boxShadow: {
 			DEFAULT: '0 1px 3px 0 rgb(0 0 0 / 0.1)',
-			md: '0 4px 12px rgba(0, 0, 0, 0.08)',
+			lg: '0 4px 12px rgba(0, 0, 0, 0.08)',
 		},
 		extend: {
 			typography: kivaTypography.proseOverrides, // prose plugin overrides

--- a/@kiva/kv-tokens/configs/tailwind.config.cjs
+++ b/@kiva/kv-tokens/configs/tailwind.config.cjs
@@ -22,7 +22,6 @@ module.exports = {
 	content: ['./**.*.js'],
 	prefix: 'tw-', // prefixes all tailwinds classes with tw. e.g., 'tw-flex tw-mb-2'
 	corePlugins: {
-		boxShadow: false,
 		container: false,
 		fontSize: false,
 		letterSpacing: false,
@@ -125,6 +124,10 @@ module.exports = {
 			tooltip: zIndices.tooltip,
 			troposphere: zIndices.troposphere,
 			stratosphere: zIndices.stratosphere,
+		},
+		boxShadow: {
+			DEFAULT: '0 1px 3px 0 rgb(0 0 0 / 0.1)',
+			md: '0 4px 12px rgba(0, 0, 0, 0.08)',
 		},
 		extend: {
 			typography: kivaTypography.proseOverrides, // prose plugin overrides


### PR DESCRIPTION
- Used the default TW shadow for the default
- Added the shadow we used for Kiva cards as the `md` variation, since it's a fairly wide shadow

default:
![image](https://github.com/kiva/kv-ui-elements/assets/16867161/f2ecc240-6ce9-4ad2-a1cb-1126f1baadeb)


`md`:
![image](https://github.com/kiva/kv-ui-elements/assets/16867161/c58b1b64-993a-429d-a589-b5e62c40ab86)
