### PR TITLE
fix: pie chart not animating in vue 3

### DIFF
--- a/@kiva/kv-components/vue/KvPieChart.vue
+++ b/@kiva/kv-components/vue/KvPieChart.vue
@@ -23,7 +23,7 @@
 					v-for="(slice, index) in slices"
 					:key="index"
 					class="tw-origin-center tw-transition-transform"
-					:style="activeSlice === slice ? { transform: 'scale(1.1)' } : {}"
+					:style="isSliceActive(slice) ? { transform: 'scale(1.1)' } : {}"
 					:d="slice.path"
 					:stroke="slice.color"
 					:stroke-width="lineWidth"
@@ -174,7 +174,7 @@ export default {
 				const end = start + value.percent;
 				const [startX, startY] = circumPointFromAngle(cX, cY, r, start * Math.PI * 2);
 				let path = `M ${startX},${startY} `;
-				if (value.percent === 1) {
+				if (value.percent > 0.99) {
 					// Draw a full circle in two arcs
 					const [midX, midY] = circumPointFromAngle(cX, cY, r, (start + end) * Math.PI);
 					path += `A ${r},${r} 0 0,1 ${midX},${midY} `;
@@ -210,6 +210,10 @@ export default {
 			}
 		};
 
+		const isSliceActive = (slice) => {
+			return activeSlice.value === slice;
+		};
+
 		const setActiveSlice = (slice) => {
 			activeSlice.value = slice;
 			emit('click', slice.label);
@@ -228,6 +232,7 @@ export default {
 			pageCount,
 			prevPage,
 			nextPage,
+			isSliceActive,
 			setActiveSlice,
 		};
 	},


### PR DESCRIPTION
The `activeSlice === slice` comparison in the template works in Vue 2, but in Vue 3 `activeSlice` is actually a Ref of the slice and so `activeSlice.value` needs to be compared instead. For compatibility with Vue 2, I moved the comparison out of the template and into a method.

I also change the check for the large slice to be for slices larger than 99% rather than exactly 100%, to account for any rounding of numbers less than 100 that might result in the slice not displaying.