### PR TITLE
fix: event is firing twice

### DIFF
--- a/@kiva/kv-components/utils/loanCard.js
+++ b/@kiva/kv-components/utils/loanCard.js
@@ -186,13 +186,6 @@ export function loanCardMethods(props, emit) {
 		kvTrackFunction,
 	} = toRefs(props);
 
-	function showLoanDetails(event) {
-		if (customLoanDetails.value) {
-			event.preventDefault();
-			emit('show-loan-details');
-		}
-	}
-
 	function clickReadMore(target, event) {
 		kvTrackFunction.value('Lending', 'click-Read more', target, loanId.value);
 		if (customLoanDetails.value) {
@@ -202,7 +195,6 @@ export function loanCardMethods(props, emit) {
 	}
 
 	return {
-		showLoanDetails,
 		clickReadMore,
 	};
 }

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -17,7 +17,6 @@
 				<div
 					v-else
 					class="tw-relative"
-					@click="showLoanDetails"
 				>
 					<component
 						:is="tag"
@@ -455,7 +454,6 @@ export default {
 
 		const {
 			clickReadMore,
-			showLoanDetails,
 		} = loanCardMethods(props, emit);
 
 		return {
@@ -480,7 +478,6 @@ export default {
 			tag,
 			unreservedAmount,
 			clickReadMore,
-			showLoanDetails,
 		};
 	},
 	computed: {

--- a/@kiva/kv-components/vue/KvWideLoanCard.vue
+++ b/@kiva/kv-components/vue/KvWideLoanCard.vue
@@ -27,7 +27,6 @@
 			<div
 				v-else
 				class="tw-relative tw-w-full"
-				@click="showLoanDetails"
 			>
 				<component
 					:is="tag"
@@ -364,7 +363,6 @@ export default {
 
 		const {
 			clickReadMore,
-			showLoanDetails,
 		} = loanCardMethods(props, emit);
 
 		return {
@@ -389,7 +387,6 @@ export default {
 			tag,
 			unreservedAmount,
 			clickReadMore,
-			showLoanDetails,
 		};
 	},
 	computed: {


### PR DESCRIPTION
Event was firing twice because there was a click handler on the borrower image wrapper element and the image element. Now that we are listening to this event and either suppressing it or navigating on the various `readMore` click handlers, we actually don't need this event, it does the same thing. 