### PR TITLE
fix: change activity copy in team pick loan

### DIFF
--- a/@kiva/kv-components/tests/unit/specs/components/KvClassicLoanCard.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvClassicLoanCard.spec.js
@@ -194,7 +194,7 @@ describe('KvClassicLoanCard', () => {
 				},
 			});
 
-		const activityText = getByText('7 members lent $950.');
+		const activityText = getByText('7 lenders lent $950.');
 		const activityBtn = getByRole('button', { name: 'See all activity' });
 		expect(activityText).toBeDefined();
 		expect(activityBtn).toBeDefined();

--- a/@kiva/kv-components/vue/KvLoanActivities.vue
+++ b/@kiva/kv-components/vue/KvLoanActivities.vue
@@ -10,7 +10,7 @@
 		</div>
 		<div class="tw-flex tw-justify-center tw-mt-1 tw-text-small">
 			<span v-if="lendersNumber && amountLent">
-				{{ lendersNumber }} members lent {{ amountLent }}. &nbsp;
+				{{ lendersNumber }} lenders lent {{ amountLent }}. &nbsp;
 			</span>
 			<button
 				class="tw-text-action hover:tw-underline"


### PR DESCRIPTION
This change comes from captain's feedback. Seems like activity it's not being filtered for just team members activity.