### PR TITLE
fix: height modal and not necessary fixed position

### DIFF
--- a/@kiva/kv-components/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/vue/KvSideSheet.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="visible"
-		class="tw-block tw-fixed lg:tw-mt-0 md:tw-absolute tw-inset-0
+		class="tw-block lg:tw-mt-0 tw-absolute tw-inset-0
             tw-bg-black tw-transition-all md:tw-duration-150 tw-z-modal"
 		:class="{
 			'tw-bg-opacity-0 tw-delay-300': !open,
@@ -172,7 +172,7 @@ export default {
 							top: '0',
 							left: '0',
 							width: '100vw',
-							height: '100vh',
+							height: '100%',
 							transition: 'all 0.5s ease-in-out',
 						};
 					}, 10);


### PR DESCRIPTION
While testing on https://github.com/kiva/cms-page-server/pull/1688, I realized we didn't need to set fixed for mobile since absolute was working ok and that ensures modal being shown bellow the navbar