### PR TITLE
fix: preventDefault from undefined with showViewLoan and showLoanDeta…

### DIFF
--- a/@kiva/kv-components/vue/KvLendCta.vue
+++ b/@kiva/kv-components/vue/KvLendCta.vue
@@ -36,7 +36,7 @@
 			:to="!externalLinks ? readMorePath : undefined"
 			:href="externalLinks ? readMorePath : undefined"
 			class="tw-mb-0"
-			@click.native="$emit('show-loan-details', $event)"
+			@click="$emit('show-loan-details', $event)"
 		>
 			<span class="tw-flex">
 				View loan


### PR DESCRIPTION
…ils enabled

To reproduce enable `customLoanDetails`, `showViewLoan` and add a `showLoanDetails` method.

While working on showing sidesheet.. when clicking `View Loan` on homepage this error appeared 
`Cannot read properties of undefined (reading 'preventDefault') ` in clickReadMore because `event` was missing on the first  emit

https://github.com/kiva/kv-ui-elements/blob/6f19e0608b3be3b817bdca2908abdc6749746f9d/%40kiva/kv-components/utils/loanCard.js#L196