### PR TITLE
fix: upgrade to latest vue-demi to support vue 2.7

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -64,7 +64,7 @@
     "moment": "^2.29.4",
     "nanoid": "^3.1.23",
     "numeral": "^2.0.6",
-    "vue-demi": "^0.12.1"
+    "vue-demi": "^0.14.7"
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.0.0-rc.1",

--- a/@kiva/kv-shop/package.json
+++ b/@kiva/kv-shop/package.json
@@ -43,7 +43,7 @@
         "@types/braintree-web-drop-in": "^1.34.2",
         "braintree-web-drop-in": "^1.37.0",
         "numeral": "^2.0.6",
-        "vue-demi": "^0.14.1"
+        "vue-demi": "^0.14.7"
     },
     "peerDependencies": {
         "@vue/composition-api": "^1.0.0-rc.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3014,7 +3014,7 @@
         "moment": "^2.29.4",
         "nanoid": "^3.1.23",
         "numeral": "^2.0.6",
-        "vue-demi": "^0.12.1"
+        "vue-demi": "^0.14.7"
       },
       "devDependencies": {
         "@babel/core": "^7.14.8",
@@ -4243,7 +4243,7 @@
         "@types/braintree-web-drop-in": "^1.34.2",
         "braintree-web-drop-in": "^1.37.0",
         "numeral": "^2.0.6",
-        "vue-demi": "^0.14.1"
+        "vue-demi": "^0.14.7"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.7",
@@ -5422,31 +5422,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
-    },
-    "@kiva/kv-shop/node_modules/vue-demi": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.1.tgz",
-      "integrity": "sha512-rt+yuCtXvscYot9SQQj3WKZJVSriPNqVkpVBNEHPzSgBv7QIYzsS410VqVgvx8f9AAPgjg+XPKvmV3vOqqkJQQ==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
     },
     "@kiva/kv-shop/node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
@@ -46921,9 +46896,9 @@
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
     "node_modules/vue-demi": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
-      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
+      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -55171,7 +55146,7 @@
         "style-loader": "^2.0.0",
         "tailwindcss": "^3.0.18",
         "vue": "^2.6.14",
-        "vue-demi": "^0.12.1",
+        "vue-demi": "^0.14.7",
         "vue-loader": "^15.9.6",
         "vue-router": "^3.5.2",
         "vue-template-compiler": "^2.6.12"
@@ -56029,7 +56004,7 @@
         "tsup": "^6.7.0",
         "typescript": "^5.0.4",
         "vue": "2.6",
-        "vue-demi": "^0.14.1",
+        "vue-demi": "0.14.7",
         "vue-eslint-parser": "^9.3.0"
       },
       "dependencies": {
@@ -56878,12 +56853,6 @@
               "dev": true
             }
           }
-        },
-        "vue-demi": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.1.tgz",
-          "integrity": "sha512-rt+yuCtXvscYot9SQQj3WKZJVSriPNqVkpVBNEHPzSgBv7QIYzsS410VqVgvx8f9AAPgjg+XPKvmV3vOqqkJQQ==",
-          "requires": {}
         },
         "w3c-xmlserializer": {
           "version": "4.0.0",
@@ -84912,9 +84881,9 @@
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
     "vue-demi": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
-      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
+      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
       "requires": {}
     },
     "vue-docgen-api": {


### PR DESCRIPTION
Ran into an error trying to use `@kiva/kv-components` in a vue 2.7 project, and it turns out that's because support for vue 2.7 wasn't added until vue-demi 0.13, and kv-components is still using 0.12.