### PR TITLE
feat: add autoplay and fade plugin options for carousels

### DIFF
--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -71,6 +71,8 @@
     "change-case": "^4.1.2",
     "date-fns": "^2.30.0",
     "embla-carousel": "^8.5.1",
+    "embla-carousel-autoplay": "^8.5.1",
+    "embla-carousel-fade": "^8.5.1",
     "flag-icons": "^7.2.3",
     "focus-trap": "^6.7.2",
     "moment": "^2.29.4",

--- a/@kiva/kv-components/vue/KvCarousel.vue
+++ b/@kiva/kv-components/vue/KvCarousel.vue
@@ -181,6 +181,22 @@ export default {
 			},
 		},
 		/**
+		 * Options for the autoplay plugin - // https://www.embla-carousel.com/plugins/autoplay/#options
+		 * */
+		autoplayOptions: {
+			type: Object,
+			default() {
+				return {};
+			},
+		},
+		/**
+		 * Enable fade plugin - // https://www.embla-carousel.com/plugins/fade/
+		 * */
+		fadeEnabled: {
+			type: Boolean,
+			default: false,
+		},
+		/**
 		 * The type of logic to implement when deciding how many slides
 		 * to scroll when pressing the next/prev button
 		 * `visible, auto`
@@ -233,6 +249,7 @@ export default {
 			goToSlide,
 			handleUserInteraction,
 			isAriaHidden,
+			isAutoplaying,
 			nextIndex,
 			onCarouselContainerClick,
 			previousIndex,
@@ -242,6 +259,7 @@ export default {
 			slideIndicatorCount,
 			slideIndicatorListLength,
 			slides,
+			toggleAutoPlay,
 		} = carouselUtil(props, { emit, slots });
 
 		return {
@@ -251,6 +269,7 @@ export default {
 			goToSlide,
 			handleUserInteraction,
 			isAriaHidden,
+			isAutoplaying,
 			mdiArrowLeft,
 			mdiArrowRight,
 			mdiChevronLeft,
@@ -264,6 +283,7 @@ export default {
 			slideIndicatorCount,
 			slideIndicatorListLength,
 			slides,
+			toggleAutoPlay,
 		};
 	},
 };

--- a/@kiva/kv-components/vue/KvVerticalCarousel.vue
+++ b/@kiva/kv-components/vue/KvVerticalCarousel.vue
@@ -107,6 +107,22 @@ export default {
 			default: 'auto',
 			validator: (value) => ['visible', 'auto'].indexOf(value) !== -1,
 		},
+		/**
+		 * Options for the autoplay plugin - // https://www.embla-carousel.com/plugins/autoplay/#options
+		 * */
+		autoplayOptions: {
+			type: Object,
+			default() {
+				return {};
+			},
+		},
+		/**
+		 * Enable fade plugin - // https://www.embla-carousel.com/plugins/fade/
+		 * */
+		fadeEnabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	emits: [
 		'change',
@@ -120,6 +136,7 @@ export default {
 			goToSlide,
 			handleUserInteraction,
 			isAriaHidden,
+			isAutoplaying,
 			nextIndex,
 			onCarouselContainerClick,
 			previousIndex,
@@ -128,6 +145,7 @@ export default {
 			rootEl,
 			slideIndicatorCount,
 			slides,
+			toggleAutoPlay,
 		} = carouselUtil(props, { emit, slots }, { axis: 'y' });
 
 		return {
@@ -137,6 +155,7 @@ export default {
 			goToSlide,
 			handleUserInteraction,
 			isAriaHidden,
+			isAutoplaying,
 			mdiChevronDown,
 			mdiChevronUp,
 			nextIndex,
@@ -147,6 +166,7 @@ export default {
 			rootEl,
 			slideIndicatorCount,
 			slides,
+			toggleAutoPlay,
 		};
 	},
 };

--- a/@kiva/kv-components/vue/stories/KvCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvCarousel.stories.js
@@ -424,3 +424,81 @@ export const ThreeDimensional = () => ({
 		</kv-carousel>
 	`,
 });
+
+export const AutoPlayAutomatically = () => ({
+	components: {
+		KvCarousel,
+	},
+	template: `
+		<kv-carousel
+			style="max-width: 400px;"
+			:embla-options="{ loop: false }"
+			:autoplay-options="{ playOnInit: true, delay: 3000 }"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const AutoPlayButton = () => ({
+	components: {
+		KvCarousel,
+	},
+	data() {
+		return {
+			isPlaying: false,
+		};
+	},
+	mounted() {
+		this.$nextTick(() => {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		});
+	},
+	template: `
+		<div>
+			<kv-carousel
+				ref="sampleCarousel"
+				style="max-width: 400px;"
+				:embla-options="{ loop: false }"
+				:autoplay-options="{ playOnInit: true, delay: 3000 }"
+				@interact-carousel="carouselInteraction"
+			>
+				${defaultCarouselSlides}
+			</kv-carousel>
+			<a href="#" @click.native.prevent="toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
+			<br/>
+			<p>AutoPlay is: {{ isPlaying ? 'ON' : 'OFF' }}</p>
+		</div>
+	`,
+	methods: {
+		toggleAutoPlay() {
+			this.$refs.sampleCarousel.toggleAutoPlay();
+		},
+		carouselInteraction() {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		},
+	},
+});
+
+export const Fade = () => ({
+	components: {
+		KvCarousel,
+	},
+	mounted() {
+		this.$nextTick(() => {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		});
+	},
+	template: `
+		<div>
+			<kv-carousel
+				ref="sampleCarousel"
+				style="max-width: 400px;"
+				:embla-options="{ loop: false }"
+				:fade-enabled="true"
+			>
+				${defaultCarouselSlides}
+			</kv-carousel>
+		</div>
+	`,
+});

--- a/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
@@ -166,3 +166,81 @@ export const CustomStartIndex = () => ({
 		</kv-vertical-carousel>
 	`,
 });
+
+export const AutoPlayAutomatically = () => ({
+	components: {
+		KvVerticalCarousel,
+	},
+	template: `
+		<kv-vertical-carousel
+			style="max-width: 400px;"
+			:embla-options="{ loop: false }"
+			:autoplay-options="{ playOnInit: true, delay: 3000 }"
+		>
+			${defaultCarouselSlides}
+		</kv-vertical-carousel>
+	`,
+});
+
+export const AutoPlayButton = () => ({
+	components: {
+		KvVerticalCarousel,
+	},
+	data() {
+		return {
+			isPlaying: false,
+		};
+	},
+	mounted() {
+		this.$nextTick(() => {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		});
+	},
+	template: `
+		<div>
+			<kv-vertical-carousel
+				ref="sampleCarousel"
+				style="max-width: 400px;"
+				:embla-options="{ loop: false }"
+				:autoplay-options="{ playOnInit: true, delay: 3000 }"
+				@interact-carousel="carouselInteraction"
+			>
+				${defaultCarouselSlides}
+			</kv-vertical-carousel>
+			<a href="#" @click.native.prevent="toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
+			<br/>
+			<p>AutoPlay is: {{ isPlaying ? 'ON' : 'OFF' }}</p>
+		</div>
+	`,
+	methods: {
+		toggleAutoPlay() {
+			this.$refs.sampleCarousel.toggleAutoPlay();
+		},
+		carouselInteraction() {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		},
+	},
+});
+
+export const Fade = () => ({
+	components: {
+		KvVerticalCarousel,
+	},
+	mounted() {
+		this.$nextTick(() => {
+			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		});
+	},
+	template: `
+		<div>
+			<kv-vertical-carousel
+				ref="sampleCarousel"
+				style="max-width: 400px;"
+				:embla-options="{ loop: false }"
+				:fade-enabled="true"
+			>
+				${defaultCarouselSlides}
+			</kv-vertical-carousel>
+		</div>
+	`,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,6 +2239,8 @@
         "change-case": "^4.1.2",
         "date-fns": "^2.30.0",
         "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1",
         "flag-icons": "^7.2.3",
         "focus-trap": "^6.7.2",
         "moment": "^2.29.4",
@@ -17519,6 +17521,22 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.1.tgz",
       "integrity": "sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A=="
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.5.1.tgz",
+      "integrity": "sha512-FnZklFpePfp8wbj177UwVaGFehgs+ASVcJvYLWTtHuYKURynCc3IdDn2qrn0E5Qpa3g9yeGwCS4p8QkrZmO8xg==",
+      "peerDependencies": {
+        "embla-carousel": "8.5.1"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.5.1.tgz",
+      "integrity": "sha512-n7vRe2tsTW0vc0Xxtk3APoxhUSXIGh/lGRKYtBJS/SWDeXf9E3qVUst4MfHhwXaHlfu5PLqG3xIEDAr2gwbbNA==",
+      "peerDependencies": {
+        "embla-carousel": "8.5.1"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",


### PR DESCRIPTION
* Adds fade plugin -- initialized via `:fade-enabled="true"`
* Adds autoplay plugin initialized via: `:autoplay-options="{ playOnInit: true, delay: 3000 }"` (for example)

See stories for use, theres some trickyness to get the auto playing status and trigger autoplay outside of the carousel, mostly related to when the carousel is initialized and the fact that most carousel interactions actually pause the auto play behavior