### PR TITLE
fix: max dimensions on kvContentfulImg

### DIFF
--- a/@kiva/kv-components/vue/KvContentfulImg.vue
+++ b/@kiva/kv-components/vue/KvContentfulImg.vue
@@ -213,9 +213,22 @@ export default {
 
 		const buildUrl = (image = null, multiplier = 1) => {
 			let src = image && image.url ? `${image.url}?` : `${contentfulSrc.value}?`;
-			const imgWidth = image ? image.width : width.value;
-			const imgHeight = image ? image.height : height.value;
-
+			let imgWidth = image ? image.width : width.value;
+			let imgHeight = image ? image.height : height.value;
+			// The max contentful image size is 4000px so we have to
+			// impose a limit of 2000px here for both height and width
+			// so when we request the retina x2 image we don't go over the 4000px limit
+			let newMultiplier;
+			if (imgWidth >= 2000) {
+				newMultiplier = imgWidth / 1999;
+				imgWidth = 1999;
+				imgHeight = Math.round(imgHeight / newMultiplier);
+			}
+			if (imgHeight >= 2000) {
+				newMultiplier = imgHeight / 1999;
+				imgHeight = 1999;
+				imgWidth = Math.round(imgWidth / newMultiplier);
+			}
 			if (imgWidth) {
 				src += `w=${imgWidth * multiplier}`;
 			}

--- a/@kiva/kv-components/vue/stories/KvContentfulImg.stories.js
+++ b/@kiva/kv-components/vue/stories/KvContentfulImg.stories.js
@@ -4,7 +4,7 @@ export default {
 	title: 'KvContentfulImg',
 	component: KvContentfulImg,
 	args: {
-		contentfulSrc: 'https://images.ctfassets.net/j0p9a6ql0rn7/2TWV32iioxapwjn26ZpigZ/84ac39a1396d6be9eea472cf8791faa7/Cynthia.png',
+		contentfulSrc: 'https://images.ctfassets.net/j0p9a6ql0rn7/35lkLRfbLxzFPlDVgA4aKI/c435630d811f9ad35ddfc88eaea22b08/Blog-import-1082518_us_shawn_16.jpg',
 		fallbackFormat: 'jpg',
 		width: 200,
 		height: null,
@@ -77,6 +77,7 @@ export const ResponsiveImageSet = (args, { argTypes }) => ({
 		/>
 	`,
 });
+
 ResponsiveImageSet.args = {
 	fit: 'fill',
 	focus: 'face',
@@ -168,3 +169,28 @@ export const WithCaption = (args, { argTypes }) => ({
 		/>
 	`,
 });
+
+export const GiantImage = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		KvContentfulImg,
+	},
+	template: `
+		<kv-contentful-img
+			:contentful-src="contentfulSrc"
+			:fallback-format="fallbackFormat"
+			:width="width"
+			:height="height"
+			alt="Descriptive alt text"
+			:loading="loading"
+			:fit="fit"
+			:focus="focus"
+		/>
+	`,
+});
+
+GiantImage.args = {
+	contentfulSrc: 'https://images.ctfassets.net/j0p9a6ql0rn7/7dVINOyAxRaXM8p6aq7p5s/9213f63ff10dec57c5f740c056afe8a8/gradient-hero-bg__1_.jpg',
+	width: 4000,
+	height: 2000,
+};


### PR DESCRIPTION
Contentful will not serve images with a single dimension > 4000 px. This came up again. Usually an issue on retina screens when we build the 2x url. I made a similar fix for the responsive image sets in cps, but we need this fix for embedded images.  This seems to be coming up lately because the imported images from the legacy blog are huge, and we are linking to blog entries in other contexts for example the new us-hubs page