### PR TITLE
feat: initial styles for ecosystem themes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,6 +21,8 @@ jobs:
           fetch-depth: 0 # 👈 Required to retrieve git history
       - name: Install dependencies
         run: npm ci
+      - name: Build kv-tokens
+        run: npm run build -w @kiva/kv-tokens
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v11.4.0

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+env:
+  GITHUB_PAT: "${{ secrets.KIVA_ROBOT_GITHUB_PAT || github.token }}"
+  AWS_REGION: "us-west-2"
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,6 +38,15 @@ jobs:
           # Personal Access Token with the 'public_repo' scope, to allow tagging the latest release
           token: ${{ secrets.PUBLISH_PAT }}
 
+      # Checkout shared GitHub Actions workflows
+      - name: Checkout shared workflows
+        uses: actions/checkout@v3
+        with:
+          repository: kiva/github-actions
+          ref: main
+          token: ${{ env.GITHUB_PAT }}
+          path: .github/
+
       # Configure Git user email and name for the release tags
       - name: Configure Git user
         run: |
@@ -45,6 +60,12 @@ jobs:
       # Build projects
       - name: Build projects
         run: npm run build
+
+      # Upload static asssets
+      - name: upload static assets
+        uses: ./.github/actions/upload-static-assets
+        with:
+          source_dir: "dist/assets"
 
       # Tag release and publish to NPM
       - name: Publish release

--- a/@kiva/kv-components/vue/.storybook/main.js
+++ b/@kiva/kv-components/vue/.storybook/main.js
@@ -7,6 +7,10 @@ const config = {
 		'../stories/**/*.stories.@(js|jsx|ts|tsx)'
 	],
 
