### PR TITLE
fix: add tailwind config to kv-components exports

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -84,7 +84,11 @@
     "./dist/components/*.vue": {
       "import": "./dist/components/*.vue",
       "require": "./dist/components/*.vue"
-    }
+    },
+	"./tailwind.config.cjs": {
+	  "import": "./tailwind.config.cjs",
+	  "require": "./tailwind.config.cjs"
+	}
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.0.0-rc.1",


### PR DESCRIPTION
All files that can be imported from a package need to be declared in the package.json exports. the tailwind config is imported here https://github.com/kiva/ui/blob/main/tailwind.config.js#L1