### PR TITLE
fix: set full width for cart modal in tablet

### DIFF
--- a/@kiva/kv-components/vue/KvCartModal.vue
+++ b/@kiva/kv-components/vue/KvCartModal.vue
@@ -340,7 +340,6 @@ export default {
 
 .modal {
 	@apply tw-bg-primary md:tw-absolute md:tw-right-0 tw-w-full tw-rounded-b;
-	max-width: 30rem;
 	max-height: 90%;
 }
 


### PR DESCRIPTION
<img width="793" alt="image" src="https://github.com/user-attachments/assets/b6d6c144-e52b-407e-b870-09eaff88e8f2">
