### PR TITLE
feat: one-time checkout and supporting functions MARS-546

### DIFF
--- a/@kiva/kv-shop/src/basket.ts
+++ b/@kiva/kv-shop/src/basket.ts
@@ -1,16 +1,6 @@
 import { gql } from '@apollo/client/core';
+import { getCookieValue, setCookieValue } from './util/cookie';
 import { parseShopError } from './shopError';
-
-// TODO: could be moved to shared file or separate package
-export const getCookieValue = (name: string) => {
-	if (typeof document !== undefined) {
-		// From: https://stackoverflow.com/a/25490531
-		return decodeURIComponent(document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || '');
-	}
-};
-export const setCookieValue = (name: string, value: string, options = '') => {
-	document.cookie = `${name}=${encodeURIComponent(value)};${options}`;
-};
 
 export function getBasketID() {
 	return getCookieValue('kvbskt');

--- a/@kiva/kv-shop/src/basketCredits.ts
+++ b/@kiva/kv-shop/src/basketCredits.ts
@@ -1,0 +1,45 @@
+import type { ApolloClient } from '@apollo/client/core';
+import { gql } from '@apollo/client/core';
+import { callShopMutation } from './shopQueries';
+
+export interface ApplyKivaCreditData {
+	shop: {
+		id: string,
+		addCreditByType: boolean,
+	} | null,
+}
+
+export async function applyKivaCredit(apollo: ApolloClient<any>): Promise<boolean> {
+	const data = await callShopMutation<ApplyKivaCreditData>(apollo, {
+		awaitRefetchQueries: true,
+		mutation: gql`mutation applyKivaCredit($basketId: String) {
+			shop (basketId: $basketId) {
+				id
+				addCreditByType(creditType: kiva_credit)
+			}
+		}`,
+	});
+
+	return !!data?.shop?.addCreditByType;
+}
+
+export interface RemoveKivaCreditData {
+	shop: {
+		id: string,
+		removeCreditByType: boolean,
+	} | null,
+}
+
+export async function removeKivaCredit(apollo: ApolloClient<any>): Promise<boolean> {
+	const data = await callShopMutation<RemoveKivaCreditData>(apollo, {
+		awaitRefetchQueries: true,
+		mutation: gql`mutation removeKivaCredit($basketId: String) {
+			shop (basketId: $basketId) {
+				id
+				removeCreditByType(creditType: kiva_credit)
+			}
+		}`,
+	});
+
+	return !!data?.shop?.removeCreditByType;
+}

--- a/@kiva/kv-shop/src/basketItems.ts
+++ b/@kiva/kv-shop/src/basketItems.ts
@@ -1,76 +1,44 @@
-import { gql, ApolloClient, DocumentNode } from '@apollo/client/core';
+import type { ApolloClient } from '@apollo/client/core';
+import { gql } from '@apollo/client/core';
 import numeral from 'numeral';
-import { getBasketID, hasBasketExpired, createBasket } from './basket';
-import { ShopError, parseShopError } from './shopError';
-
-/**
- * Call a shop mutation with a basketId, creating a new basket if necessary.
- */
-async function callShopMutation(
-	apollo: ApolloClient<any>,
-	mutation: DocumentNode,
-	variables: Record<string, any>,
-	maxretries = 2,
-) {
-	try {
-		const result = await apollo.mutate({
-			mutation,
-			variables: {
-				...variables,
-				basketId: getBasketID(),
-			},
-		});
-		if (result?.errors?.length) {
-			// Retry recoverable basket expired errors
-			const basketErrors = result?.errors.filter((err) => hasBasketExpired(err));
-			if (basketErrors.length) {
-				// Create a new basket and retry if retries remain
-				if (maxretries > 0) {
-					await createBasket(apollo);
-					return callShopMutation(apollo, mutation, variables, maxretries - 1);
-				}
-				// Fail on basket expired errors if no retries remain
-				throw basketErrors[0];
-			}
-
-			// Fail on non-recoverable errors
-			const otherErrors = result?.errors?.filter((err) => !hasBasketExpired(err));
-			if (otherErrors.length) {
-				throw otherErrors[0];
-			}
-		}
-		// Return successful result data
-		return result?.data;
-	} catch (e) {
-		// Parse and throw on non-recoverable errors
-		if (e instanceof ShopError) {
-			throw e;
-		}
-		throw parseShopError(e);
-	}
-}
+import { callShopMutation } from './shopQueries';
 
 export interface SetTipDonationOptions {
 	amount: string | number,
 	apollo: ApolloClient<any>,
 }
 
+export interface SetTipDonationData {
+	shop: {
+		id: string,
+		updateDonation: {
+			id: string,
+			price: string,
+			isTip: boolean,
+		} | null,
+	} | null,
+}
+
 export async function setTipDonation({ amount, apollo }: SetTipDonationOptions) {
 	const donationAmount = numeral(amount).format('0.00');
-	const data = await callShopMutation(apollo, gql`mutation setTipDonation($price: Money!, $basketId: String) {
-		shop (basketId: $basketId) {
-			id
-			updateDonation (donation: {
-				price: $price,
-				isTip: true
-			})
-			{
+	const data = await callShopMutation<SetTipDonationData>(apollo, {
+		awaitRefetchQueries: true,
+		mutation: gql`mutation setTipDonation($price: Money!, $basketId: String) {
+			shop (basketId: $basketId) {
 				id
-				price
-				isTip
+				updateDonation (donation: {
+					price: $price,
+					isTip: true
+				})
+				{
+					id
+					price
+					isTip
+				}
 			}
-		}
-	}`, { price: donationAmount });
+		}`,
+		variables: { price: donationAmount },
+	});
 
 	return data?.shop?.updateDonation;
 }

