### PR TITLE
fix: handle slide scale instead of img

### DIFF
--- a/@kiva/kv-components/vue/KvCarousel.vue
+++ b/@kiva/kv-components/vue/KvCarousel.vue
@@ -1,8 +1,8 @@
 <template>
 	<section
 		ref="rootEl"
-		class="kv-carousel tw-w-full"
-		:class="{ 'lg:tw-relative': asideControls, 'tw-overflow-hidden': !inCircle }"
+		class="kv-carousel tw-overflow-hidden tw-w-full"
+		:class="{ 'lg:tw-relative': asideControls }"
 		aria-label="carousel"
 	>
 		<!-- Carousel Content -->


### PR DESCRIPTION
Scaling the whole slide instead of the container and prevent overflow hidden in the main slide due to over scale