### PR TITLE
feat: avoid adding themes to callouts when equal to category page

### DIFF
--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -476,7 +476,8 @@ export default {
 			if (!!themes.length && callouts.length < 2) {
 				const position = Math.floor(Math.random() * themes.length);
 				const theme = themes[position];
-				if (!callouts.filter((c) => c.toUpperCase() === theme.toUpperCase()).length) {
+				if (!callouts.filter((c) => c.toUpperCase() === theme.toUpperCase()).length
+					&& theme.toUpperCase() !== this.categoryPageName?.toUpperCase()) {
 					callouts.push(theme);
 				}
 			}


### PR DESCRIPTION
- Avoid adding a theme to callouts when equal to category page name in loan card