+	staticDirs: [
+		'../../../../dist/assets',
+	],
+
 	addons: [
 		"@storybook/addon-links",
 		"@storybook/addon-essentials",
@@ -23,7 +27,7 @@ const config = {
 							'style-loader',
 							{
 								loader: 'css-loader',
-								options: { importLoaders: 1 }
+								options: { importLoaders: 1, url: false }
 							},
 							{
 								// Gets options from `postcss.config.js` in your project root

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -137,12 +137,12 @@ export default {
 					}
 					break;
 				case 'secondary':
-					classes = 'tw-text-action';
+					classes = 'tw-text-action-highlight';
 					if (state.value === 'active') {
 						classes = `${classes} tw-bg-secondary`;
 					} else {
 						// eslint-disable-next-line max-len
-						classes = `${classes} tw-bg-primary hover:tw-bg-secondary tw-border-action`;
+						classes = `${classes} tw-bg-primary hover:tw-bg-secondary tw-border-action-highlight`;
 					}
 					break;
 				case 'danger':

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -137,12 +137,12 @@ export default {
 					}
 					break;
 				case 'secondary':
-					classes = 'tw-text-primary';
+					classes = 'tw-text-action';
 					if (state.value === 'active') {
-						classes = `${classes} tw-bg-secondary tw-border-primary`;
+						classes = `${classes} tw-bg-secondary`;
 					} else {
 						// eslint-disable-next-line max-len
-						classes = `${classes} tw-bg-primary hover:tw-bg-secondary tw-border-tertiary hover:tw-border-primary`;
+						classes = `${classes} tw-bg-primary hover:tw-bg-secondary tw-border-action`;
 					}
 					break;
 				case 'danger':

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -137,7 +137,7 @@ export default {
 					}
 					break;
 				case 'secondary':
-					classes = 'tw-text-action-highlight'; // TODO: dark themes want to use text-primary and text-primary-inverse
+					classes = 'tw-text-action-highlight';
 					if (state.value === 'active') {
 						classes = `${classes} tw-bg-secondary`;
 					} else {

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -5,7 +5,7 @@
 		:to="to"
 		:type="computedType"
 		:disabled="isDisabled"
-		class="hover:tw-no-underline focus:tw-no-underline tw-inline-block"
+		class="tw-no-underline hover:tw-no-underline focus:tw-no-underline tw-inline-block"
 		:class="{
 			'tw-opacity-low': state === 'disabled',
 			'tw-pointer-events-none': state === 'loading' || isDisabled

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -137,7 +137,7 @@ export default {
 					}
 					break;
 				case 'secondary':
-					classes = 'tw-text-action-highlight';
+					classes = 'tw-text-action-highlight'; // TODO: dark themes want to use text-primary and text-primary-inverse
 					if (state.value === 'active') {
 						classes = `${classes} tw-bg-secondary`;
 					} else {
@@ -146,7 +146,7 @@ export default {
 					}
 					break;
 				case 'danger':
-					classes = 'tw-text-primary-inverse';
+					classes = 'tw-text-danger';
 					if (state.value === 'active') {
 						classes = `${classes} tw-bg-danger-highlight tw-border-danger-highlight`;
 					} else {
@@ -171,11 +171,12 @@ export default {
 					}
 					break;
 				case 'caution':
-					classes = 'tw-text-primary tw-border-transparent';
+					classes = 'tw-text-caution';
 					if (state.value === 'active') {
-						classes = `${classes} tw-bg-caution-highlight`;
+						classes = `${classes} tw-bg-caution-highlight tw-border-caution-highlight`;
 					} else {
-						classes = `${classes} tw-bg-caution hover:tw-bg-caution-highlight`;
+						// eslint-disable-next-line max-len
+						classes = `${classes} tw-bg-caution hover:tw-bg-caution-highlight tw-border-caution hover:tw-border-caution-highlight`;
 					}
 					break;
 			}

--- a/@kiva/kv-components/vue/KvButton.vue
+++ b/@kiva/kv-components/vue/KvButton.vue
@@ -157,9 +157,9 @@ export default {
 				case 'link':
 					classes = 'tw-bg-primary-inverse tw-text-primary-inverse';
 					if (state.value === 'active') {
-						classes = `${classes} tw-border-secondary`;
+						classes = `${classes} tw-border-secondary tw-bg-action`;
 					} else {
-						classes = `${classes} tw-border-primary hover:tw-border-secondary`;
+						classes = `${classes} tw-border-action-highlight hover:tw-border-action hover:tw-bg-action`;
 					}
 					break;
 				case 'ghost':

--- a/@kiva/kv-components/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/vue/KvClassicLoanCard.vue
@@ -90,7 +90,7 @@
 					:is="tag"
 					:to="readMorePath"
 					:href="readMorePath"
-					class="tw-flex hover:tw-no-underline focus:tw-no-underline"
+					class="tw-flex tw-no-underline hover:tw-no-underline focus:tw-no-underline"
 					:class="{ 'tw-px-1': largeCard }"
 					aria-label="Loan tag"
 					@click.native="clickReadMore('Tag', $event)"
@@ -105,7 +105,7 @@
 					:is="tag"
 					:to="readMorePath"
 					:href="readMorePath"
-					class="loan-card-use tw-text-primary"
+					class="loan-card-use tw-no-underline tw-text-primary"
 					aria-label="Loan use"
 					@click.native="clickReadMore('Use', $event)"
 				>
@@ -183,7 +183,7 @@
 					v-if="unreservedAmount > 0"
 					:to="readMorePath"
 					:href="readMorePath"
-					class="loan-card-progress tw-mt-1"
+					class="loan-card-progress tw-no-underline tw-mt-1"
 					aria-label="Loan progress"
 					@click.native="clickReadMore('Progress', $event)"
 				>

--- a/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
+++ b/@kiva/kv-components/vue/KvIntroductionLoanCard.vue
@@ -96,7 +96,7 @@
 					:to="readMorePath"
 					:href="readMorePath"
 					aria-label="Borrower name"
-					class="!tw-text-primary"
+					class="!tw-text-primary tw-no-underline"
 					@click.native="clickReadMore('Name', $event)"
 				>
 					<h3
@@ -136,7 +136,7 @@
 					v-else
 					:to="readMorePath"
 					:href="readMorePath"
-					class="tw-flex hover:tw-no-underline focus:tw-no-underline tw-justify-center"
+					class="tw-flex tw-no-underline hover:tw-no-underline focus:tw-no-underline tw-justify-center"
 					aria-label="Loan tag"
 					@click.native="clickReadMore('Tag', $event)"
 				>
@@ -151,7 +151,7 @@
 					:is="tag"
 					:to="readMorePath"
 					:href="readMorePath"
-					class="loan-card-use tw-text-primary"
+					class="loan-card-use tw-text-primary tw-no-underline"
 					aria-label="Loan use"
 					@click.native="clickReadMore('Use', $event)"
 				>
@@ -433,6 +433,7 @@ export default {
 .loan-card-active-hover:hover .loan-card-use, .loan-card-active-hover:hover .loan-card-name {
 	@apply tw-underline;
 }
+.loan-card-progress,
 .loan-card-progress:hover,
 .loan-card-progress:focus {
 	@apply tw-no-underline;

--- a/@kiva/kv-components/vue/KvTab.vue
+++ b/@kiva/kv-components/vue/KvTab.vue
@@ -2,9 +2,9 @@
 	<button
 		:id="`kv-tab-${forPanel}`"
 		class="tw-text-h3 tw-mb-1.5 tw-whitespace-nowrap tw-text-left"
-		:class="{ 'hover:tw-text-action-highlight' : !isActive,
+		:class="{ 'hover:tw-text-action' : !isActive,
 			'md:tw-border-l-2 tw-border-transparent md:tw-pl-2' : vertical,
-			'tw-text-action-highlight' : isActive && vertical
+			'tw-text-action' : isActive && vertical
 		}"
 		role="tab"
 		:aria-selected="isActive"

--- a/@kiva/kv-components/vue/KvTabs.vue
+++ b/@kiva/kv-components/vue/KvTabs.vue
@@ -22,7 +22,7 @@
 					tw-bg-primary-inverse tw-rounded-full
 					tw-origin-left tw-transition-all tw-duration-300
 				"
-				:class="{ 'tw-hidden md:tw-block tw-top-0 md:tw-bg-action-highlight' : vertical}"
+				:class="{ 'tw-hidden md:tw-block tw-top-0 md:tw-bg-action' : vertical}"
 				:style="`
 					width: ${selectedTabEl && !vertical ? selectedTabEl.clientWidth : 3}px;
 					height: ${selectedTabEl && vertical ? `${selectedTabEl.clientHeight}px` : '0.25rem'};

--- a/@kiva/kv-components/vue/KvTextInput.vue
+++ b/@kiva/kv-components/vue/KvTextInput.vue
@@ -67,7 +67,7 @@
 			</button>
 			<div
 				v-if="$slots.error"
-				class="tw-text-danger tw-text-small tw-font-medium tw-mt-1"
+				class="tw-text-danger-highlight tw-text-small tw-font-medium tw-mt-1"
 			>
 				<!-- @slot Used in conjuction with the `valid` prop to tell the user what must be fixed -->
 				<slot name="error"></slot>

--- a/@kiva/kv-components/vue/KvTextInput.vue
+++ b/@kiva/kv-components/vue/KvTextInput.vue
@@ -28,7 +28,7 @@
 						: valid && !disabled,
 					'tw-border-tertiary focus:tw-ring-action'
 						: valid,
-					'tw-pr-6 tw-bg-danger-highlight tw-border-danger-highlight tw-bg-opacity-10 focus:tw-ring-danger-highlight'
+					'tw-pr-6 tw-bg-danger-highlight tw-border-danger focus:tw-ring-danger-highlight'
 						: !valid,
 					'tw-bg-tertiary'
 						: disabled,

--- a/@kiva/kv-components/vue/KvTextInput.vue
+++ b/@kiva/kv-components/vue/KvTextInput.vue
@@ -16,16 +16,19 @@
 				class="
 					tw-h-6 tw-w-full
 					tw-px-2
-					tw-border tw-border-tertiary
+					tw-border
 					tw-rounded-sm
 					tw-appearance-none
 					tw-text-base
-					tw-bg-primary
 					tw-ring-inset
-					focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-action focus:tw-border-transparent
+					focus:tw-outline-none focus:tw-ring-2 focus:tw-border-transparent
 				"
 				:class="{
-					'tw-pr-6 tw-bg-danger tw-border-danger-highlight tw-bg-opacity-low focus:tw-ring-danger-highlight'
+					'tw-bg-primary'
+						: valid && !disabled,
+					'tw-border-tertiary focus:tw-ring-action'
+						: valid,
+					'tw-pr-6 tw-bg-danger-highlight tw-border-danger-highlight tw-bg-opacity-10 focus:tw-ring-danger-highlight'
 						: !valid,
 					'tw-bg-tertiary'
 						: disabled,

--- a/@kiva/kv-components/vue/KvWideLoanCard.vue
+++ b/@kiva/kv-components/vue/KvWideLoanCard.vue
@@ -100,7 +100,7 @@
 				:is="tag"
 				:to="readMorePath"
 				:href="readMorePath"
-				class="tw-flex hover:tw-no-underline focus:tw-no-underline"
+				class="tw-flex tw-no-underline hover:tw-no-underline focus:tw-no-underline"
 				aria-label="Loan tag"
 				@click.native="clickReadMore('Tag', $event)"
 			>
@@ -114,7 +114,7 @@
 				:is="tag"
 				:to="readMorePath"
 				:href="readMorePath"
-				class="loan-card-use tw-text-primary"
+				class="loan-card-use tw-no-underline tw-text-primary"
 				aria-label="Loan use"
 				@click="clickReadMore('Use')"
 			>
@@ -421,6 +421,7 @@ export default {
 .loan-card-active-hover:hover .loan-card-use {
 	@apply tw-underline;
 }
+.loan-card-progress,
 .loan-card-progress:hover,
 .loan-card-progress:focus {
 	@apply tw-no-underline;

--- a/@kiva/kv-components/vue/stories/KvThemeProvider.stories.js
+++ b/@kiva/kv-components/vue/stories/KvThemeProvider.stories.js
@@ -104,7 +104,7 @@ const demoTemplate = `
 		<section>
 			<ul>
 				<li
-					v-for="variant in ['primary', 'secondary', 'link', 'danger', 'ghost']"
+					v-for="variant in ['primary', 'secondary', 'link', 'danger', 'caution', 'ghost']"
 					:key="variant"
 					class="tw-mb-2"
 				>

--- a/@kiva/kv-components/vue/stories/KvThemeProvider.stories.js
+++ b/@kiva/kv-components/vue/stories/KvThemeProvider.stories.js
@@ -1,6 +1,16 @@
 import primitives from '@kiva/kv-tokens/primitives.json';
 import {
-	defaultTheme, darkTheme, darkGreenTheme, mintTheme, darkMintTheme, darkStoneTheme,
+	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
+	darkTheme,
+	darkGreenTheme,
+	mintTheme,
+	darkMintTheme,
+	darkStoneTheme,
 } from '@kiva/kv-tokens/configs/kivaColors.cjs';
 import KvButton from '../KvButton.vue';
 import KvGrid from '../KvGrid.vue';
@@ -99,7 +109,7 @@ const demoTemplate = `
 					class="tw-mb-2"
 				>
 					<kv-button :variant="variant">
-						Find a borrower
+						{{ variant }}
 					</kv-button>
 				</li>
 			</ul>
@@ -137,6 +147,31 @@ const Template = (args, {
 });
 
 export const Default = Template.bind({});
+
+export const GreenLight = Template.bind({});
+GreenLight.args = {
+	theme: greenLightTheme,
+};
+
+export const GreenDark = Template.bind({});
+GreenDark.args = {
+	theme: greenDarkTheme,
+};
+
+export const MarigoldLight = Template.bind({});
+MarigoldLight.args = {
+	theme: marigoldLightTheme,
+};
+
+export const StoneLight = Template.bind({});
+StoneLight.args = {
+	theme: stoneLightTheme,
+};
+
+export const StoneDark = Template.bind({});
+StoneDark.args = {
+	theme: stoneDarkTheme,
+};
 
 export const Dark = Template.bind({});
 Dark.args = {

--- a/@kiva/kv-components/vue/stories/StyleguideProse.stories.js
+++ b/@kiva/kv-components/vue/stories/StyleguideProse.stories.js
@@ -1,18 +1,74 @@
+import {
+	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
+	darkTheme,
+	darkGreenTheme,
+	mintTheme,
+	darkMintTheme,
+	darkStoneTheme,
+} from '@kiva/kv-tokens/configs/kivaColors.cjs';
 import KvGrid from '../KvGrid.vue';
 import KvPageContainer from '../KvPageContainer.vue';
 
 export default {
 	title: 'Base Styling/Prose Demo',
+	args: {
+		theme: 'greenLight',
+	},
+	argTypes: {
+		theme: {
+			control: {
+				type: 'select',
+			},
+			options: ['default', 'greenLight', 'greenDark', 'marigoldLight', 'stoneLight', 'stoneDark', 'dark', 'darkGreen', 'mint', 'darkMint', 'darkStone'],
+		},
+	},
 };
 
 export const ProseDemo = (args, { argTypes }) => ({
 	props: Object.keys(argTypes),
 	components: { KvPageContainer, KvGrid },
+	computed: {
+		themeStyles() {
+			switch (this.theme) {
+				case 'greenLight':
+					return greenLightTheme;
+				case 'greenDark':
+					return greenDarkTheme;
+				case 'marigoldLight':
+					return marigoldLightTheme;
+				case 'stoneLight':
+					return stoneLightTheme;
+				case 'stoneDark':
+					return stoneDarkTheme;
+				case 'dark':
+					return darkTheme;
+				case 'darkGreen':
+					return darkGreenTheme;
+				case 'mint':
+					return mintTheme;
+				case 'darkMint':
+					return darkMintTheme;
+				case 'darkStone':
+					return darkStoneTheme;
+				default:
+					return defaultTheme;
+			}
+		},
+	},
 	template: `
-	<kv-page-container>
+	<kv-page-container :style="{
+		...themeStyles,
+		color: 'rgb(var(--text-primary))',
+		backgroundColor: 'rgb(var(--bg-primary))',
+	}">
 		<kv-grid class="tw-grid-cols-12 tw-prose">
 			<div class="tw-col-span-full md:tw-col-span-10 md:tw-col-start-2 lg:tw-col-span-8 lg:tw-col-start-3">
-				<h1>Typography</h1>
+				<h1><u>Typography</u></h1>
 				<p class="tw-text-subhead">Until now, trying to style an article, document, or blog post with Tailwind has been a tedious task that required a keen eye for typography and a lot of complex custom CSS.</p>
 				<p>By default, Tailwind removes all of the default browser styling from paragraphs, headings, lists and more. This ends up being really useful for building application UIs because you spend less time undoing user-agent styles, but when you <em>really are</em> just trying to style some content that came from a rich-text editor in a CMS or a markdown file, it can be surprising and unintuitive.</p>
 				<p>We get lots of complaints about it actually, with people regularly asking us things like:</p>

--- a/@kiva/kv-tokens/build/build.cjs
+++ b/@kiva/kv-tokens/build/build.cjs
@@ -1,0 +1,14 @@
+const fs = require('node:fs');
+const { generateExternalSVG } = require('../configs/kivaHeadingUnderline.cjs');
+
+// Note: dir is relative to the root of the kv-tokens package
+const dir = '../../dist/assets';
+
+// Create dist folder
+if (!fs.existsSync(dir)) {
+	fs.mkdirSync(dir, { recursive: true });
+}
+
+// Generate Heading Underline SVG
+const svg = generateExternalSVG();
+fs.writeFileSync(`${dir}/heading-underline.svg`, svg);

--- a/@kiva/kv-tokens/configs/kivaColors.cjs
+++ b/@kiva/kv-tokens/configs/kivaColors.cjs
@@ -4,6 +4,11 @@ const designtokens = require('../primitives.json');
 
 const {
 	DEFAULT: defaultThemeTokens,
+	'green-light': greenLightThemeTokens,
+	'green-dark': greenDarkThemeTokens,
+	'marigold-light': marigoldLightThemeTokens,
+	'stone-light': stoneLightThemeTokens,
+	'stone-dark': stoneDarkThemeTokens,
 	dark: darkThemeTokens,
 	'dark-green': darkGreenThemeTokens,
 	mint: mintThemeTokens,
@@ -31,7 +36,7 @@ const buildCSSVarsFromTokens = (theme) => {
 			if (category === 'heading-underline') {
 				// TODO: use this when we have the themable heading-underline.svg file
 				// customProperties[key] = `url('/heading-underline.svg${theme[category][property]}')`;
-				customProperties[key] = generateInlineSVG();
+				customProperties[key] = generateInlineSVG(theme[category][property]);
 			} else {
 				customProperties[key] = hexToRGB(theme[category][property]);
 			}
@@ -41,6 +46,11 @@ const buildCSSVarsFromTokens = (theme) => {
 };
 
 const defaultTheme = buildCSSVarsFromTokens(defaultThemeTokens);
+const greenLightTheme = buildCSSVarsFromTokens(greenLightThemeTokens);
+const greenDarkTheme = buildCSSVarsFromTokens(greenDarkThemeTokens);
+const marigoldLightTheme = buildCSSVarsFromTokens(marigoldLightThemeTokens);
+const stoneLightTheme = buildCSSVarsFromTokens(stoneLightThemeTokens);
+const stoneDarkTheme = buildCSSVarsFromTokens(stoneDarkThemeTokens);
 const darkTheme = buildCSSVarsFromTokens(darkThemeTokens);
 const mintTheme = buildCSSVarsFromTokens(mintThemeTokens);
 const darkGreenTheme = buildCSSVarsFromTokens(darkGreenThemeTokens);
@@ -93,6 +103,11 @@ const buildColorChoices = (themeProperty) => {
 module.exports = {
 	buildColorChoices,
 	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
 	darkTheme,
 	darkGreenTheme,
 	mintTheme,

--- a/@kiva/kv-tokens/configs/kivaColors.cjs
+++ b/@kiva/kv-tokens/configs/kivaColors.cjs
@@ -1,5 +1,4 @@
 const { hexToRGB } = require('./util.cjs');
-const { generateInlineSVG } = require('./kivaHeadingUnderline.cjs');
 const designtokens = require('../primitives.json');
 
 const {
@@ -34,9 +33,7 @@ const buildCSSVarsFromTokens = (theme) => {
 		properties.forEach((property) => {
 			const key = `--${twPrefix}-${property}`;
 			if (category === 'heading-underline') {
-				// TODO: use this when we have the themable heading-underline.svg file
-				// customProperties[key] = `url('/heading-underline.svg${theme[category][property]}')`;
-				customProperties[key] = generateInlineSVG(theme[category][property]);
+				customProperties[key] = `url('/heading-underline.svg${theme[category][property]}')`;
 			} else {
 				customProperties[key] = hexToRGB(theme[category][property]);
 			}

--- a/@kiva/kv-tokens/configs/kivaHeadingUnderline.cjs
+++ b/@kiva/kv-tokens/configs/kivaHeadingUnderline.cjs
@@ -39,13 +39,15 @@ function generateExternalSVG() {
 }
 
 /*
- * Generates an inline-style SVG string for brush-stroke underlines, in the brand color only. This can be used as a background image in css.
+ * Generates an inline-style SVG string for brush-stroke underlines, in one color only, to be used as a background image in css.
+ *
+ * THIS SHOULD ONLY BE USED FOR DEMO PURPOSES.
+ *
+ * This will greatly increase the size of your css file if used in production with multiple colors.
  */
-function generateInlineSVG() {
-	const { brand } = colors;
-	const brandColor = brand.DEFAULT;
+function generateInlineSVG(color) {
 	const svg = `${svgOpenTag}
-		<g fill="${brandColor}">
+		<g fill="${color}">
 			${underlinePath}
 		</g>
 	</svg>`;

--- a/@kiva/kv-tokens/configs/kivaTypography.cjs
+++ b/@kiva/kv-tokens/configs/kivaTypography.cjs
@@ -180,7 +180,7 @@ const textStyles = (() => {
 
 	const textLink = {
 		color: 'rgb(var(--text-action))',
-		textDecoration: 'none',
+		textDecoration: 'underline',
 		'&:hover, &:focus': {
 			color: 'rgb(var(--text-action-highlight))',
 			textDecoration: 'underline',

--- a/@kiva/kv-tokens/configs/tailwind.config.cjs
+++ b/@kiva/kv-tokens/configs/tailwind.config.cjs
@@ -105,6 +105,7 @@ module.exports = {
 		},
 		opacity: {
 			0: '0',
+			10: '0.1',
 			low: `${opacity.low}`,
 			full: '1',
 		},

--- a/@kiva/kv-tokens/package.json
+++ b/@kiva/kv-tokens/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "test": "echo No tests specified for @kiva/kv-tokens.",
         "lint": "eslint --ext .js ./",
-        "build": "echo No build needed for @kiva/kv-tokens."
+        "build": "node ./build/build.cjs"
     },
     "dependencies": {
         "@tailwindcss/typography": "^0.5.1",

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -67,8 +67,8 @@
 				"text": {
 					"primary": "#223829",
 					"primary-inverse": "#EDF4F1",
-					"secondary": "#757575",
-					"tertiary": "#9E9E9E",
+					"secondary": "#223829",
+					"tertiary": "#223829",
 					"action": "#276A43",
 					"action-highlight": "#223829",
 					"danger": "#E42A2A",
@@ -76,9 +76,9 @@
 				},
 				"background": {
 					"primary": "#FFFFFF",
-					"primary-inverse": "#000000",
-					"secondary": "#F5F5F5",
-					"tertiary": "#E0E0E0",
+					"primary-inverse": "#223829",
+					"secondary": "#EDF4F1",
+					"tertiary": "#FFFFFF",
 					"action": "#276A43",
 					"action-highlight": "#223829",
 					"danger": "#E42A2A",
@@ -87,10 +87,10 @@
 					"caution-highlight": "#D9BC3B"
 				},
 				"border": {
-					"primary": "#223829",
+					"primary": "#276A43",
 					"primary-inverse": "#EDF4F1",
-					"secondary": "#757575",
-					"tertiary": "#C4C4C4",
+					"secondary": "#78C79F",
+					"tertiary": "#FFFFFF",
 					"action": "#276A43",
 					"action-highlight": "#223829",
 					"danger": "#E42A2A",
@@ -102,20 +102,25 @@
 			},
 			"green-light": {
 				"background": {
-					"primary": "#EDF4F1"
+					"primary": "#EDF4F1",
+					"secondary": "#FFFFFF",
+					"tertiary": "#EDF4F1"
 				}
 			},
 			"green-dark": {
 				"text": {
 					"primary": "#F8F2E6",
-					"primary-inverse": "#593207",
-					"secondary": "#F8CD69",
+					"primary-inverse": "#223829",
+					"secondary": "#F8F2E6",
+					"tertiary": "#F8F2E6",
 					"action": "#F8CD69",
 					"action-highlight": "#F8F2E6"
 				},
 				"background": {
 					"primary": "#223829",
-					"secondary": "#276A43",
+					"primary-inverse": "#FFFFFF",
+					"secondary": "#EDF4F1",
+					"tertiary": "#223829",
 					"action": "#F8CD69",
 					"action-highlight": "#F8F2E6"
 				},
@@ -134,19 +139,26 @@
 				"text": {
 					"primary": "#593207",
 					"primary-inverse": "#F8F2E6",
+					"secondary": "#593207",
+					"tertiary": "#593207",
 					"action": "#996210",
 					"action-highlight": "#593207"
 				},
 				"background": {
 					"primary": "#F8F2E6",
-					"action": "#F4B539",
-					"action-highlight": "#F8CD69"
+					"primary-inverse": "#593207",
+					"secondary": "#FFFFFF",
+					"tertiary": "#F8CD69",
+					"action": "#996210",
+					"action-highlight": "#593207"
 				},
 				"border": {
-					"primary": "#593207",
+					"primary": "#996210",
 					"primary-inverse": "#F8F2E6",
-					"action": "#F8CD69",
-					"action-highlight": "#F8F2E6"
+					"secondary": "#F8CD69",
+					"tertiary": "#FFFFFF",
+					"action": "#996210",
+					"action-highlight": "#593207"
 				},
 				"heading-underline": {
 					"primary": "#F8CD69"
@@ -156,17 +168,24 @@
 				"text": {
 					"primary": "#2E271E",
 					"primary-inverse": "#F3F1EF",
+					"secondary": "#2E271E",
+					"tertiary": "#2E271E",
 					"action": "#635544",
 					"action-highlight": "#2E271E"
 				},
 				"background": {
 					"primary": "#F3F1EF",
+					"primary-inverse": "#2E271E",
+					"secondary": "#FFFFFF",
+					"tertiary": "#F3F1EF",
 					"action": "#635544",
 					"action-highlight": "#2E271E"
 				},
 				"border": {
-					"primary": "#2E271E",
+					"primary": "#635544",
 					"primary-inverse": "#F3F1EF",
+					"secondary": "#AA9E8D",
+					"tertiary": "#FFFFFF",
 					"action": "#635544",
 					"action-highlight": "#2E271E"
 				},
@@ -178,17 +197,24 @@
 				"text": {
 					"primary": "#F3F1EF",
 					"primary-inverse": "#2E271E",
+					"secondary": "#F3F1EF",
+					"tertiary": "#F3F1EF",
 					"action": "#DFD0BC",
 					"action-highlight": "#F3F1EF"
 				},
 				"background": {
 					"primary": "#2E271E",
+					"primary-inverse": "#F3F1EF",
+					"secondary": "#FFFFFF",
+					"tertiary": "#F3F1EF",
 					"action": "#DFD0BC",
 					"action-highlight": "#F3F1EF"
 				},
 				"border": {
 					"primary": "#F3F1EF",
-					"primary-inverse": "#2E271E",
+					"primary-inverse": "#635544",
+					"secondary": "#AA9E8D",
+					"tertiary": "#FFFFFF",
 					"action": "#DFD0BC",
 					"action-highlight": "#F3F1EF"
 				},

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -83,14 +83,14 @@
 					"action-highlight": "#223829",
 					"danger": "#A24536",
 					"danger-highlight": "#C45F4F",
-					"caution": "#E6CB55",
-					"caution-highlight": "#D9BC3B"
+					"caution": "#F8CD69",
+					"caution-highlight": "#F4B539"
 				},
 				"border": {
-					"primary": "#9E9E9E",
-					"primary-inverse": "#E0E0E0",
-					"secondary": "#276A43",
-					"tertiary": "#78C79F",
+					"primary": "#505050",
+					"primary-inverse": "#FFFFFF",
+					"secondary": "#757575",
+					"tertiary": "#C4C4C4",
 					"action": "#276A43",
 					"action-highlight": "#223829",
 					"danger": "#A24536",
@@ -112,23 +112,23 @@
 					"primary-inverse": "#223829",
 					"secondary": "#F8F2E6",
 					"tertiary": "#F8F2E6",
-					"action": "#F8CD69",
-					"action-highlight": "#F8F2E6"
+					"action": "#2AA967",
+					"action-highlight": "#78C79F"
 				},
 				"background": {
 					"primary": "#223829",
 					"primary-inverse": "#FFFFFF",
-					"secondary": "#EDF4F1",
-					"tertiary": "#223829",
-					"action": "#F8CD69",
-					"action-highlight": "#F8F2E6"
+					"secondary": "#276A43",
+					"tertiary": "#EDF4F1",
+					"action": "#2AA967",
+					"action-highlight": "#78C79F"
 				},
 				"border": {
 					"primary": "#F8F2E6",
 					"primary-inverse": "#593207",
 					"secondary": "#F8CD69",
-					"action": "#F8CD69",
-					"action-highlight": "#F8F2E6"
+					"action": "#2AA967",
+					"action-highlight": "#78C79F"
 				},
 				"heading-underline": {
 					"primary": "#F8CD69"

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -67,34 +67,34 @@
 				"text": {
 					"primary": "#223829",
 					"primary-inverse": "#EDF4F1",
-					"secondary": "#223829",
-					"tertiary": "#223829",
+					"secondary": "#757575",
+					"tertiary": "#9E9E9E",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#E42A2A",
-					"danger-highlight": "#CE2626"
+					"danger": "#A24536",
+					"danger-highlight": "#C45F4F"
 				},
 				"background": {
 					"primary": "#FFFFFF",
 					"primary-inverse": "#223829",
 					"secondary": "#EDF4F1",
-					"tertiary": "#FFFFFF",
+					"tertiary": "#C4C4C4",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#E42A2A",
-					"danger-highlight": "#CE2626",
+					"danger": "#A24536",
+					"danger-highlight": "#C45F4F",
 					"caution": "#E6CB55",
 					"caution-highlight": "#D9BC3B"
 				},
 				"border": {
-					"primary": "#276A43",
-					"primary-inverse": "#EDF4F1",
-					"secondary": "#78C79F",
-					"tertiary": "#FFFFFF",
+					"primary": "#9E9E9E",
+					"primary-inverse": "#E0E0E0",
+					"secondary": "#276A43",
+					"tertiary": "#78C79F",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#E42A2A",
-					"danger-highlight": "#CE2626"
+					"danger": "#A24536",
+					"danger-highlight": "#C45F4F"
 				},
 				"heading-underline": {
 					"primary": "#2AA967"
@@ -103,8 +103,7 @@
 			"green-light": {
 				"background": {
 					"primary": "#EDF4F1",
-					"secondary": "#FFFFFF",
-					"tertiary": "#EDF4F1"
+					"secondary": "#FFFFFF"
 				}
 			},
 			"green-dark": {

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -122,7 +122,7 @@
 				"background": {
 					"primary": "#223829",
 					"primary-inverse": "#FFFFFF",
-					"secondary": "#EDF4F1",
+					"secondary": "#276A43",
 					"tertiary": "#C4C4C4",
 					"action": "#78C79F",
 					"action-highlight": "#EDF4F1",
@@ -208,7 +208,7 @@
 				"background": {
 					"primary": "#2E271E",
 					"primary-inverse": "#F3F1EF",
-					"secondary": "#FFFFFF",
+					"secondary": "#635544",
 					"action": "#DFD0BC",
 					"action-highlight": "#F3F1EF",
 					"caution-highlight": "#F8F2E6",

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -71,8 +71,10 @@
 					"tertiary": "#9E9E9E",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#A24536",
-					"danger-highlight": "#C45F4F"
+					"caution": "#593207",
+					"caution-highlight": "#996210",
+					"danger": "#5C2A22",
+					"danger-highlight": "#A24536"
 				},
 				"background": {
 					"primary": "#FFFFFF",
@@ -81,10 +83,10 @@
 					"tertiary": "#C4C4C4",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#A24536",
-					"danger-highlight": "#C45F4F",
 					"caution": "#F8CD69",
-					"caution-highlight": "#F4B539"
+					"caution-highlight": "#F8F2E6",
+					"danger": "#E0988D",
+					"danger-highlight": "#F9F0EF"
 				},
 				"border": {
 					"primary": "#505050",
@@ -93,8 +95,10 @@
 					"tertiary": "#C4C4C4",
 					"action": "#276A43",
 					"action-highlight": "#223829",
-					"danger": "#A24536",
-					"danger-highlight": "#C45F4F"
+					"caution": "#F8CD69",
+					"caution-highlight": "#F8F2E6",
+					"danger": "#E0988D",
+					"danger-highlight": "#F9F0EF"
 				},
 				"heading-underline": {
 					"primary": "#2AA967"
@@ -108,38 +112,37 @@
 			},
 			"green-dark": {
 				"text": {
-					"primary": "#F8F2E6",
+					"primary": "#EDF4F1",
 					"primary-inverse": "#223829",
-					"secondary": "#F8F2E6",
-					"tertiary": "#F8F2E6",
-					"action": "#2AA967",
-					"action-highlight": "#78C79F"
+					"secondary": "#C4C4C4",
+					"tertiary": "#E0E0E0",
+					"action": "#78C79F",
+					"action-highlight": "#EDF4F1"
 				},
 				"background": {
 					"primary": "#223829",
 					"primary-inverse": "#FFFFFF",
-					"secondary": "#276A43",
-					"tertiary": "#EDF4F1",
-					"action": "#2AA967",
-					"action-highlight": "#78C79F"
+					"secondary": "#EDF4F1",
+					"tertiary": "#C4C4C4",
+					"action": "#78C79F",
+					"action-highlight": "#EDF4F1",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				},
 				"border": {
-					"primary": "#F8F2E6",
-					"primary-inverse": "#593207",
-					"secondary": "#F8CD69",
-					"action": "#2AA967",
-					"action-highlight": "#78C79F"
-				},
-				"heading-underline": {
-					"primary": "#F8CD69"
+					"primary": "#EDF4F1",
+					"primary-inverse": "#223829",
+					"secondary": "#276A43",
+					"action": "#78C79F",
+					"action-highlight": "#EDF4F1",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				}
 			},
 			"marigold-light": {
 				"text": {
 					"primary": "#593207",
 					"primary-inverse": "#F8F2E6",
-					"secondary": "#593207",
-					"tertiary": "#593207",
 					"action": "#996210",
 					"action-highlight": "#593207"
 				},
@@ -147,9 +150,11 @@
 					"primary": "#F8F2E6",
 					"primary-inverse": "#593207",
 					"secondary": "#FFFFFF",
-					"tertiary": "#F8CD69",
+					"tertiary": "#C4C4C4",
 					"action": "#996210",
-					"action-highlight": "#593207"
+					"action-highlight": "#593207",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				},
 				"border": {
 					"primary": "#996210",
@@ -157,7 +162,9 @@
 					"secondary": "#F8CD69",
 					"tertiary": "#FFFFFF",
 					"action": "#996210",
-					"action-highlight": "#593207"
+					"action-highlight": "#593207",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				},
 				"heading-underline": {
 					"primary": "#F8CD69"
@@ -167,8 +174,6 @@
 				"text": {
 					"primary": "#2E271E",
 					"primary-inverse": "#F3F1EF",
-					"secondary": "#2E271E",
-					"tertiary": "#2E271E",
 					"action": "#635544",
 					"action-highlight": "#2E271E"
 				},
@@ -176,7 +181,6 @@
 					"primary": "#F3F1EF",
 					"primary-inverse": "#2E271E",
 					"secondary": "#FFFFFF",
-					"tertiary": "#F3F1EF",
 					"action": "#635544",
 					"action-highlight": "#2E271E"
 				},
@@ -196,8 +200,8 @@
 				"text": {
 					"primary": "#F3F1EF",
 					"primary-inverse": "#2E271E",
-					"secondary": "#F3F1EF",
-					"tertiary": "#F3F1EF",
+					"secondary": "#C4C4C4",
+					"tertiary": "#E0E0E0",
 					"action": "#DFD0BC",
 					"action-highlight": "#F3F1EF"
 				},
@@ -205,17 +209,19 @@
 					"primary": "#2E271E",
 					"primary-inverse": "#F3F1EF",
 					"secondary": "#FFFFFF",
-					"tertiary": "#F3F1EF",
 					"action": "#DFD0BC",
-					"action-highlight": "#F3F1EF"
+					"action-highlight": "#F3F1EF",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				},
 				"border": {
 					"primary": "#F3F1EF",
-					"primary-inverse": "#635544",
-					"secondary": "#AA9E8D",
-					"tertiary": "#FFFFFF",
+					"primary-inverse": "#2E271E",
+					"secondary": "#635544",
 					"action": "#DFD0BC",
-					"action-highlight": "#F3F1EF"
+					"action-highlight": "#F3F1EF",
+					"caution-highlight": "#F8F2E6",
+					"danger-highlight": "#F9F0EF"
 				},
 				"heading-underline": {
 					"primary": "#AA9E8D"

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -40,7 +40,7 @@
 			"1": "#F8F2E6",
 			"2": "#F8CD69",
 			"DEFAULT": "#F4B539",
-			"3": "#AF741C",
+			"3": "#996210",
 			"4": "#593207"
 		},
 		"desert-rose": {
@@ -54,7 +54,7 @@
 			"1": "#F3F1EF",
 			"2": "#AA9E8D",
 			"DEFAULT": "#DFD0BC",
-			"3": "#726554",
+			"3": "#635544",
 			"4": "#2E271E"
 		},
 		"social": {
@@ -65,12 +65,12 @@
 		"theme": {
 			"DEFAULT": {
 				"text": {
-					"primary": "#212121",
-					"primary-inverse": "#F5F5F5",
+					"primary": "#223829",
+					"primary-inverse": "#EDF4F1",
 					"secondary": "#757575",
 					"tertiary": "#9E9E9E",
-					"action": "#2B7C5F",
-					"action-highlight": "#277056",
+					"action": "#276A43",
+					"action-highlight": "#223829",
 					"danger": "#E42A2A",
 					"danger-highlight": "#CE2626"
 				},
@@ -79,25 +79,121 @@
 					"primary-inverse": "#000000",
 					"secondary": "#F5F5F5",
 					"tertiary": "#E0E0E0",
-					"action": "#2B7C5F",
-					"action-highlight": "#277056",
+					"action": "#276A43",
+					"action-highlight": "#223829",
 					"danger": "#E42A2A",
 					"danger-highlight": "#CE2626",
 					"caution": "#E6CB55",
 					"caution-highlight": "#D9BC3B"
 				},
 				"border": {
-					"primary": "#212121",
-					"primary-inverse": "#FFFFFF",
+					"primary": "#223829",
+					"primary-inverse": "#EDF4F1",
 					"secondary": "#757575",
 					"tertiary": "#C4C4C4",
-					"action": "#2B7C5F",
-					"action-highlight": "#277056",
+					"action": "#276A43",
+					"action-highlight": "#223829",
 					"danger": "#E42A2A",
 					"danger-highlight": "#CE2626"
 				},
 				"heading-underline": {
 					"primary": "#2AA967"
+				}
+			},
+			"green-light": {
+				"background": {
+					"primary": "#EDF4F1"
+				}
+			},
+			"green-dark": {
+				"text": {
+					"primary": "#F8F2E6",
+					"primary-inverse": "#593207",
+					"secondary": "#F8CD69",
+					"action": "#F8CD69",
+					"action-highlight": "#F8F2E6"
+				},
+				"background": {
+					"primary": "#223829",
+					"secondary": "#276A43",
+					"action": "#F8CD69",
+					"action-highlight": "#F8F2E6"
+				},
+				"border": {
+					"primary": "#F8F2E6",
+					"primary-inverse": "#593207",
+					"secondary": "#F8CD69",
+					"action": "#F8CD69",
+					"action-highlight": "#F8F2E6"
+				},
+				"heading-underline": {
+					"primary": "#F8CD69"
+				}
+			},
+			"marigold-light": {
+				"text": {
+					"primary": "#593207",
+					"primary-inverse": "#F8F2E6",
+					"action": "#996210",
+					"action-highlight": "#593207"
+				},
+				"background": {
+					"primary": "#F8F2E6",
+					"action": "#F4B539",
+					"action-highlight": "#F8CD69"
+				},
+				"border": {
+					"primary": "#593207",
+					"primary-inverse": "#F8F2E6",
+					"action": "#F8CD69",
+					"action-highlight": "#F8F2E6"
+				},
+				"heading-underline": {
+					"primary": "#F8CD69"
+				}
+			},
+			"stone-light": {
+				"text": {
+					"primary": "#2E271E",
+					"primary-inverse": "#F3F1EF",
+					"action": "#635544",
+					"action-highlight": "#2E271E"
+				},
+				"background": {
+					"primary": "#F3F1EF",
+					"action": "#635544",
+					"action-highlight": "#2E271E"
+				},
+				"border": {
+					"primary": "#2E271E",
+					"primary-inverse": "#F3F1EF",
+					"action": "#635544",
+					"action-highlight": "#2E271E"
+				},
+				"heading-underline": {
+					"primary": "#AA9E8D"
+				}
+			},
+			"stone-dark": {
+				"text": {
+					"primary": "#F3F1EF",
+					"primary-inverse": "#2E271E",
+					"action": "#DFD0BC",
+					"action-highlight": "#F3F1EF"
+				},
+				"background": {
+					"primary": "#2E271E",
+					"action": "#DFD0BC",
+					"action-highlight": "#F3F1EF"
+				},
+				"border": {
+					"primary": "#F3F1EF",
+					"primary-inverse": "#2E271E",
+					"action": "#DFD0BC",
+					"action-highlight": "#F3F1EF"
+				},
+				"heading-underline": {
+					"primary": "#AA9E8D"
 				}
 			},
 			"dark": {

--- a/@kiva/kv-tokens/primitives.json
+++ b/@kiva/kv-tokens/primitives.json
@@ -263,35 +263,94 @@
 			},
 			"mint": {
 				"text": {
+					"primary": "#212121",
+					"primary-inverse": "#F5F5F5",
 					"secondary": "#228752",
-					"tertiary": "#28A062"
+					"tertiary": "#28A062",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				},
 				"background": {
-					"primary": "#95D4B3"
+					"primary": "#95D4B3",
+					"primary-inverse": "#000000",
+					"secondary": "#F5F5F5",
+					"tertiary": "#E0E0E0",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626",
+					"caution": "#E6CB55",
+					"caution-highlight": "#D9BC3B"
 				},
 				"border": {
-					"tertiary": "#4AB67E"
+					"primary": "#212121",
+					"tertiary": "#4AB67E",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				}
 			},
 			"dark-green": {
 				"text": {
 					"primary": "#F5F5F5",
 					"primary-inverse": "#212121",
-					"secondary": "#9E9E9E"
+					"secondary": "#9E9E9E",
+					"tertiary": "#9E9E9E",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				},
 				"background": {
 					"primary": "#2AA967",
 					"primary-inverse": "#F5F5F5",
-					"secondary": "#228752"
+					"secondary": "#228752",
+					"tertiary": "#E0E0E0",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626",
+					"caution": "#E6CB55",
+					"caution-highlight": "#D9BC3B"
+				},
+				"border": {
+					"primary": "#212121",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				}
 			},
 			"dark-mint": {
 				"text": {
 					"primary": "#FFFFFF",
-					"action": "#95D4B3"
+					"primary-inverse": "#F5F5F5",
+					"action": "#95D4B3",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				},
 				"background": {
-					"primary": "#454545"
+					"primary": "#454545",
+					"primary-inverse": "#000000",
+					"secondary": "#F5F5F5",
+					"tertiary": "#E0E0E0",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626",
+					"caution": "#E6CB55",
+					"caution-highlight": "#D9BC3B"
+				},
+				"border": {
+					"primary": "#212121",
+					"action": "#2B7C5F",
+					"action-highlight": "#277056",
+					"danger": "#E42A2A",
+					"danger-highlight": "#CE2626"
 				}
 			},
 			"dark-stone": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run build --workspaces",
     "prepare": "husky install",
     "publish-release": "lerna publish -m 'chore: publish'",
-    "storybook": "npm run storybook -w @kiva/kv-components",
+    "storybook": "npm run build -w @kiva/kv-tokens && npm run storybook -w @kiva/kv-components",
     "build-storybook": "npm run build-storybook -w @kiva/kv-components"
   },
   "devDependencies": {


### PR DESCRIPTION
Initial pass at ecosystem themes to create a working storybook link for refining theme tokens.

Includes:
- color updates for stone-3 and marigold-3
- underline styling for links
- updated default theme
- 5 new ecosystem-based themes
- tweaks to KvButton color classes for button variants
- tweaks to KvTextInput color classes

There is very limited usage of existing themes throughout the site. Where they are used, they are only used for their background color and text color, so this won't change how those sections appear. We will replace those usages in follow-up design-debt tasks.