### PR TITLE
Extend loan use with why special

### DIFF
--- a/@kiva/kv-components/vue/KvLoanUse.vue
+++ b/@kiva/kv-components/vue/KvLoanUse.vue
@@ -55,6 +55,11 @@ export default {
 		isDirect() {
 			return this.distributionModel === DIRECT;
 		},
+		whySpecialSentence() {
+			return this.whySpecial
+				? ` This loan is special because ${this.whySpecial.charAt(0).toLowerCase() + this.whySpecial.slice(1)}`
+				: '';
+		},
 		loanUse() {
 			if (this.anonymizationLevel === 'full' || this.use.length === 0) {
 				return 'For the borrower\'s privacy, this loan has been made anonymous.';
@@ -68,7 +73,7 @@ export default {
 				+ `${this.name} `
 				+ `${this.isDirect ? `${this.helpLanguage} ` : ''}`
 				+ `${this.use.charAt(0).toLowerCase() + this.use.slice(1)}`
-				+ `${this.whySpecial ? ` ${this.whySpecial}` : ''}`;
+				+ `${this.whySpecialSentence}`;
 		},
 	},
 };

--- a/@kiva/kv-components/vue/KvLoanUse.vue
+++ b/@kiva/kv-components/vue/KvLoanUse.vue
@@ -40,6 +40,10 @@ export default {
 			type: String,
 			default: DIRECT,
 		},
+		whySpecial: {
+			type: String,
+			default: '',
+		},
 	},
 	computed: {
 		helpLanguage() {
@@ -63,7 +67,8 @@ export default {
 				+ `${isGroup ? 'a member of ' : ''}`
 				+ `${this.name} `
 				+ `${this.isDirect ? `${this.helpLanguage} ` : ''}`
-				+ `${this.use.charAt(0).toLowerCase() + this.use.slice(1)}`;
+				+ `${this.use.charAt(0).toLowerCase() + this.use.slice(1)}`
+				+ `${this.whySpecial ? ` ${this.whySpecial}` : ''}`;
 		},
 	},
 };

--- a/@kiva/kv-components/vue/stories/KvLoanUse.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLoanUse.stories.js
@@ -18,6 +18,7 @@ const story = (args) => {
 				:borrower-count="borrowerCount"
 				:name="name"
 				:distribution-model="distributionModel"
+				:why-special="whySpecial"
 			/>
 		`,
 	});
@@ -48,4 +49,12 @@ export const Group = story({
 	status: 'fundraising',
 	name: 'Farm Organization',
 	borrowerCount: 2,
+});
+
+export const WhySpecial = story({
+	use: 'buy supplies.',
+	loanAmount: '1000.00',
+	status: 'fundraising',
+	name: 'Bob Smith',
+	whySpecial: 'It supports organic farming and includes a lower interest rate.',
 });


### PR DESCRIPTION
- Added option why special string to loan use so we can re-use the component in impact dashboard

![image](https://github.com/kiva/kv-ui-elements/assets/16867161/7745be30-9d74-403e-8317-edee9aa5a198)
