### PR TITLE
feat(kv-tokens): generate scss variables from primitives.json during build

### DIFF
--- a/@kiva/kv-tokens/build/build.cjs
+++ b/@kiva/kv-tokens/build/build.cjs
@@ -1,5 +1,7 @@
 const fs = require('node:fs');
+const primitives = require('../primitives.json');
 const { generateExternalSVG } = require('../configs/kivaHeadingUnderline.cjs');
+const { flattenJSON } = require('../configs/util.cjs');
 
 // Note: dir is relative to the root of the kv-tokens package
 const dir = '../../dist/kvui';
@@ -12,3 +14,12 @@ if (!fs.existsSync(dir)) {
 // Generate Heading Underline SVG
 const svg = generateExternalSVG();
 fs.writeFileSync(`${dir}/heading-underline.svg`, svg);
+
+// Generate SCSS variables
+const today = new Date().toUTCString();
+const variables = flattenJSON(primitives);
+const scss = Object.keys(variables)
+	.map((key) => `$${key.toLowerCase().replace('.', '-')}: ${variables[key]};`)
+	.join('\n');
+const withComment = `// Do not edit directly.\n// Generated on ${today}. \n\n${scss}\n`;
+fs.writeFileSync(`${dir}/tw-exported-vars.scss`, withComment);

--- a/@kiva/kv-tokens/configs/util.cjs
+++ b/@kiva/kv-tokens/configs/util.cjs
@@ -20,9 +20,25 @@ const base64 = (str) => {
 	return window.btoa(str);
 };
 
+const flattenJSON = (obj, parentKey = '') => {
+	const flattened = {};
+
+	Object.keys(obj).forEach((key) => {
+		const newKey = parentKey ? `${parentKey}-${key}` : key;
+		if (typeof obj[key] === 'object') {
+			Object.assign(flattened, flattenJSON(obj[key], newKey));
+		} else {
+			flattened[newKey] = obj[key];
+		}
+	});
+
+	return flattened;
+};
+
 module.exports = {
 	rem,
 	em,
 	hexToRGB,
 	base64,
+	flattenJSON,
 };


### PR DESCRIPTION
This adds a script that generates this file for us https://github.com/kiva/kiva/blob/development/sites/www_kiva/styleguide/source/css/scss/tw-exported-vars.scss

Like other monolith styles, we'll need to manually update this file in the monolith when there are changes.