### PR TITLE
fix: update font cdn url

### DIFF
--- a/@kiva/kv-tokens/configs/kivaTypography.cjs
+++ b/@kiva/kv-tokens/configs/kivaTypography.cjs
@@ -23,7 +23,7 @@ const webFonts = [
 			fontStyle: 'normal',
 			fontDisplay: 'swap',
 			// eslint-disable-next-line max-len
-			src: 'url(//www-kiva-org.freetls.fastly.net/static/fonts/PostGrotesk-Medium.8c8a585.woff2) format(\'woff2\')',
+			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-Medium.8c8a585.woff2) format(\'woff2\')',
 		},
 	},
 	// Note corresponding font weight in Tailwind is "normal"
@@ -34,7 +34,7 @@ const webFonts = [
 			fontStyle: 'italic',
 			fontDisplay: 'swap',
 			// eslint-disable-next-line max-len
-			src: 'url(//www-kiva-org.freetls.fastly.net/static/fonts/PostGrotesk-MediumItalic.133f41d.woff2) format(\'woff2\')',
+			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-MediumItalic.133f41d.woff2) format(\'woff2\')',
 		},
 	},
 	// Note corresponding font weight in Tailwind is "light"
@@ -44,7 +44,7 @@ const webFonts = [
 			fontWeight: '300',
 			fontStyle: 'normal',
 			fontDisplay: 'swap',
-			src: 'url(//www-kiva-org.freetls.fastly.net/static/fonts/PostGrotesk-Book.246fc8e.woff2) format(\'woff2\')',
+			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-Book.246fc8e.woff2) format(\'woff2\')',
 		},
 	},
 	// Note corresponding font weight in Tailwind is "light"
@@ -55,7 +55,7 @@ const webFonts = [
 			fontStyle: 'italic',
 			fontDisplay: 'swap',
 			// eslint-disable-next-line max-len
-			src: 'url(//www-kiva-org.freetls.fastly.net/static/fonts/PostGrotesk-BookItalic.4d06d39.woff2) format(\'woff2\')',
+			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-BookItalic.4d06d39.woff2) format(\'woff2\')',
 		},
 	},
 ];


### PR DESCRIPTION
UI and CPS are pre-loading fonts while using `https://www.kiva.org` as the cdn url. Because this config is still using the a different url (the fastly freetls url) for the cdn, the fonts are re-downloaded when the tailwind css is parsed. Making the urls match fixes this (confirmed locally with CPS).

I also found that UI is generating different font files now. This doesn't cause the same re-downloading issue, because on UI pages the tailwind css is placed first, so the UI font-face rules override the tailwind ones and the urls from the tailwind css are ignored. I think a good follow-up task to this is centralizing the font files and definitions in kv-tokens, but this quick fix will address the font re-downloading issue in CPS for now.