### PR TITLE
fix: ensure pass distributionModel value is capitalized when lowercas…

### DIFF
--- a/@kiva/kv-loan-filters/src/distributionModels.ts
+++ b/@kiva/kv-loan-filters/src/distributionModels.ts
@@ -84,7 +84,8 @@ export default {
 		distributionModel: distributionModelEnumMap[loanSearchState?.distributionModel?.toUpperCase()],
 	}),
 	getFlssFilter: (loanSearchState) => ({
-		...(loanSearchState?.distributionModel && { distributionModel: { eq: loanSearchState.distributionModel } }),
+		...(loanSearchState?.distributionModel
+			&& { distributionModel: { eq: loanSearchState.distributionModel.toUpperCase() } }),
 	}),
 	getValidatedSearchState: (loanSearchState, allFacets) => ({
 		distributionModel: allFacets?.distributionModels?.includes(loanSearchState?.distributionModel?.toUpperCase())

--- a/@kiva/kv-loan-filters/src/tests/distributionModels.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/distributionModels.spec.ts
@@ -115,6 +115,11 @@ describe('distributionModels.ts', () => {
 				expect(distributionModels.getFlssFilter({ distributionModel: 'DIRECT' }))
 					.toEqual({ distributionModel: { eq: 'DIRECT' } });
 			});
+
+			it('should capitalize filters', () => {
+				expect(distributionModels.getFlssFilter({ distributionModel: 'direct' }))
+					.toEqual({ distributionModel: { eq: 'DIRECT' } });
+			});
 		});
 	});
 


### PR DESCRIPTION
…e, converted from legacy

Distribution model in legacy is passed as camel case. This ensures that when we start with a loan search criteria and create loanSearchState with it, we automatically move to uppercase for this enum.

I didn't see any other filters that have this issue...