### PR TITLE
Cit 334 line graph

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvLineGraph.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvLineGraph.spec.js
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/vue';
+import { axe } from 'jest-axe';
+import KvLineGraph from '../../../../vue/KvLineGraph.vue';
+
+describe('KvLineGraph', () => {
+	const points = [
+		{ value: 10 },
+		{ value: 20 },
+		{ value: 50 },
+		{ value: 60 },
+		{ value: 80 },
+	];
+
+	const pointsWithLabels = [
+		{ value: 10, label: '2014' },
+		{ value: 20, label: '2015' },
+		{ value: 50, label: '2016' },
+		{ value: 60, label: '2017' },
+		{ value: 80, label: '2018' },
+	];
+
+	it('should render chart with points', () => {
+		const { container } = render(KvLineGraph, { props: { points } });
+		const pointElements = container.querySelectorAll('span');
+
+		expect(pointElements.length).toBe(points.length);
+	});
+
+	it('should render chart with value labels', () => {
+		const { container } = render(KvLineGraph, { props: { points: pointsWithLabels } });
+		const pointElements = container.querySelectorAll('span');
+
+		expect(pointElements.length).toBe(points.length * 2);
+	});
+
+	it('should render chart with x-axis label', () => {
+		const { container } = render(KvLineGraph, { props: { points, axisLabel: 'People supported over time' } });
+		const label = container.querySelectorAll('h4');
+
+		expect(label.length).toBe(1);
+	});
+
+	it('should render chart with value labels and x-axis label', () => {
+		const { container } = render(KvLineGraph, { props: { points: pointsWithLabels, axisLabel: 'People supported over time' } });
+		const pointElements = container.querySelectorAll('span');
+		const label = container.querySelectorAll('h4');
+
+		expect(pointElements.length).toBe(points.length * 2);
+		expect(label.length).toBe(1);
+	});
+
+	it('should have no automated accessibility violations', async () => {
+		const { container } = render(KvLineGraph, { props: { points } });
+		const results = await axe(container);
+
+		expect(results).toHaveNoViolations();
+	});
+});

--- a/@kiva/kv-components/vue/KvLineGraph.vue
+++ b/@kiva/kv-components/vue/KvLineGraph.vue
@@ -12,32 +12,33 @@
 				class="tw-absolute tw-top-0 tw-w-full tw-h-full tw-bg-marigold-2"
 				:style="{ clipPath: `polygon(${line})` }"
 			></div>
-			<div
+			<span
 				v-for="point in normalizedPoints"
 				:key="point.x"
 				class="
-				tw-absolute
-				tw-w-2
-				tw-h-2
-				tw-border
-				tw-border-white
-				tw-bg-marigold-2
-				tw-rounded-full
-			"
+					tw-absolute
+					tw-w-2
+					tw-h-2
+					tw-border
+					tw-border-white
+					tw-bg-marigold-2
+					tw-rounded-full
+				"
 				:style="{ left: `${point.x}%`, top: `${point.y}%`, transform: 'translate(-50%, -50%)' }"
-			></div>
+			></span>
 			<template v-for="point in normalizedPoints">
-				<div
+				<span
 					v-if="point.label"
 					:key="point.label"
 					class="tw-absolute"
 					:style="{ left: `${point.x}%`, bottom: '-3rem', transform: 'translate(-50%, -50%)' }"
 				>
 					{{ point.label }}
-				</div>
+				</span>
 			</template>
 		</figure>
 		<h4
+			v-if="axisLabel"
 			class="tw-text-center"
 			:class="{ 'tw-pt-1': !hasValueLabels, 'tw-pt-6': hasValueLabels }"
 		>