--- a/@kiva/kv-shop/src/basketTotals.ts
+++ b/@kiva/kv-shop/src/basketTotals.ts
@@ -1,0 +1,69 @@
+import type { ApolloClient } from '@apollo/client/core';
+import { gql } from '@apollo/client/core';
+import { watchShopQuery } from './shopQueries';
+
+export const basketTotalsQuery = gql`query basketTotals($basketId: String) {
+	shop (basketId: $basketId) {
+		id
+		basket {
+			id
+			totals {
+				bonusAppliedTotal
+				bonusAvailableTotal
+				creditAmountNeeded
+				creditAppliedTotal
+				creditAvailableTotal
+				donationTotal
+				itemTotal
+				freeTrialAppliedTotal
+				freeTrialAvailableTotal
+				loanReservationTotal
+				kivaCardTotal
+				kivaCreditAppliedTotal
+				kivaCreditAvailableTotal
+				kivaCreditRemaining
+				kivaCreditToReapply
+				redemptionCodeAppliedTotal
+				redemptionCodeAvailableTotal
+				universalCodeAppliedTotal
+				universalCodeAvailableTotal
+			}
+		}
+	}
+}`;
+
+export interface BasketTotalsData {
+	shop: {
+		id: string,
+		basket: {
+			id: string,
+			totals: {
+				bonusAppliedTotal: string,
+				bonusAvailableTotal: string,
+				creditAmountNeeded: string,
+				creditAppliedTotal: string,
+				creditAvailableTotal: string,
+				donationTotal: string,
+				itemTotal: string,
+				freeTrialAppliedTotal: string,
+				freeTrialAvailableTotal: string,
+				loanReservationTotal: string,
+				kivaCardTotal: string,
+				kivaCreditAppliedTotal: string,
+				kivaCreditAvailableTotal: string,
+				kivaCreditRemaining: string,
+				kivaCreditToReapply: string,
+				redemptionCodeAppliedTotal: string,
+				redemptionCodeAvailableTotal: string,
+				universalCodeAppliedTotal: string,
+				universalCodeAvailableTotal: string,
+			} | null,
+		} | null,
+	} | null,
+}
+
+export function watchBasketTotals(apollo: ApolloClient<any>) {
+	return watchShopQuery<BasketTotalsData>(apollo, {
+		query: basketTotalsQuery,
+	});
+}

--- a/@kiva/kv-shop/src/basketVerification.ts
+++ b/@kiva/kv-shop/src/basketVerification.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line no-shadow
+export enum VerificationState {
+	VERIFIED = 'verified',
+	PENDING = 'pending',
+	REQUIRED = 'required',
+	MAY_BE_NEEDED = 'may_be_needed',
+	NOT_NEEDED = 'not_needed',
+}
+
+export function isBasketVerified(state: VerificationState): boolean {
+	return state === VerificationState.VERIFIED || state === VerificationState.NOT_NEEDED;
+}

--- a/@kiva/kv-shop/src/checkoutStatus.ts
+++ b/@kiva/kv-shop/src/checkoutStatus.ts
@@ -1,0 +1,101 @@
+import type { ApolloClient } from '@apollo/client/core';
+import { gql } from '@apollo/client/core';
+import { poll } from './util/poll';
+import getVisitorID from './util/visitorId';
+
+export interface GetCheckoutStatusOptions {
+	apollo: ApolloClient<any>,
+	transactionSagaId: string,
+}
+
+export interface CheckoutStatusQueryResult {
+	data: {
+		checkoutStatus: any
+	} | null,
+	errors?: any,
+}
+
+export async function getCheckoutStatus(
+	{ apollo, transactionSagaId }: GetCheckoutStatusOptions,
+): Promise<CheckoutStatusQueryResult> {
+	return apollo.query({
+		query: gql`
+			query checkoutStatus($transactionId: String!, $visitorId: String) {
+				checkoutStatus(transactionId: $transactionId, visitorId: $visitorId) {
+					basketId
+					errorCode
+					errorMessage
+					receipt {
+						checkoutId
+					}
+					requestedAt
+					status
+					transactionId
+					updatedAt
+				}
+			}
+		`,
+		variables: {
+			transactionId: transactionSagaId,
+			visitorId: getVisitorID(),
+		},
+	});
+}
+
+export interface PollForCheckoutStatusOptions extends GetCheckoutStatusOptions {
+	interval?: number,
+	timeout?: number,
+}
+
+/**
+ * Poll the checkoutStatus endpoint until the checkout is complete
+ * Note: We only operate on the COMPLETED or results with errors
+ *
+ * Possible status values:
+ * - BASKET_MANIFEST
+ * - BASKET_VALID
+ * - CHECKOUT_FAILED
+ * - CHECKOUT_RECORDED
+ * - CHECKOUT_ROLLED_BACK
+ * - COMPLETED
+ * - CREDIT_ADDED
+ * - DEPOSIT_RECORDED
+ * - FAILED
+ * - MANIFEST_FAILED
+ * - RECORD_CHECKOUT_FAILED
+ * - REQUEST_RECEIVED
+ * - RESERVATIONS_COMPLETED
+ * - STARTED
+ * - TRANSIENT_PAYMENT_METHOD_CHARGED
+ *
+ * @param apollo Apollo Client instance
+ * @param transactionId
+ * @param interval How often to poll
+ * @param timeout How long to allow polling to continue
+ */
+export async function pollForFinishedCheckout({
+	apollo,
+	transactionSagaId,
+	interval = 1000,
+	timeout = 60000,
+}: PollForCheckoutStatusOptions) {
+	return poll<CheckoutStatusQueryResult>(
+		// function to poll
+		() => getCheckoutStatus({
+			apollo,
+			transactionSagaId,
+		}),
+		// function to check for completed status
+		(result: CheckoutStatusQueryResult) => {
+			// extract fields to check for a completed status or errors
+			const { status, errorCode, errorMessage } = result?.data?.checkoutStatus;
+			// Check for completed status, or errors and return if present
+			if (status === 'COMPLETED' || errorCode || errorMessage) {
+				return true;
+			}
+			return false;
+		},
+		interval,
+		timeout,
+	);
+}

