### PR TITLE
fix: modal position and size on desktop

### DIFF
--- a/@kiva/kv-components/vue/KvCartModal.vue
+++ b/@kiva/kv-components/vue/KvCartModal.vue
@@ -40,9 +40,9 @@
 										class="tw-w-4 tw-h-4 tw-text-brand"
 										:icon="mdiCheckCircle"
 									/>
-									<h3	class="tw-text-h3 tw-flex-1">
-										Added to Basket
-									</h3>
+									<p class="tw-flex-1 tw-font-medium">
+										Added to basket
+									</p>
 								</slot>
 								<button
 									v-if="!preventClose"


### PR DESCRIPTION
<img width="1151" alt="image" src="https://github.com/user-attachments/assets/53c09619-462b-493a-bebe-b98c1d9d4868">

Design on desktop: (Missing check in dekstop)
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/114be376-e1cd-45f2-a998-7c9e4dcef8eb">


Mobile keeps being full width and in the top of the page