### PR TITLE
fix: activeSlice value isn't comparable because it's a Proxy, use toRaw

### DIFF
--- a/@kiva/kv-components/vue/KvPieChart.vue
+++ b/@kiva/kv-components/vue/KvPieChart.vue
@@ -97,7 +97,12 @@
 
 <script>
 import numeral from 'numeral';
-import { ref, toRefs, computed } from 'vue-demi';
+import {
+	ref,
+	toRaw,
+	toRefs,
+	computed,
+} from 'vue-demi';
 import Alea from '../utils/Alea';
 import KvLoadingPlaceholder from './KvLoadingPlaceholder.vue';
 
@@ -211,7 +216,7 @@ export default {
 		};
 
 		const isSliceActive = (slice) => {
-			return activeSlice.value === slice;
+			return toRaw(activeSlice.value) === slice;
 		};
 
 		const setActiveSlice = (slice) => {


### PR DESCRIPTION
Pie chart slice animation was still not working, due to vue 3 reference objects being Proxies. Vue provides the `toRaw` method to unwrap those proxies and access (but not modify) the original object. Confirmed working in UI with vue 3 locally.