### PR TITLE
fix: use auth0 package file name to be compatible with es modules

### DIFF
--- a/@kiva/kv-shop/src/basket.ts
+++ b/@kiva/kv-shop/src/basket.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import { getCookieValue, setCookieValue } from './util/cookie';
 import { parseShopError } from './shopError';
 

--- a/@kiva/kv-shop/src/basketCredits.ts
+++ b/@kiva/kv-shop/src/basketCredits.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient, MutationOptions } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient, type MutationOptions } from '@apollo/client/core/core.cjs';
 import { callShopMutation } from './shopQueries';
 
 export interface ApplyKivaCreditData {

--- a/@kiva/kv-shop/src/basketItems.ts
+++ b/@kiva/kv-shop/src/basketItems.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import numeral from 'numeral';
 import { callShopMutation } from './shopQueries';
 

--- a/@kiva/kv-shop/src/basketTotals.ts
+++ b/@kiva/kv-shop/src/basketTotals.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import { watchShopQuery } from './shopQueries';
 
 export const basketTotalsQuery = gql`query basketTotals($basketId: String) {

--- a/@kiva/kv-shop/src/checkoutStatus.ts
+++ b/@kiva/kv-shop/src/checkoutStatus.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import { poll } from './util/poll';
 import { getVisitorID } from './util/visitorId';
 

--- a/@kiva/kv-shop/src/managedAccount.ts
+++ b/@kiva/kv-shop/src/managedAccount.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient, QueryOptions } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient, type QueryOptions } from '@apollo/client/core/core.cjs';
 import { callShopQuery } from './shopQueries';
 
 export interface ShopPromoCampaignData {

--- a/@kiva/kv-shop/src/oneTimeCheckout.ts
+++ b/@kiva/kv-shop/src/oneTimeCheckout.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import { trackTransaction } from '@kiva/kv-analytics';
 import numeral from 'numeral';
 import type { DropInWrapper } from './useBraintreeDropIn';

--- a/@kiva/kv-shop/src/receipt.ts
+++ b/@kiva/kv-shop/src/receipt.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import type { ApolloClient, ApolloQueryResult } from '@apollo/client/core';
+import { gql, type ApolloClient, type ApolloQueryResult } from '@apollo/client/core/core.cjs';
 import type { TransactionData } from '@kiva/kv-analytics';
-import { gql } from '@apollo/client/core';
 import { getVisitorID } from './util/visitorId';
 
 export async function getFTDStatus(apollo: ApolloClient<any>) {

--- a/@kiva/kv-shop/src/shopQueries.ts
+++ b/@kiva/kv-shop/src/shopQueries.ts
@@ -5,7 +5,7 @@ import type {
 	MutationOptions,
 	QueryOptions,
 	WatchQueryOptions,
-} from '@apollo/client/core';
+} from '@apollo/client/core/core.cjs';
 import { getBasketID, hasBasketExpired, createBasket } from './basket';
 import { parseShopError } from './shopError';
 

--- a/@kiva/kv-shop/src/subscriptionCheckout.ts
+++ b/@kiva/kv-shop/src/subscriptionCheckout.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client/core';
+import { gql } from '@apollo/client/core/core.cjs';
 import type { PaymentMethodPayload } from 'braintree-web-drop-in';
 import { parseShopError, ShopError } from './shopError';
 

--- a/@kiva/kv-shop/src/useBraintreeDropIn.ts
+++ b/@kiva/kv-shop/src/useBraintreeDropIn.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { gql } from '@apollo/client/core';
+import { gql } from '@apollo/client/core/core.cjs';
 import numeral from 'numeral';
 import type { Ref } from 'vue-demi';
 import { ref } from 'vue-demi';

--- a/@kiva/kv-shop/src/validatePreCheckout.ts
+++ b/@kiva/kv-shop/src/validatePreCheckout.ts
@@ -1,5 +1,4 @@
-import type { ApolloClient } from '@apollo/client/core';
-import { gql } from '@apollo/client/core';
+import { gql, type ApolloClient } from '@apollo/client/core/core.cjs';
 import { callShopMutation } from './shopQueries';
 import { getVisitorID } from './util/visitorId';
 import { ShopError, parseShopError } from './shopError';


### PR DESCRIPTION
- Apparently this is a known issue with using the Apollo package within an ES module
- The Vue migration converted the `ui` repo to an ES module, so this changeset is needed (checkout page currently crashes the dev server 😄 )