### PR TITLE
fix: checkoutStatus query was only called once, the apollo cache retu…

### DIFF
--- a/@kiva/kv-shop/src/checkoutStatus.ts
+++ b/@kiva/kv-shop/src/checkoutStatus.ts
@@ -39,6 +39,7 @@ export async function getCheckoutStatus(
 			transactionId: transactionSagaId,
 			visitorId: getVisitorID(),
 		},
+		fetchPolicy: 'network-only',
 	});
 }
 


### PR DESCRIPTION
…rns same response until timeout.

I was able to link this to Ui and test with some specialized steps b/c UI will not parse the dist or ts files directly:
1. Do the link setup
2. add the `--target es5` flag to the package.json build command
3. rebuild the repo
4. import methods into UI directly from each file `import { pollForFinishedCheckout } from '~/@kiva/kv-shop/dist/checkoutStatus';`