### PR TITLE
feat: use kiva fork of treemap repo

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -72,7 +72,7 @@
     "nanoid": "^3.1.23",
     "numeral": "^2.0.6",
     "popper.js": "^1.16.1",
-    "treemap-squarify": "^1.0.1",
+    "treemap-squarify": "github:kiva/treemap",
     "vue-demi": "^0.14.7"
   },
   "peerDependencies": {

--- a/@kiva/kv-components/vue/KvTreeMapChart.vue
+++ b/@kiva/kv-components/vue/KvTreeMapChart.vue
@@ -43,7 +43,7 @@
 
 <script>
 import numeral from 'numeral';
-import treemap from 'treemap-squarify';
+import { getTreemap } from 'treemap-squarify';
 import kvTokensPrimitives from '@kiva/kv-tokens/primitives.json';
 import { throttle } from '../utils/throttle';
 import KvTooltip from './KvTooltip.vue';
@@ -100,7 +100,7 @@ export default {
 			}
 
 			// Calculate treemap blocks using canvas size 100x100 to easily translate to percentages
-			const blocks = treemap.getTreemap({
+			const blocks = getTreemap({
 				data: this.values,
 				width: 100,
 				height: 100,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2799,7 +2799,7 @@
         "nanoid": "^3.1.23",
         "numeral": "^2.0.6",
         "popper.js": "^1.16.1",
-        "treemap-squarify": "^1.0.1",
+        "treemap-squarify": "github:kiva/treemap",
         "vue-demi": "^0.14.7"
       },
       "devDependencies": {
@@ -43617,8 +43617,7 @@
     },
     "node_modules/treemap-squarify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/treemap-squarify/-/treemap-squarify-1.0.1.tgz",
-      "integrity": "sha512-+3jeoBCbQzk8o3YvBtUsQ97f+2x9K5CtEoE+z9Uua8czPko87i9gx8kUBQUplq6rQlRud0W9tp2+8A9q361+pg==",
+      "resolved": "git+ssh://git@github.com/kiva/treemap.git#22ae08c838b6472ed6f24183763bec16d6162cbb",
       "dependencies": {
         "@babel/polyfill": "^7.8.7"
       },
@@ -52667,7 +52666,7 @@
         "storybook": "7.6.20",
         "style-loader": "^3.3.4",
         "tailwindcss": "^3.4.3",
-        "treemap-squarify": "^1.0.1",
+        "treemap-squarify": "github:kiva/treemap",
         "vue": "2.6.14",
         "vue-demi": "^0.14.7",
         "vue-loader": "^15.9.6",
@@ -79121,9 +79120,8 @@
       "dev": true
     },
     "treemap-squarify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/treemap-squarify/-/treemap-squarify-1.0.1.tgz",
-      "integrity": "sha512-+3jeoBCbQzk8o3YvBtUsQ97f+2x9K5CtEoE+z9Uua8czPko87i9gx8kUBQUplq6rQlRud0W9tp2+8A9q361+pg==",
+      "version": "git+ssh://git@github.com/kiva/treemap.git#22ae08c838b6472ed6f24183763bec16d6162cbb",
+      "from": "treemap-squarify@github:kiva/treemap",
       "requires": {
         "@babel/polyfill": "^7.8.7"
       }


### PR DESCRIPTION
- Vite was having issues importing the treemap package in the `vue-3` branch of `ui`
- This uses a new fork I created of the treemap package that converts the package to the module type

https://github.com/kiva/treemap