### PR TITLE
feat: add dafEligible as a valid loan filter for flss

### DIFF
--- a/@kiva/kv-loan-filters/src/dafEligible.ts
+++ b/@kiva/kv-loan-filters/src/dafEligible.ts
@@ -1,0 +1,49 @@
+import { getBooleanValueFromQueryParam } from './queryParseUtils';
+
+export const facetsKey = 'dafEligible';
+
+export const stateKey = 'dafEligible';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({ dafEligible: null }),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(typeof loanSearchState?.dafEligible !== 'undefined' && loanSearchState.dafEligible !== null && {
+			dafEligible: { eq: loanSearchState.dafEligible },
+		}),
+	}),
+	getValidatedSearchState: (loanSearchState) => ({
+		// dafEligible is a boolean filter
+		// We don't display this filter in the UI and only use it for a small number of categories
+		dafEligible: typeof loanSearchState?.dafEligible === 'boolean' ? loanSearchState?.dafEligible : null,
+	}),
+	getFilterFromQuery: (query) => ({ dafEligible: getBooleanValueFromQueryParam(query.dafEligible) }),
+	getQueryFromFilter: (loanSearchState) => ({
+		...(typeof loanSearchState.dafEligible === 'boolean' && {
+			dafEligible: loanSearchState.dafEligible.toString(),
+		}),
+	}),
+};

--- a/@kiva/kv-loan-filters/src/tests/dafEligible.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/dafEligible.spec.ts
@@ -1,0 +1,67 @@
+import dafEligible from '../dafEligible';
+
+describe('dafEligible.ts', () => {
+	describe('default', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(dafEligible.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(dafEligible.getFlssFilter({ dafEligible: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(dafEligible.getFlssFilter({ dafEligible: false })).toEqual({ dafEligible: { eq: false } });
+			});
+		});
+
+		describe('getRemovedFacet', () => {
+			it('should remove facet', () => {
+				expect(dafEligible.getRemovedFacet()).toEqual({ dafEligible: null });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				expect(dafEligible.getValidatedSearchState(undefined)).toEqual({ dafEligible: null });
+			});
+
+			it('should handle missing', () => {
+				expect(dafEligible.getValidatedSearchState({})).toEqual({ dafEligible: null });
+			});
+
+			it('should return value', () => {
+				expect(dafEligible.getValidatedSearchState({ dafEligible: true })).toEqual({ dafEligible: true });
+			});
+		});
+
+		describe('getFilterFromQuery', () => {
+			it('it should get filter', () => {
+				const query = { dafEligible: 'true' };
+
+				const result = dafEligible.getFilterFromQuery(query);
+
+				expect(result).toEqual({ dafEligible: true });
+			});
+
+			it('should handle different is query casing', () => {
+				const query = { dafEligible: 'TRUE' };
+
+				const result = dafEligible.getFilterFromQuery(query);
+
+				expect(result).toEqual({ dafEligible: true });
+			});
+		});
+
+		describe('getQueryFromFilter', () => {
+			it('should push is dafEligible', () => {
+				const state = { dafEligible: true };
+
+				const result = dafEligible.getQueryFromFilter(state);
+
+				expect(result).toEqual({ dafEligible: 'true' });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
+++ b/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
@@ -5,6 +5,7 @@ export const mockState = {
 	sortBy: 'expiringSoon',
 	themeId: [1],
 	tagId: [1],
+	dafEligible: null,
 	distributionModel: 'DIRECT',
 	isIndividual: false,
 	lenderRepaymentTerm: { min: 0, max: 8, __typename: 'MinMaxRange' },


### PR DESCRIPTION
This shoud ensure we can apply `dafEligible` to flss filters that use these utils.

I've got a separate set of work in CPS that includes this as part of the defaultLoanSearchState as well.