--- a/@kiva/kv-shop/src/components/KvPaymentSelect.vue
+++ b/@kiva/kv-shop/src/components/KvPaymentSelect.vue
@@ -41,6 +41,13 @@ export default defineComponent({
 			required: true,
 		},
 		/**
+		 * Braintree Drop In instance name.
+		 */
+		dropInName: {
+			type: String,
+			default: 'default',
+		},
+		/**
 		 * Paypal flow options.
 		 * Must be 'checkout' or 'vault'
 		* */
@@ -92,7 +99,7 @@ export default defineComponent({
 			paymentMethodRequestable,
 			requestPaymentMethod,
 			updateAmount,
-		} = useBraintreeDropIn();
+		} = useBraintreeDropIn(props.dropInName);
 
 		const errorToast = ref();
 		const showError = (message: string) => {

--- a/@kiva/kv-shop/src/index.ts
+++ b/@kiva/kv-shop/src/index.ts
@@ -1,7 +1,13 @@
 export * from './basket';
+export * from './basketCredits';
 export * from './basketItems';
+export * from './basketTotals';
+export * from './basketVerification';
+export * from './checkoutStatus';
 export * from './oneTimeCheckout';
 export * from './shopError';
+export * from './shopQueries';
 export * from './subscriptionCheckout';
 export { default as useBraintreeDropIn } from './useBraintreeDropIn';
 export * from './useBraintreeDropIn';
+export * from './validatePreCheckout';

--- a/@kiva/kv-shop/src/oneTimeCheckout.ts
+++ b/@kiva/kv-shop/src/oneTimeCheckout.ts
@@ -1,52 +1,172 @@
+import type { ApolloClient } from '@apollo/client/core';
+import type { Dropin } from 'braintree-web-drop-in';
 import { gql } from '@apollo/client/core';
+import numeral from 'numeral';
+import { pollForFinishedCheckout } from './checkoutStatus';
+import { parseShopError } from './shopError';
+import { callShopMutation, callShopQuery } from './shopQueries';
+import { validatePreCheckout } from './validatePreCheckout';
+import getVisitorID from './util/visitorId';
 
-// TODO: get (and maybe set) basket and visitor cookies
-
-export interface OneTimeCheckoutOptions {
-	apollo: any,
-	basketId: string,
-	visitorId: string|null|undefined,
+interface CreditAmountNeededData {
+	shop: {
+		id: string,
+		basket: {
+			id: string,
+			totals: {
+				creditAmountNeeded: string,
+			} | null,
+		} | null,
+	} | null,
 }
 
-export async function executeOneTimeCheckout({ apollo }: OneTimeCheckoutOptions) {
-	// check that basket is ready
-
-	// check that bt transactions are enabled
-
-	// do pre-checkout validation
-	// handle errors
-
-	// if credit required
-	// request payment method
-
-	// initiate async checkout (choose mutation based on credit required or not)
-	// wait on checkout to complete (separate method for this)
-	// handle errors
-
-	// redirect to thanks or just resolve?
-}
-
-export interface WaitOnTransactionOptions {
-	apollo: any
-	transactionId: string
-}
-
-export async function waitOnTransaction({ apollo, transactionId }: WaitOnTransactionOptions) {
-	// TODO: get visitor ID
-	// poll transaction status and resolve when complete
-	const result = await apollo.query({
+async function creditAmountNeeded(apollo: ApolloClient<any>): Promise<string|null> {
+	const data = await callShopQuery<CreditAmountNeededData>(apollo, {
 		query: gql`
-			query checkoutStatus($transactionId: String!, $visitorId: string) {
-				checkoutStatus(transactionId: $transactionId, visitorId: $visitorId) {
-					errorCode
-					errorMessage
-					status
-					transactionId
+			query creditAmountNeeded($basketId: String) {
+				shop (basketId: $basketId) {
+					id
+					basket {
+						id
+						totals {
+							creditAmountNeeded
+						}
+					}
 				}
 			}
 		`,
+	}, 0);
+	return data?.shop?.basket?.totals?.creditAmountNeeded;
+}
+
+const creditCheckoutMutation = gql`
+	mutation creditCheckout(
+		$basketId: String,
+		$visitorId: String
+	) {
+		shop (basketId: $basketId) {
+			id
+			transactionId: checkoutAsync (visitorId: $visitorId)
+		}
+	}
+`;
+
+const depositCheckoutMutation = gql`
+	mutation depositCheckout(
+		$basketId: String,
+		$amount: Money!,
+		$nonce: String!,
+		$savePaymentMethod: Boolean,
+		$deviceData: String,
+		$visitorId: String
+	) {
+		shop (basketId: $basketId) {
+			id
+			transactionId: doNoncePaymentDepositAndCheckoutAsync(
+				amount: $amount,
+				nonce: $nonce,
+				savePaymentMethod: $savePaymentMethod,
+				deviceData: $deviceData,
+				visitorId: $visitorId
+			)
+		}
+	}
+`;
+
+interface CheckoutData {
+	shop: {
+		id: string,
+		transactionId: string,
+	} | null,
+}
+
+function creditCheckout(apollo: ApolloClient<any>) {
+	return callShopMutation<CheckoutData>(apollo, {
+		mutation: creditCheckoutMutation,
 		variables: {
-			transactionId,
+			visitorId: getVisitorID(),
 		},
+	}, 0);
+}
+
+interface DepositCheckoutOptions {
+	apollo: ApolloClient<any>,
+	braintree: Dropin,
+	amount: string,
+}
+
+async function depositCheckout({
+	apollo,
+	braintree,
+	amount,
+}: DepositCheckoutOptions) {
+	// TODO: handle thrown braintree errors
+	const { nonce, deviceData } = await braintree.requestPaymentMethod();
+	// TODO: need to also track paymentType from above
+	return callShopMutation<CheckoutData>(apollo, {
+		mutation: depositCheckoutMutation,
+		variables: {
+			nonce,
+			amount,
+			savePaymentMethod: false, // save payment methods handled by braintree drop in UI
+			deviceData,
+			visitorId: getVisitorID(),
+		},
+	}, 0);
+}
+
+export interface OneTimeCheckoutOptions {
+	apollo: ApolloClient<any>,
+	braintree: Dropin,
+	emailAddress?: string,
+	emailOptIn?: boolean,
+}
+
+export async function executeOneTimeCheckout({
+	apollo,
+	braintree,
+	emailAddress,
+	emailOptIn,
+}: OneTimeCheckoutOptions) {
+	// check that basket is ready (check form validation?)
+
+	// do pre-checkout validation
+	// TODO: promo guest checkout validation
+	await validatePreCheckout({
+		apollo,
+		emailAddress,
+		emailOptIn,
 	});
+	// TODO: tracking for validation errors?
+
+	const creditNeeded = await creditAmountNeeded(apollo);
+	const creditRequired = numeral(creditNeeded).value() > 0;
+
+	// initiate async checkout
+	const data = creditRequired ? await depositCheckout({
+		apollo,
+		braintree,
+		amount: creditNeeded,
+	}) : await creditCheckout(apollo);
+	const transactionId = data?.shop?.transactionId;
+
+	// TODO: so much tracking
+
+	// wait on checkout to complete
+	const result = await pollForFinishedCheckout({
+		apollo,
+		transactionSagaId: transactionId,
+		timeout: 300000, // five minutes
+	});
+
+	// handle errors
+	if (result.errors?.length) {
+		// TODO: tracking?
+		throw parseShopError(result.errors[0]);
+	}
+
+	// TODO: redirect needs to handle challenge completion parameters
+
+	// redirect to thanks page
+	window.location.href = `/checkout/post-purchase?kiva_transaction_id=${transactionId}`;
 }

--- a/@kiva/kv-shop/src/shopError.ts
+++ b/@kiva/kv-shop/src/shopError.ts
@@ -8,6 +8,8 @@ export class ShopError extends Error {
 
 	original?: object;
 
+	errors?: Array<ShopError>;
+
 	constructor({ code, original }: ShopErrorOptions, ...params) {
 		super(...params);
 
@@ -20,9 +22,17 @@ export class ShopError extends Error {
 		this.code = code;
 		this.original = original;
 	}
+
+	aggregateErrors(errors: Array<ShopError>) {
+		this.errors = errors;
+	}
 }
 
 export function parseShopError(error: any) {
+	if (error instanceof ShopError) {
+		return error;
+	}
+
 	const errorCode = error?.code ?? error?.extensions?.code ?? error?.name ?? '';
 	const errorMessage = typeof error === 'string' ? error : error?.message ?? '';
 

--- a/@kiva/kv-shop/src/shopQueries.ts
+++ b/@kiva/kv-shop/src/shopQueries.ts
@@ -1,0 +1,162 @@
+import type {
+	ApolloClient,
+	ApolloError,
+	DocumentNode,
+	MutationOptions,
+	QueryOptions,
+	WatchQueryOptions,
+} from '@apollo/client/core';
+import { getBasketID, hasBasketExpired, createBasket } from './basket';
+import { parseShopError } from './shopError';
+
+const watchQueries = new Set<DocumentNode>();
+
+/**
+ * Call a shop mutation with a basketId, creating a new basket if necessary.
+ */
+export async function callShopMutation<TData>(
+	apollo: ApolloClient<any>,
+	options: MutationOptions<TData, any>,
+	maxretries = 2,
+) {
+	try {
+		const result = await apollo.mutate({
+			...options,
+			variables: {
+				...options.variables,
+				basketId: getBasketID(),
+			},
+			refetchQueries: options.awaitRefetchQueries ? Array.from(watchQueries) : [],
+		});
+		if (result?.errors?.length) {
+			// Retry recoverable basket expired errors
+			const basketErrors = result?.errors.filter((err) => hasBasketExpired(err));
+			if (basketErrors.length) {
+				// Create a new basket and retry if retries remain
+				if (maxretries > 0) {
+					await createBasket(apollo);
+					return callShopMutation(apollo, options, maxretries - 1);
+				}
+				// Fail on basket expired errors if no retries remain
+				throw basketErrors[0];
+			}
+
+			// Fail on non-recoverable errors
+			if (result?.errors?.length) {
+				throw result.errors[0];
+			}
+		}
+		// Return successful result data
+		return result?.data;
+	} catch (e) {
+		// Parse and throw on non-recoverable errors
+		throw parseShopError(e);
+	}
+}
+
+/**
+ * Call a shop query with a basketId, creating a new basket if necessary.
+ */
+export async function callShopQuery<TData>(
+	apollo: ApolloClient<any>,
+	options: QueryOptions<any, TData>,
+	maxretries = 2,
+) {
+	try {
+		const result = await apollo.query({
+			...options,
+			variables: {
+				...options.variables,
+				basketId: getBasketID(),
+			},
+		});
+		if (result?.errors?.length) {
+			// Retry recoverable basket expired errors
+			const basketErrors = result?.errors.filter((err) => hasBasketExpired(err));
+			if (basketErrors.length) {
+				// Create a new basket and retry if retries remain
+				if (maxretries > 0) {
+					await createBasket(apollo);
+					return callShopQuery(apollo, options, maxretries - 1);
+				}
+				// Fail on basket expired errors if no retries remain
+				throw basketErrors[0];
+			}
+
+			// Fail on non-recoverable errors
+			if (result?.errors?.length) {
+				throw result.errors[0];
+			}
+		}
+		// Return successful result data
+		return result?.data;
+	} catch (e) {
+		// Parse and throw on non-recoverable errors
+		throw parseShopError(e);
+	}
+}
+
+/**
+ * Watch a shop query with a basketId, creating a new basket if necessary.
+ */
+export function watchShopQuery<TData>(
+	apollo: ApolloClient<any>,
+	options: WatchQueryOptions<any, TData>,
+	maxretries = 2,
+) {
+	let retries = 0;
+	watchQueries.add(options.query);
+	const observable = apollo.watchQuery({
+		...options,
+		variables: {
+			...options.variables,
+			basketId: getBasketID(),
+		},
+	});
+
+	const oldSubscribe = observable.subscribe.bind(observable);
+	observable.subscribe = (...args) => {
+		let nextFn;
+		let errorFn;
+		let completeFn;
+		if (typeof args[0] === 'function') {
+			[nextFn, errorFn, completeFn] = args;
+		} else {
+			nextFn = args[0]?.next;
+			errorFn = args[0]?.error;
+			completeFn = args[0]?.complete;
+		}
+
+		const newErrorFn = (err: ApolloError) => {
+			// Retry recoverable basket expired errors
+			const basketErrors = err?.graphQLErrors?.filter((e) => hasBasketExpired(e));
+			if (basketErrors.length) {
+				// Create a new basket and retry if retries remain
+				if (retries < maxretries) {
+					createBasket(apollo).then(() => {
+						retries += 1;
+						observable.refetch({
+							...observable.variables,
+							basketId: getBasketID(),
+						});
+					});
+				} else {
+					// Fail on basket expired errors if no retries remain
+					errorFn(parseShopError(basketErrors[0]));
+				}
+			} else {
+				// Fail on non-recoverable errors
+				if (err?.graphQLErrors?.length) {
+					errorFn(parseShopError(err.graphQLErrors[0]));
+				}
+				if (err?.networkError) {
+					errorFn(parseShopError(err.networkError));
+				}
+			}
+		};
+
+		return oldSubscribe(nextFn, newErrorFn, completeFn);
+	};
+
+	return observable;
+}

--- a/@kiva/kv-shop/src/tests/basket.spec.ts
+++ b/@kiva/kv-shop/src/tests/basket.spec.ts
@@ -1,13 +1,6 @@
-import { getCookieValue, setCookieValue, hasBasketExpired } from '../basket';
+import { hasBasketExpired } from '../basket';
 
 describe('basket.ts', () => {
-	it('encoded token', () => {
-		setCookieValue('encoded', 'tests==', 'Max-Age=5;');
-		expect(document.cookie).toEqual('encoded=tests%3D%3D');
-		const cookieValue = getCookieValue('encoded');
-		expect(cookieValue).toEqual('tests==');
-	});
-
 	describe('hasBasketExpired', () => {
 		// helper function to test all three error formats
 		const testHasBasketExpiredWithErrorCode = (code, expected) => {

--- a/@kiva/kv-shop/src/tests/basketCredits.spec.ts
+++ b/@kiva/kv-shop/src/tests/basketCredits.spec.ts
@@ -1,0 +1,103 @@
+import { applyKivaCredit, removeKivaCredit } from '../basketCredits';
+
+describe('basketCredits', () => {
+	describe('applyKivaCredit', () => {
+		it('should return true if the mutation returns true', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: {
+							id: '123',
+							addCreditByType: true,
+						},
+					},
+				}),
+			};
+
+			const result = await applyKivaCredit(apollo as any);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if the mutation returns false', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: {
+							id: '123',
+							addCreditByType: false,
+						},
+					},
+				}),
+			};
+
+			const result = await applyKivaCredit(apollo as any);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if the mutation returns null', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: null,
+					},
+				}),
+			};
+
+			const result = await applyKivaCredit(apollo as any);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('removeKivaCredit', () => {
+		it('should return true if the mutation returns true', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: {
+							id: '123',
+							removeCreditByType: true,
+						},
+					},
+				}),
+			};
+
+			const result = await removeKivaCredit(apollo as any);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if the mutation returns false', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: {
+							id: '123',
+							removeCreditByType: false,
+						},
+					},
+				}),
+			};
+
+			const result = await removeKivaCredit(apollo as any);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if the mutation returns null', async () => {
+			const apollo = {
+				mutate: jest.fn().mockResolvedValue({
+					data: {
+						shop: null,
+					},
+				}),
+			};
+
+			const result = await removeKivaCredit(apollo as any);
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/@kiva/kv-shop/src/tests/basketItems.spec.ts
+++ b/@kiva/kv-shop/src/tests/basketItems.spec.ts
@@ -13,7 +13,10 @@ describe('basketItem.ts', () => {
 		const apollo = new MockApolloClient({ data: { shop: { updateDonation: { id: 123 } } } });
 		const donation = await setTipDonation({ amount: 25, apollo });
 		expect(apollo.mutate).toHaveBeenCalledWith({
-			mutation: expect.anything(), variables: { basketId: '', price: '25.00' },
+			mutation: expect.anything(),
+			awaitRefetchQueries: true,
+			refetchQueries: expect.anything(),
+			variables: { basketId: '', price: '25.00' },
 		});
 		expect(donation).toEqual({ id: 123 });
 	});

