### PR TITLE
chore: add loan-card class to all loan cards for cypress test access

### DIFF
--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -1,7 +1,8 @@
 <template>
 	<div
-		class="loan-card tw-flex tw-flex-col tw-bg-white tw-rounded tw-w-full tw-pb-1"
+		class="tw-flex tw-flex-col tw-bg-white tw-rounded tw-w-full tw-pb-1"
 		:class="{ 'tw-p-1': !largeCard, 'tw-pointer-events-none' : isLoading }"
+		data-testid="loan-card"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 		:style="{ minWidth: '230px', maxWidth: cardWidth }"
 	>

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="tw-flex tw-flex-col tw-bg-white tw-rounded tw-w-full tw-pb-1"
+		class="loan-card tw-flex tw-flex-col tw-bg-white tw-rounded tw-w-full tw-pb-1"
 		:class="{ 'tw-p-1': !largeCard, 'tw-pointer-events-none' : isLoading }"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 		:style="{ minWidth: '230px', maxWidth: cardWidth }"

--- a/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
+++ b/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="card-container"
+		class="loan-card card-container"
 		:class="{ 'tw-pointer-events-none' : isLoading }"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 		:style="{ minWidth: '230px', maxWidth: '20.5rem' }"

--- a/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
+++ b/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
@@ -1,7 +1,8 @@
 <template>
 	<div
-		class="loan-card card-container"
+		class="card-container"
 		:class="{ 'tw-pointer-events-none' : isLoading }"
+		data-testid="loan-card"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 		:style="{ minWidth: '230px', maxWidth: '20.5rem' }"
 	>

--- a/@kiva/kv-components/vue/KvWideLoanCard.vue
+++ b/@kiva/kv-components/vue/KvWideLoanCard.vue
@@ -1,7 +1,6 @@
 <template>
 	<div
 		class="
-			loan-card
 			tw-flex
 			tw-flex-row
 			tw-flex-wrap
@@ -14,6 +13,7 @@
 			tw-items-center
 		"
 		:class="{'tw-pointer-events-none' : isLoading }"
+		data-testid="loan-card"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 	>
 		<div

--- a/@kiva/kv-components/vue/KvWideLoanCard.vue
+++ b/@kiva/kv-components/vue/KvWideLoanCard.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
 		class="
+			loan-card
 			tw-flex
 			tw-flex-row
 			tw-flex-wrap


### PR DESCRIPTION
Our cypress tests search through collections of loan cards to target specific states. This will make sure there is always a way to find a list of loan cards on a page across any usages of these components.