### PR TITLE
feat: slightly larger default box shadow

### DIFF
--- a/@kiva/kv-tokens/configs/tailwind.config.cjs
+++ b/@kiva/kv-tokens/configs/tailwind.config.cjs
@@ -126,7 +126,7 @@ module.exports = {
 			stratosphere: zIndices.stratosphere,
 		},
 		boxShadow: {
-			DEFAULT: '0 1px 3px 0 rgb(0 0 0 / 0.1)',
+			DEFAULT: '0 1px 4px 0 rgb(0 0 0 / 0.08)',
 			lg: '0 4px 12px rgba(0, 0, 0, 0.08)',
 		},
 		extend: {


### PR DESCRIPTION
- In the mindset of simply creating a new default tip message, here's a slightly larger default box shadow that helps distinguish the tip from the same colored background
- This new default is just slightly larger and lighter, and actually aligns better with our existing box shadows

<img width="568" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/16867161/39d26344-37fe-4e8f-8896-b22f1767d2d5">
