### PR TITLE
feat: add activity feed update user method

### DIFF
--- a/@kiva/kv-activity-feed/src/index.ts
+++ b/@kiva/kv-activity-feed/src/index.ts
@@ -57,6 +57,21 @@ export default class ActivityFeedService {
 	}
 
 	/**
+	 * Updates the user with the data
+	 *
+	 * @param userId The ID of the user
+	 * @param publicLenderId The public lender ID of the user
+	 * @returns The updated user if successful, otherwise undefined
+	 */
+	async updateUser(userId: number, publicLenderId?: string): Promise<User|undefined> {
+		try {
+			return await this.client?.user(userId.toString()).update({ publicLenderId });
+		} catch (error) {
+			parseError(error);
+		}
+	}
+
+	/**
 	 * Gets an activity based on the provided activity ID
 	 *
 	 * @param activityId The activity ID returned from Stream

--- a/@kiva/kv-activity-feed/src/tests/ActivityFeedService.spec.ts
+++ b/@kiva/kv-activity-feed/src/tests/ActivityFeedService.spec.ts
@@ -6,7 +6,11 @@ import * as parseError from '../utils/parseError';
 const mockActivity = { id: 'asd' };
 
 const mockUserGetOrCreate = jest.fn();
-const mockUser = jest.fn(() => ({ getOrCreate: mockUserGetOrCreate }));
+const mockUserUpdate = jest.fn();
+const mockUser = jest.fn(() => ({
+	getOrCreate: mockUserGetOrCreate,
+	update: mockUserUpdate,
+}));
 const mockGetActivities = jest.fn(() => Promise.resolve({ results: [mockActivity] }));
 const mockAddComment = jest.fn();
 
@@ -59,6 +63,17 @@ describe('StreamService', () => {
 
 			expect(mockUser).toHaveBeenCalledWith(userId.toString());
 			expect(mockUserGetOrCreate).toHaveBeenCalledWith({ publicLenderId });
+		});
+	});
+
+	describe('updateUser', () => {
+		it('should call user update', async () => {
+			const userId = 1;
+			const publicLenderId = '2';
+			await (new ActivityFeedService(API_KEY, AUTH_TOKEN, APP_ID)).updateUser(userId, publicLenderId);
+
+			expect(mockUser).toHaveBeenCalledWith(userId.toString());
+			expect(mockUserUpdate).toHaveBeenCalledWith({ publicLenderId });
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/ACK-1023

- Apparently `getOrCreate` doesn't update if data is provided
- We need this `updateUser` method to be able to update existing users