### PR TITLE
fix: loan card button secondary action and destination

### DIFF
--- a/@kiva/kv-components/vue/KvLendCta.vue
+++ b/@kiva/kv-components/vue/KvLendCta.vue
@@ -6,9 +6,9 @@
 			variant="secondary"
 			class="tw-inline-flex tw-flex-1"
 			data-testid="bp-lend-cta-checkout-button"
-			:to="!externalLinks || secondaryButtonHandler ? '/basket' : undefined"
-			:href="externalLinks || secondaryButtonHandler ? '/basket' : undefined"
-			@click.native="clickSecondaryButton"
+			:to="!externalLinks ? '/basket' : undefined"
+			:href="externalLinks ? '/basket' : undefined"
+			@click.native="clickSecondaryButton($event)"
 		>
 			{{ loanInBasketButtonText }}
 		</kv-ui-button>
@@ -407,8 +407,10 @@ export default {
 		clickDropdown() {
 			this.kvTrackFunction('Lending', 'click-Modify loan amount', 'open dialog', this.loanId, this.loanId);
 		},
-		clickSecondaryButton() {
+		clickSecondaryButton(event) {
 			if (this.secondaryButtonHandler) {
+				event.preventDefault();
+				event.stopPropagation();
 				// Custom secondary button behavior
 				this.secondaryButtonHandler();
 			} else {

--- a/@kiva/kv-components/vue/stories/KvLendCta.stories.js
+++ b/@kiva/kv-components/vue/stories/KvLendCta.stories.js
@@ -23,6 +23,8 @@ const story = (args) => {
 					:custom-loan-details="customLoanDetails"
 					:enable-huge-amount="enableHugeAmount"
 					:is-visitor="isVisitor"
+					:secondary-button-handler="secondaryButtonHandler"
+					:external-links="externalLinks"
 				/>
 			</div>
 		`,
@@ -32,6 +34,8 @@ const story = (args) => {
 };
 
 const kvTrackFunction = () => { };
+
+const secondaryButtonHandler = () => { console.log('secondary button handler'); };
 
 export const Loading = story({ isLoading: true, kvTrackFunction });
 
@@ -47,6 +51,20 @@ export const Basketed = story({
 		},
 	],
 	kvTrackFunction,
+});
+
+export const BasketedWithSecondaryAction = story({
+	isLoading: false,
+	loan: { id: 1 },
+	basketItems: [
+		{
+			__typename: 'LoanReservation',
+			id: 1,
+		},
+	],
+	externalLinks: true,
+	kvTrackFunction,
+	secondaryButtonHandler,
 });
 
 export const Funded = story({


### PR DESCRIPTION
Fixes issue with button still navigating when a secondary button handler is supplied, updated story.

Logic is: 
If secondary button handler exists, execute it. 
If secondary button handler does not exist, run handleCheckoutFunction (for tracking) and navigate 