--- a/@kiva/kv-shop/src/tests/basketVerification.spec.ts
+++ b/@kiva/kv-shop/src/tests/basketVerification.spec.ts
@@ -1,0 +1,25 @@
+import { isBasketVerified, VerificationState } from '../basketVerification';
+
+describe('basketVerification', () => {
+	describe('isBasketVerified', () => {
+		it('should return true if the state is VERIFIED', () => {
+			expect(isBasketVerified(VerificationState.VERIFIED)).toBe(true);
+		});
+
+		it('should return true if the state is NOT_NEEDED', () => {
+			expect(isBasketVerified(VerificationState.NOT_NEEDED)).toBe(true);
+		});
+
+		it('should return false if the state is PENDING', () => {
+			expect(isBasketVerified(VerificationState.PENDING)).toBe(false);
+		});
+
+		it('should return false if the state is REQUIRED', () => {
+			expect(isBasketVerified(VerificationState.REQUIRED)).toBe(false);
+		});
+
+		it('should return false if the state is MAY_BE_NEEDED', () => {
+			expect(isBasketVerified(VerificationState.MAY_BE_NEEDED)).toBe(false);
+		});
+	});
+});

--- a/@kiva/kv-shop/src/tests/checkoutStatus.spec.ts
+++ b/@kiva/kv-shop/src/tests/checkoutStatus.spec.ts
@@ -1,0 +1,95 @@
+import { getCheckoutStatus, pollForFinishedCheckout } from '../checkoutStatus';
+
+describe('checkoutStatus', () => {
+	describe('getCheckoutStatus', () => {
+		it('should return the checkout status', async () => {
+			const apollo = {
+				query: jest.fn().mockResolvedValue({
+					data: {
+						checkoutStatus: {
+							basketId: '123',
+							errorCode: '123',
+							errorMessage: '123',
+							receipt: {
+								checkoutId: '123',
+							},
+							requestedAt: '123',
+							status: '123',
+							transactionId: '123',
+							updatedAt: '123',
+						},
+					},
+				}),
+			};
+
+			const result = await getCheckoutStatus({
+				apollo: apollo as any,
+				transactionSagaId: '123',
+				visitorId: '123',
+			});
+
+			expect(result).toEqual({
+				data: {
+					checkoutStatus: {
+						basketId: '123',
+						errorCode: '123',
+						errorMessage: '123',
+						receipt: {
+							checkoutId: '123',
+						},
+						requestedAt: '123',
+						status: '123',
+						transactionId: '123',
+						updatedAt: '123',
+					},
+				},
+			});
+		});
+	});
+
+	describe('pollForFinishedCheckout', () => {
+		it('should return the checkout status', async () => {
+			const apollo = {
+				query: jest.fn().mockResolvedValue({
+					data: {
+						checkoutStatus: {
+							basketId: '123',
+							errorCode: '123',
+							errorMessage: '123',
+							receipt: {
+								checkoutId: '123',
+							},
+							requestedAt: '123',
+							status: '123',
+							transactionId: '123',
+							updatedAt: '123',
+						},
+					},
+				}),
+			};
+
+			const result = await pollForFinishedCheckout({
+				apollo: apollo as any,
+				transactionSagaId: '123',
+				visitorId: '123',
+			});
+
+			expect(result).toEqual({
+				data: {
+					checkoutStatus: {
+						basketId: '123',
+						errorCode: '123',
+						errorMessage: '123',
+						receipt: {
+							checkoutId: '123',
+						},
+						requestedAt: '123',
+						status: '123',
+						transactionId: '123',
+						updatedAt: '123',
+					},
+				},
+			});
+		});
+	});
+});

