### PR TITLE
feat: add basic comments container for future comment work

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvCommentsContainer.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvCommentsContainer.spec.js
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/vue';
+import Container from '../../../../vue/KvCommentsContainer.vue';
+
+const renderContainer = (props = {}) => {
+	return render(Container, { props });
+};
+
+describe('KvCommentsContainer', () => {
+	it('should render without activity ID', async () => {
+		const component = renderContainer();
+		component.getByText('Activity ID missing');
+	});
+
+	it('should render with activity ID', async () => {
+		const component = renderContainer({ activityId: 'asd' });
+		component.getByText('Comment functionality coming soon!');
+	});
+});

--- a/@kiva/kv-components/vue/KvCommentsContainer.vue
+++ b/@kiva/kv-components/vue/KvCommentsContainer.vue
@@ -1,0 +1,28 @@
+<template>
+	<div>
+		<h3>Comment Container Placeholder</h3>
+		<p v-if="activityId">
+			Comment functionality coming soon!
+		</p>
+		<p
+			v-else
+			class="tw-text-desert-rose"
+		>
+			Activity ID missing
+		</p>
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		/**
+		 * The activity ID for the comments
+		 */
+		activityId: {
+			type: String,
+			default: '',
+		},
+	},
+};
+</script>

--- a/@kiva/kv-components/vue/stories/KvCommentsContainer.stories.js
+++ b/@kiva/kv-components/vue/stories/KvCommentsContainer.stories.js
@@ -1,0 +1,23 @@
+import KvCommentsContainer from '../KvCommentsContainer.vue';
+
+export default {
+	title: 'KvCommentsContainer',
+	component: KvCommentsContainer,
+};
+
+const story = (args) => {
+	const template = (templateArgs, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { KvCommentsContainer },
+		setup() { return { args: templateArgs }; },
+		template: `
+			<KvCommentsContainer v-bind="args" />
+		`,
+	});
+	template.args = args;
+	return template;
+};
+
+export const Default = story({});
+
+export const Activity = story({ activityId: 'asd' });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/ACK-919

- Created basic comments container for the commenting work
- The comments will likely exist in both UI and CPS
- Added basic stories and unit tests

<img width="612" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/16867161/c61c8e57-3739-4810-8992-917002d98aa4">

<img width="620" alt="image" src="https://github.com/kiva/kv-ui-elements/assets/16867161/e515bbac-7504-4bad-9ffe-b84d9c4e4973">
