### PR TITLE
feat: increase impact visibility for lse loans

### DIFF
--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -231,6 +231,8 @@ import KvLoanTag from './KvLoanTag.vue';
 import KvMaterialIcon from './KvMaterialIcon.vue';
 import KvLoadingPlaceholder from './KvLoadingPlaceholder.vue';
 
+const LSE_LOAN_KEY = 'N/A';
+
 export default {
 	name: 'KvClassicLoanCard',
 	components: {
@@ -438,8 +440,19 @@ export default {
 				singleParents: !!tags.filter((t) => t.toUpperCase() === 'SINGLE PARENT').length,
 			};
 
+			const isLseLoan = this.loan?.partnerName?.includes(LSE_LOAN_KEY);
+
 			// P1 Category
 			// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents
+			// Tag as first option for LSE loans
+			if (isLseLoan) {
+				const position = Math.floor(Math.random() * tags.length);
+				const tag = tags[position];
+				if (!callouts.filter((c) => c.toUpperCase() === tag.toUpperCase()).length) {
+					callouts.push(tag);
+				}
+			}
+
 			if (!this.categoryPageName) {
 				if (categories.ecoFriendly) {
 					callouts.push('Eco-friendly');
@@ -482,6 +495,8 @@ export default {
 				}
 			}
 
+			// Only show one callout for LSE loans
+			if (isLseLoan && callouts.length > 1) return [callouts.shift()];
 			return callouts;
 		},
 	},

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -440,7 +440,7 @@ export default {
 				singleParents: !!tags.filter((t) => t.toUpperCase() === 'SINGLE PARENT').length,
 			};
 
-			const isLseLoan = this.loan?.partnerName?.includes(LSE_LOAN_KEY);
+			const isLseLoan = this.loan?.partnerName?.toUpperCase().includes(LSE_LOAN_KEY);
 
 			// P1 Category
 			// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -445,7 +445,7 @@ export default {
 			// P1 Category
 			// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents
 			// Tag as first option for LSE loans
-			if (isLseLoan) {
+			if (isLseLoan && tags.length) {
 				const position = Math.floor(Math.random() * tags.length);
 				const tag = tags[position];
 				callouts.push(tag);

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -448,17 +448,17 @@ export default {
 			if (isLseLoan) {
 				const position = Math.floor(Math.random() * tags.length);
 				const tag = tags[position];
-				if (!callouts.filter((c) => c.toUpperCase() === tag.toUpperCase()).length) {
-					callouts.push(tag);
-				}
+				callouts.push(tag);
 			}
 
 			if (!this.categoryPageName) {
-				if (categories.ecoFriendly) {
+				if (categories.ecoFriendly
+					&& !callouts.filter((c) => c.toUpperCase() === categories.ecoFriendly.toUpperCase()).length) {
 					callouts.push('Eco-friendly');
 				} else if (categories.refugeesIdps) {
 					callouts.push('Refugees and IDPs');
-				} else if (categories.singleParents) {
+				} else if (categories.singleParents
+					&& !callouts.filter((c) => c.toUpperCase() === categories.singleParents.toUpperCase()).length) {
 					callouts.push('Single Parent');
 				}
 			}

--- a/@kiva/kv-components/vue/KvLoanTag.vue
+++ b/@kiva/kv-components/vue/KvLoanTag.vue
@@ -58,7 +58,7 @@ export default {
 		},
 		tagText() {
 			const partnerName = this.loan?.partnerName ?? '';
-			if (partnerName.includes(LSE_LOAN_KEY)) {
+			if (partnerName.toUpperCase().includes(LSE_LOAN_KEY)) {
 				return 'High community impact';
 			}
 			switch (this.variation) {

--- a/@kiva/kv-components/vue/KvLoanTag.vue
+++ b/@kiva/kv-components/vue/KvLoanTag.vue
@@ -17,6 +17,8 @@ import { differenceInDays, parseISO } from 'date-fns';
 import numeral from 'numeral';
 import KvCountdownTimer from './KvCountdownTimer.vue';
 
+const LSE_LOAN_KEY = 'N/A';
+
 export default {
 	name: 'KvLoanTag',
 	components: {
@@ -55,6 +57,10 @@ export default {
 			return null;
 		},
 		tagText() {
+			const partnerName = this.loan?.partnerName ?? '';
+			if (partnerName.includes(LSE_LOAN_KEY)) {
+				return 'High community impact';
+			}
 			switch (this.variation) {
 				case 'almost-funded': return 'Almost funded';
 				case 'matched-loan': return `${this.matchRatio + 1}x matching by ${this.loan?.matchingText}`;

--- a/@kiva/kv-components/vue/stories/KvClassicLoanCard.stories.js
+++ b/@kiva/kv-components/vue/stories/KvClassicLoanCard.stories.js
@@ -182,6 +182,29 @@ export const LongCallouts = story({
 	photoPath,
 });
 
+export const LseLoan = story({
+	loanId: loan.id,
+	loan: {
+		...loan,
+		loanFundraisingInfo: {
+			fundedAmount: '950.00',
+			isExpiringSoon: false,
+			reservedAmount: '0.00',
+		},
+		partnerName: 'N/A, direct to Novulis',
+		tags: [
+			'user_favorite',
+			'#Woman-Owned Business',
+			'#Animals',
+			'#Repeat Borrower',
+			'#Supporting Family',
+		],
+	},
+	kvTrackFunction,
+	photoPath,
+	showTags: true,
+});
+
 export const Bookmarked = story({
 	loanId: loan.id,
 	loan,

--- a/@kiva/kv-components/vue/stories/KvLoanTag.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLoanTag.stories.js
@@ -53,3 +53,15 @@ export const Matched = story({
 	},
 	kvTrackFunction,
 });
+
+export const LseLoan = story({
+	loan: {
+		matchingText: 'Ebay',
+		matchRatio: 1,
+		plannedExpirationDate: nextWeek.toISOString(),
+		loanAmount: 199,
+		loanFundraisingInfo: { fundedAmount: 0, reservedAmount: 0 },
+		partnerName: 'N/A, direct to Novulis',
+	},
+	kvTrackFunction,
+});


### PR DESCRIPTION
- Increasing impact visibility for LSE loans with next features:

1. Add a loan tag for LSE loans that says “High community impact”  
2. Change priority of grey “pills” so that we only show one public tag.
      Priority order: 1.Tag, 2. Category, 3. Activity, 4. Sector, 5. Theme

- For now we’ll use the lending partner containing “N/A” as the signifier for these loans