### PR TITLE
fix: use an image size we already have a retina size for

### DIFF
--- a/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
+++ b/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
@@ -16,7 +16,8 @@
 				/>
 				<div
 					v-else
-					class="tw-relative"
+					:style="{ height: '11rem' }"
+					class="tw-relative tw-overflow-hidden"
 				>
 					<component
 						:is="tag"
@@ -356,10 +357,10 @@ export default {
 	},
 	computed: {
 		imageAspectRatio() {
-			return 1 / 2;
+			return 5 / 8;
 		},
 		imageDefaultWidth() {
-			return 500;
+			return 480;
 		},
 		imageSizes() {
 			return [


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-607

- Turns out the previous size didn't have a retina size available in existing cloudinary sizes -> you would get black bars on the sides of the image in mobile (or chrome emulator)
- This size is slightly different ratio, but it should look pretty close
- The size used here has a retina size

![image](https://github.com/user-attachments/assets/1c677350-0ccc-4f52-b9a2-a03899f83215)