--- a/@kiva/kv-shop/src/tests/checkoutStatus.spec.ts
+++ b/@kiva/kv-shop/src/tests/checkoutStatus.spec.ts
@@ -25,7 +25,6 @@ describe('checkoutStatus', () => {
 			const result = await getCheckoutStatus({
 				apollo: apollo as any,
 				transactionSagaId: '123',
-				visitorId: '123',
 			});
 
 			expect(result).toEqual({
@@ -71,7 +70,6 @@ describe('checkoutStatus', () => {
 			const result = await pollForFinishedCheckout({
 				apollo: apollo as any,
 				transactionSagaId: '123',
-				visitorId: '123',
 			});
 
 			expect(result).toEqual({

--- a/@kiva/kv-shop/src/tests/util/cookie.spec.ts
+++ b/@kiva/kv-shop/src/tests/util/cookie.spec.ts
@@ -1,0 +1,10 @@
+import { getCookieValue, setCookieValue } from '../../util/cookie';
+
+describe('cookie.ts', () => {
+	it('encoded token', () => {
+		setCookieValue('encoded', 'tests==', 'Max-Age=5;');
+		expect(document.cookie).toEqual('encoded=tests%3D%3D');
+		const cookieValue = getCookieValue('encoded');
+		expect(cookieValue).toEqual('tests==');
+	});
+});

--- a/@kiva/kv-shop/src/tests/util/poll.spec.ts
+++ b/@kiva/kv-shop/src/tests/util/poll.spec.ts
@@ -1,0 +1,41 @@
+import { wait, poll } from '../../util/poll';
+
+describe('poll.ts', () => {
+	it('should wait', async () => {
+		const startTime = Date.now();
+		await wait(100);
+		const endTime = Date.now();
+		expect(endTime - startTime).toBeGreaterThanOrEqual(100);
+	});
+
+	it('should poll', async () => {
+		let count = 0;
+		const result = await poll(
+			async () => {
+				count += 1;
+				return count;
+			},
+			(arg) => arg >= 5,
+			10,
+			100,
+		);
+		expect(result).toEqual(5);
+		expect(count).toEqual(5);
+	});
+
+	it('should throw if timeout', async () => {
+		let count = 0;
+		await expect(
+			poll(
+				async () => {
+					count += 1;
+					return count;
+				},
+				(arg) => arg >= 10,
+				10,
+				50,
+			),
+		).rejects.toThrow('Polling timed out');
+		expect(count).toEqual(6);
+	});
+});

--- a/@kiva/kv-shop/src/tests/util/poll.spec.ts
+++ b/@kiva/kv-shop/src/tests/util/poll.spec.ts
@@ -36,6 +36,5 @@ describe('poll.ts', () => {
 				50,
 			),
 		).rejects.toThrow('Polling timed out');
-		expect(count).toEqual(6);
 	});
 });

--- a/@kiva/kv-shop/src/useBraintreeDropIn.ts
+++ b/@kiva/kv-shop/src/useBraintreeDropIn.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { gql } from '@apollo/client/core';
 import numeral from 'numeral';
+import type { Ref } from 'vue-demi';
 import { ref } from 'vue-demi';
 import type { ApplePayPaymentRequest } from 'braintree-web';
-import type { Dropin } from 'braintree-web-drop-in';
+import type { Dropin, PaymentMethodPayload } from 'braintree-web-drop-in';
 import { ShopError, parseShopError } from './shopError';
 
 export type PaymentType = 'card' | 'paypal' | 'paypalCredit' | 'venmo' | 'applePay' | 'googlePay';
@@ -44,7 +45,14 @@ export interface DropInInitOptions {
 	paypalFlow?: PayPalFlowType,
 }
 
-export default function useBraintreeDropIn() {
+export interface DropInWrapper {
+	initDropIn: (options: DropInInitOptions) => Promise<Dropin>,
+	paymentMethodRequestable: Ref<boolean>,
+	requestPaymentMethod: () => Promise<PaymentMethodPayload | void>,
+	updateAmount: (amount: string|number) => void,
+}
+
+function initBraintreeDropin(): DropInWrapper {
 	let instance: Dropin;
 	let formattedAmount = '';
 	const paymentMethodRequestable = ref(false);
@@ -206,4 +214,13 @@ export default function useBraintreeDropIn() {
 		requestPaymentMethod,
 		updateAmount,
 	};
+}
+
+const instances = {};
+export default function useBraintreeDropIn(key = 'default'): DropInWrapper {
+	if (!instances[key]) {
+		instances[key] = initBraintreeDropin();
+	}
+
+	return instances[key];
 }

--- a/@kiva/kv-shop/src/util/cookie.ts
+++ b/@kiva/kv-shop/src/util/cookie.ts
@@ -5,5 +5,7 @@ export const getCookieValue = (name: string) => {
 	}
 };
 export const setCookieValue = (name: string, value: string, options = '') => {
-	document.cookie = `${name}=${encodeURIComponent(value)};${options}`;
+	if (typeof document !== undefined) {
+		document.cookie = `${name}=${encodeURIComponent(value)};${options}`;
+	}
 };

--- a/@kiva/kv-shop/src/util/cookie.ts
+++ b/@kiva/kv-shop/src/util/cookie.ts
@@ -1,0 +1,9 @@
+export const getCookieValue = (name: string) => {
+	if (typeof document !== undefined) {
+		// From: https://stackoverflow.com/a/25490531
+		return decodeURIComponent(document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || '');
+	}
+};
+export const setCookieValue = (name: string, value: string, options = '') => {
+	document.cookie = `${name}=${encodeURIComponent(value)};${options}`;
+};

--- a/@kiva/kv-shop/src/util/poll.ts
+++ b/@kiva/kv-shop/src/util/poll.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-await-in-loop */
+
+/**
+ * Wait for a specified number of milliseconds
+ *
+ * @param ms - number of milliseconds to wait
+ * @returns - a promise that resolves after the specified number of milliseconds
+ */
+export function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll the fn callback until the fnCondition callback returns true
+ *
+ * @param fn - function to poll
+ * @param fnCondition - function to check for completed status, called with the result of fn. Should return true when polling should stop.
+ * @param interval - how often to poll (ms)
+ * @param timeout - how long to allow polling to continue (ms)
+ * @returns - the final result of fn
+ */
+export async function poll<TResult>(
+	fn: () => Promise<TResult>,
+	fnCondition: (arg: TResult) => boolean,
+	interval: number,
+	timeout: number,
+) {
+	// establish endtime based on timeout
+	const endTime = Date.now() + timeout;
+
+	// start polling
+	let result = await fn();
+
+	while (!fnCondition(result)) {
+		// check for timeout
+		if (Date.now() > endTime) {
+			throw new Error('Polling timed out');
+		}
+
+		// wait an interval before checking again
+		await wait(interval);
+		result = await fn();
+	}
+
+	// return the final result
+	return result;
+}

--- a/@kiva/kv-shop/src/util/visitorId.ts
+++ b/@kiva/kv-shop/src/util/visitorId.ts
@@ -1,0 +1,5 @@
+import { getCookieValue } from './cookie';
+
+export default function getVisitorID() {
+	return getCookieValue('uiv');
+}

--- a/@kiva/kv-shop/src/validatePreCheckout.ts
+++ b/@kiva/kv-shop/src/validatePreCheckout.ts
@@ -1,0 +1,56 @@
+import type { ApolloClient } from '@apollo/client/core';
+import { gql } from '@apollo/client/core';
+import { callShopMutation } from './shopQueries';
+import getVisitorID from './util/visitorId';
+import { ShopError, parseShopError } from './shopError';
+
+export const validatePreCheckoutMutation = gql`
+	mutation validatePreCheckout($basketId: String, $email: String, $visitorId: String, $emailOptIn: Boolean) {
+	shop (basketId: $basketId) {
+		id
+		validatePreCheckout (email: $email, visitorId: $visitorId, emailOptIn: $emailOptIn) {
+			error
+			success
+			value
+		}
+	}
+}`;
+
+export interface ValidatePreCheckoutData {
+	shop: {
+		id: string,
+		validatePreCheckout: Array<{
+			error: string,
+			success: boolean,
+			value: string,
+		}>,
+	} | null,
+}
+
+export interface ValidatePreCheckoutOptions {
+	apollo: ApolloClient<any>,
+	emailAddress?: string,
+	emailOptIn?: boolean,
+}
+
+export async function validatePreCheckout({
+	apollo,
+	emailAddress,
+	emailOptIn,
+}: ValidatePreCheckoutOptions) {
+	const data = await callShopMutation<ValidatePreCheckoutData>(apollo, {
+		mutation: validatePreCheckoutMutation,
+		variables: {
+			visitorId: getVisitorID(),
+			email: emailAddress,
+			emailOptIn,
+		},
+	}, 0);
+	const results = data?.shop?.validatePreCheckout;
+	const errors = results.filter(({ success }) => !success).map((result) => parseShopError(result));
+	if (errors.length) {
+		const aggregate = new ShopError({ code: 'shop.failedCheckoutValidation' });
+		aggregate.aggregateErrors(errors);
+		throw aggregate;
+	}
+}


### PR DESCRIPTION
One-time async checkout, with some basket state and validation functions. Still needs to actually be tried out with an app, more tests, and a solution for tracking.

Despite the roughness, the basic flow should be all set here. Please let me know if anything looks off with the flow as it is now or if there are any missing pieces not already called out with a TODO!