--- a/@kiva/kv-components/vue/KvLineGraph.vue
+++ b/@kiva/kv-components/vue/KvLineGraph.vue
@@ -1,0 +1,62 @@
+<template>
+	<figure class="tw-w-full tw-h-full tw-relative">
+		<div
+			class="tw-w-full tw-h-full tw-bg-marigold-2 tw-opacity-low"
+			:style="{ clipPath: `polygon(${shade}, 100% 100%, 0% 100%)` }"
+		></div>
+		<div
+			class="tw-absolute tw-top-0 tw-w-full tw-h-full tw-bg-marigold-2"
+			:style="{ clipPath: `polygon(${line})` }"
+		></div>
+		<div
+			v-for="point in points"
+			:key="point.x"
+			class="
+				tw-absolute
+				tw-w-2
+				tw-h-2
+				tw-border
+				tw-border-white
+				tw-bg-marigold-2
+				tw-rounded-full
+			"
+			:style="{ left: `${point.x}%`, top: `${point.y}%`, transform: 'translate(-50%, -50%)' }"
+		></div>
+	</figure>
+</template>
+
+<script>
+import { computed, toRefs } from 'vue-demi';
+
+export default {
+	props: {
+		/**
+		 * Array of objects like { x: 4, y: 54 }, where the x and y values have been normalized to 0-100.
+		 * The origin point is the top left corner, so you may need to invert the y values (100 - y).
+		 */
+		points: {
+			type: Array,
+			required: true,
+		},
+	},
+	setup(props) {
+		const { points } = toRefs(props);
+
+		const reversePoints = computed(() => ([...points.value].reverse()));
+
+		const shade = computed(() => (points.value.map(({ x, y }) => `${x}% ${y}%`).join(',')));
+
+		const line = computed(() => {
+			const topLine = points.value.map(({ x, y }) => `${x}% ${y + 0.25}%`).join(',');
+			const bottomLine = reversePoints.value.map(({ x, y }) => `${x}% ${y - 0.25}%`).join(',');
+			return `${topLine}, ${bottomLine}`;
+		});
+
+		return {
+			reversePoints,
+			shade,
+			line,
+		};
+	},
+};
+</script>

--- a/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
@@ -20,10 +20,10 @@ const Template = (_args, { argTypes }) => ({
 export const Default = Template.bind();
 Default.args = {
 	points: [
-		{ x: 0, y: 80 },
-		{ x: 25, y: 65 },
-		{ x: 50, y: 45 },
-		{ x: 75, y: 30 },
-		{ x: 100, y: 20 },
+		{ value: 10 },
+		{ value: 20 },
+		{ value: 50 },
+		{ value: 60 },
+		{ value: 80 },
 	],
 };

--- a/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
@@ -12,18 +12,41 @@ const Template = (_args, { argTypes }) => ({
 	},
 	template: `
 		<div style="height: 500px; width: 500px;">
-			<kv-line-graph :points="points" />
+			<kv-line-graph :points="points" :axis-label="axisLabel" />
 		</div>
 	`,
 });
 
+const points = [
+	{ value: 10 },
+	{ value: 20 },
+	{ value: 50 },
+	{ value: 60 },
+	{ value: 80 },
+];
+
+const pointsWithLabels = [
+	{ value: 10, label: '2014' },
+	{ value: 20, label: '2015' },
+	{ value: 50, label: '2016' },
+	{ value: 60, label: '2017' },
+	{ value: 80, label: '2018' },
+];
+
 export const Default = Template.bind();
-Default.args = {
-	points: [
-		{ value: 10 },
-		{ value: 20 },
-		{ value: 50 },
-		{ value: 60 },
-		{ value: 80 },
-	],
+Default.args = { points };
+
+export const AxisLabel = Template.bind();
+AxisLabel.args = {
+	points,
+	axisLabel: 'People supported over time',
+};
+
+export const ValueLabels = Template.bind();
+ValueLabels.args = { points: pointsWithLabels };
+
+export const AllLabels = Template.bind();
+AllLabels.args = {
+	points: pointsWithLabels,
+	axisLabel: 'People supported over time',
 };

--- a/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLineGraph.stories.js
@@ -1,0 +1,29 @@
+import KvLineGraph from '../KvLineGraph.vue';
+
+export default {
+	title: 'KvLineGraph',
+	component: KvLineGraph,
+};
+
+const Template = (_args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		KvLineGraph,
+	},
+	template: `
+		<div style="height: 500px; width: 500px;">
+			<kv-line-graph :points="points" />
+		</div>
+	`,
+});
+
+export const Default = Template.bind();
+Default.args = {
+	points: [
+		{ x: 0, y: 80 },
+		{ x: 25, y: 65 },
+		{ x: 50, y: 45 },
+		{ x: 75, y: 30 },
+		{ x: 100, y: 20 },
+	],
+};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CIT-334

- Created line graph component using the stash from @emuvente as the base
- Added support for labels (value and x-axis)
- Added ability to just pass in an array of values w/ labels
- Labels will likely get cut-off (or overflow really) in many cases, but this is a good first pass for the impact dashboard
- Line isn't perfect (gets thinner with larger slope, but again, okay for first pass)
- Added some basic tests

![image](https://github.com/kiva/kv-ui-elements/assets/16867161/19471c03-4d53-4162-abe4-735f03aa134d)

![image](https://github.com/kiva/kv-ui-elements/assets/16867161/ae665db8-22f4-4e5c-a464-30f133886197)

![image](https://github.com/kiva/kv-ui-elements/assets/16867161/3365ffc0-6dac-43fd-855a-b7031b90f8e8)

![image](https://github.com/kiva/kv-ui-elements/assets/16867161/e8af99d4-023d-4cf0-a5d9-10ea684e4dcf)
