### PR TITLE
fix: small side sheet fixes

### DIFF
--- a/@kiva/kv-components/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/vue/KvSideSheet.vue
@@ -11,10 +11,10 @@
 	>
 		<div
 			class="tw-absolute tw-right-0 tw-h-full tw-transition-all tw-duration-300 tw-bg-white
-				tw-overflow-hidden"
+				tw-overflow-hidden tw-p-2"
 			:class="{
-				'tw-w-0 tw-p-0 tw-delay-200 tw-opacity-0': !open,
-				'lg:tw-w-1/2 tw-w-full tw-p-2 tw-opacity-full': open,
+				'tw-w-0 tw-delay-200 tw-opacity-0': !open,
+				'lg:tw-w-1/2 tw-w-full tw-opacity-full': open,
 			}"
 			:style="modalStyles"
 		>

--- a/@kiva/kv-components/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/vue/KvSideSheet.vue
@@ -11,7 +11,7 @@
 	>
 		<div
 			class="tw-absolute tw-right-0 tw-h-full tw-transition-all tw-duration-300 tw-bg-white
-				tw-overflow-hidden tw-p-2"
+				tw-overflow-y-auto tw-p-2"
 			:class="{
 				'tw-w-0 tw-delay-200 tw-opacity-0': !open,
 				'lg:tw-w-1/2 tw-w-full tw-opacity-full': open,

--- a/@kiva/kv-components/vue/stories/KvSideSheet.stories.js
+++ b/@kiva/kv-components/vue/stories/KvSideSheet.stories.js
@@ -30,6 +30,7 @@ const Template = (args, {
 			>
 				<div>
 					Some content
+					<img src="https://www-kiva-org.freetls.fastly.net/img/w600h450/9673d0722a7675b9b8d11f90849d9b44.jpg" />
 				</div>
 			</kv-side-sheet>
 		</div>`,


### PR DESCRIPTION
- Smoothed side sheet animation slightly by removing changing padding
- Added y overflow in case content is larger than parent (content was hidden, for example, when testing in storybook with the image I added)