### PR TITLE
feat: add activity feed method to get or create user

### DIFF
--- a/@kiva/kv-activity-feed/src/index.ts
+++ b/@kiva/kv-activity-feed/src/index.ts
@@ -1,10 +1,21 @@
-import { connect, StreamClient, EnrichedActivity } from 'getstream';
+import {
+	connect,
+	StreamClient,
+	EnrichedActivity,
+	StreamUser,
+	DefaultGenerics,
+} from 'getstream';
 import parseError from './utils/parseError';
 
 /**
  * Type wrapper for the Stream activity type
  */
 export type Activity = EnrichedActivity|undefined;
+
+/**
+ * Type wrapper for the Stream user type
+ */
+export type User = StreamUser<DefaultGenerics>;
 
 /**
  * Abstracts the functionality for the 3rd party Stream service
@@ -25,6 +36,21 @@ export default class ActivityFeedService {
 	constructor(apiKey: string, userToken: string, appId: string) {
 		try {
 			this.client = connect(apiKey, userToken, appId);
+		} catch (error) {
+			parseError(error);
+		}
+	}
+
+	/**
+	 * Gets (or creates) the user with the provided IDs
+	 *
+	 * @param userId The ID of the user
+	 * @param publicLenderId The public lender ID of the user
+	 * @returns The user if get/create is successful, otherwise undefined
+	 */
+	async getOrCreateUser(userId: number, publicLenderId?: string): Promise<User|undefined> {
+		try {
+			return await this.client?.user(userId.toString()).getOrCreate({ publicLenderId });
 		} catch (error) {
 			parseError(error);
 		}

--- a/@kiva/kv-activity-feed/src/tests/ActivityFeedService.spec.ts
+++ b/@kiva/kv-activity-feed/src/tests/ActivityFeedService.spec.ts
@@ -5,10 +5,13 @@ import * as parseError from '../utils/parseError';
 
 const mockActivity = { id: 'asd' };
 
+const mockUserGetOrCreate = jest.fn();
+const mockUser = jest.fn(() => ({ getOrCreate: mockUserGetOrCreate }));
 const mockGetActivities = jest.fn(() => Promise.resolve({ results: [mockActivity] }));
 const mockAddComment = jest.fn();
 
 const mockClient = {
+	user: mockUser,
 	getActivities: mockGetActivities,
 	reactions: {
 		add: mockAddComment,
@@ -45,6 +48,17 @@ describe('StreamService', () => {
 			new ActivityFeedService(API_KEY, AUTH_TOKEN, APP_ID);
 
 			expect(spyParseError).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('getOrCreateUser', () => {
+		it('should call expected user methods', async () => {
+			const userId = 1;
+			const publicLenderId = '2';
+			await (new ActivityFeedService(API_KEY, AUTH_TOKEN, APP_ID)).getOrCreateUser(userId, publicLenderId);
+
+			expect(mockUser).toHaveBeenCalledWith(userId.toString());
+			expect(mockUserGetOrCreate).toHaveBeenCalledWith({ publicLenderId });
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/ACK-1023

- Add method to `ActivityFeedService` to get or create user
- This should allow us to add the `publicLenderId` to the data stored in stream based on the Kiva user ID