### PR TITLE
feat(oneTimeCheckout): redirect in promise so loading state remains active

### DIFF
--- a/@kiva/kv-shop/.eslintrc.cjs
+++ b/@kiva/kv-shop/.eslintrc.cjs
@@ -25,6 +25,8 @@ module.exports = {
 		}],
 		// allow imports without file extensions
 		'import/extensions': 'off',
+		// allow non-default exports in files with single export
+		'import/prefer-default-export': 'off',
 		// allow `any` type
 		'@typescript-eslint/no-explicit-any': ['off'],
 	},

--- a/@kiva/kv-shop/src/checkoutStatus.ts
+++ b/@kiva/kv-shop/src/checkoutStatus.ts
@@ -1,7 +1,7 @@
 import type { ApolloClient } from '@apollo/client/core';
 import { gql } from '@apollo/client/core';
 import { poll } from './util/poll';
-import getVisitorID from './util/visitorId';
+import { getVisitorID } from './util/visitorId';
 
 export interface GetCheckoutStatusOptions {
 	apollo: ApolloClient<any>,

--- a/@kiva/kv-shop/src/oneTimeCheckout.ts
+++ b/@kiva/kv-shop/src/oneTimeCheckout.ts
@@ -8,7 +8,8 @@ import { ShopError, parseShopError } from './shopError';
 import { callShopMutation, callShopQuery } from './shopQueries';
 import { validatePreCheckout } from './validatePreCheckout';
 import { wait } from './util/poll';
-import getVisitorID from './util/visitorId';
+import { getVisitorID } from './util/visitorId';
+import { redirectTo } from './util/redirect';
 import { getCheckoutTrackingData } from './receipt';
 
 interface CreditAmountNeededData {
@@ -224,5 +225,5 @@ export async function executeOneTimeCheckout({
 	// TODO: redirect needs to handle challenge completion parameters
 
 	// redirect to thanks page
-	window.location.href = `/checkout/post-purchase?kiva_transaction_id=${checkoutId}`;
+	await redirectTo(`/checkout/post-purchase?kiva_transaction_id=${checkoutId}`);
 }

--- a/@kiva/kv-shop/src/receipt.ts
+++ b/@kiva/kv-shop/src/receipt.ts
@@ -2,7 +2,7 @@
 import type { ApolloClient, ApolloQueryResult } from '@apollo/client/core';
 import type { TransactionData } from '@kiva/kv-analytics';
 import { gql } from '@apollo/client/core';
-import getVisitorID from './util/visitorId';
+import { getVisitorID } from './util/visitorId';
 
 export async function getFTDStatus(apollo: ApolloClient<any>) {
 	const result = await apollo.query({

--- a/@kiva/kv-shop/src/util/redirect.ts
+++ b/@kiva/kv-shop/src/util/redirect.ts
@@ -1,0 +1,5 @@
+export function redirectTo(href: string) {
+	return new Promise(() => {
+		window.location.href = href;
+	});
+}

--- a/@kiva/kv-shop/src/util/visitorId.ts
+++ b/@kiva/kv-shop/src/util/visitorId.ts
@@ -1,5 +1,5 @@
 import { getCookieValue } from './cookie';
 
-export default function getVisitorID() {
+export function getVisitorID() {
 	return getCookieValue('uiv');
 }

--- a/@kiva/kv-shop/src/validatePreCheckout.ts
+++ b/@kiva/kv-shop/src/validatePreCheckout.ts
@@ -1,7 +1,7 @@
 import type { ApolloClient } from '@apollo/client/core';
 import { gql } from '@apollo/client/core';
 import { callShopMutation } from './shopQueries';
-import getVisitorID from './util/visitorId';
+import { getVisitorID } from './util/visitorId';
 import { ShopError, parseShopError } from './shopError';
 
 export const validatePreCheckoutMutation = gql`


### PR DESCRIPTION
Helps avoid an awkward experience of the checkout buttons appearing to complete moments before a new page loads.