### PR TITLE
fix: adding inviter param to validatePreCheckout

### DIFF
--- a/@kiva/kv-shop/src/validatePreCheckout.ts
+++ b/@kiva/kv-shop/src/validatePreCheckout.ts
@@ -14,7 +14,7 @@ export const validatePreCheckoutMutation = gql`
 	) {
 	shop (basketId: $basketId) {
 		id
-		validatePreCheckout (email: $email, visitorId: $visitorId, emailOptIn: $emailOptIn) {
+		validatePreCheckout (email: $email, visitorId: $visitorId, emailOptIn: $emailOptIn, inviter: $inviter) {
 			error
 			success
 			value


### PR DESCRIPTION
Missing inviter param on mutation caused the following error:

`Variable \"$inviter\" is never used in operation \"validatePreCheckout\"` 