### PR TITLE
fix: add option to deactivateRedirect to executeOnetimeCheckout method

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v11.4.0
         # Options required to the GitHub Chromatic Action
         with:
           workingDir: ./@kiva/kv-components

--- a/@kiva/kv-shop/src/oneTimeCheckout.ts
+++ b/@kiva/kv-shop/src/oneTimeCheckout.ts
@@ -174,6 +174,7 @@ export interface OneTimeCheckoutOptions {
 	emailAddress?: string,
 	emailOptIn?: boolean,
 	valetInviter?: ValetInviter,
+	deativateRedirect?: boolean,
 }
 
 export async function executeOneTimeCheckout({
@@ -182,6 +183,7 @@ export async function executeOneTimeCheckout({
 	emailAddress,
 	emailOptIn,
 	valetInviter,
+	deativateRedirect,
 }: OneTimeCheckoutOptions) {
 	// do pre-checkout validation
 	// TODO: promo guest checkout validation
@@ -230,6 +232,11 @@ export async function executeOneTimeCheckout({
 	// track success
 	const checkoutId = result.data?.checkoutStatus?.receipt?.checkoutId;
 	await trackSuccess(apollo, checkoutId, paymentType);
+
+	// if redirect is deactivated, return transaction result
+	if (deativateRedirect) {
+		return result;
+	}
 
 	// TODO: redirect needs to handle challenge completion parameters
 

--- a/@kiva/kv-shop/src/oneTimeCheckout.ts
+++ b/@kiva/kv-shop/src/oneTimeCheckout.ts
@@ -174,7 +174,7 @@ export interface OneTimeCheckoutOptions {
 	emailAddress?: string,
 	emailOptIn?: boolean,
 	valetInviter?: ValetInviter,
-	deativateRedirect?: boolean,
+	deactivateRedirect?: boolean,
 }
 
 export async function executeOneTimeCheckout({
@@ -183,7 +183,7 @@ export async function executeOneTimeCheckout({
 	emailAddress,
 	emailOptIn,
 	valetInviter,
-	deativateRedirect,
+	deactivateRedirect,
 }: OneTimeCheckoutOptions) {
 	// do pre-checkout validation
 	// TODO: promo guest checkout validation
@@ -234,7 +234,7 @@ export async function executeOneTimeCheckout({
 	await trackSuccess(apollo, checkoutId, paymentType);
 
 	// if redirect is deactivated, return transaction result
-	if (deativateRedirect) {
+	if (deactivateRedirect) {
 		return result;
 	}
 


### PR DESCRIPTION
For some in-context checkout scenarios such as impact-dashboards we do not want to redirect to our standard thanks page.