### PR TITLE
feat: add autoplay button if autoplay plugin is enabled

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -17,9 +17,9 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '20.x'
+        node-version: '18.x'
     - name: Install dependencies
-      run: npm ci --prefer-offline
+      run: npm ci
     - name: Build
       run: npm run build
     - name: Run Lint

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -17,9 +17,9 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --prefer-offline
     - name: Build
       run: npm run build
     - name: Run Lint

--- a/@kiva/kv-components/utils/carousels.js
+++ b/@kiva/kv-components/utils/carousels.js
@@ -22,6 +22,8 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 	const rootEl = ref(null);
 	const embla = ref(null);
 	const slides = ref([]);
+	const isAutoplaying = ref(false);
+
 	const startIndex = emblaOptions.value?.startIndex ?? 0;
 	const currentIndex = ref(startIndex);
 	// The indicator count may differ from the slide count when multiple slides are in view
@@ -63,6 +65,13 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 			await nextTick(); // wait for embla.
 			goToSlide(index);
 		}
+
+		/** Stop autoplay on user interaction */
+		const autoplay = embla.value?.plugins()?.autoplay;
+		if (autoplay) {
+			autoplay.stop();
+		}
+
 		/**
 		 * Fires when the user interacts with the carousel.
 		 * Contains the interaction type (swipe-left, click-left-arrow, etc.)
@@ -81,19 +90,8 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 		if (!autoplay) return;
 		const playOrStop = autoplay.isPlaying() ? autoplay.stop : autoplay.play;
 		playOrStop();
-		handleUserInteraction(null, 'autoplay');
 	};
 
-	/**
-	 * Returns true if the carousel is autoplaying
-	 *
-	 * @public This is a public method
-	 */
-	const isAutoplaying = () => {
-		const autoplay = embla.value?.plugins()?.autoplay;
-		if (!autoplay) return false;
-		return autoplay.isPlaying();
-	};
 	/**
 	 * Returns number of slides in the carousel
 	 *
@@ -198,10 +196,32 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 				emit('change', currentIndex);
 			});
 		});
+
+		embla?.value?.on('autoplay:play', () => {
+			console.log('autoplay:play');
+			/**
+			 * Fires when autoplay starts
+			 * @event autoplay-play
+			 * @type {Event}
+			 */
+			isAutoplaying.value = true;
+		});
+
+		embla?.value?.on('autoplay:stop', () => {
+			console.log('autoplay:stop');
+			/**
+			 * Fires when autoplay starts
+			 * @event autoplay-play
+			 * @type {Event}
+			 */
+			isAutoplaying.value = false;
+		});
 	});
 
 	onUnmounted(async () => {
 		embla?.value?.off('select');
+		embla?.value?.off('autoplay:play');
+		embla?.value?.off('autoplay:stop');
 		embla?.value?.destroy();
 	});
 

--- a/@kiva/kv-components/vue/KvVerticalCarousel.vue
+++ b/@kiva/kv-components/vue/KvVerticalCarousel.vue
@@ -29,40 +29,69 @@
 		<!-- Carousel Controls -->
 		<div
 			class="kv-carousel__controls tw-flex
-			tw-justify-between md:tw-justify-center tw-items-center tw-gap-2
-			tw-mt-2 tw-w-full"
+			tw-items-center tw-gap-2
+			tw-mt-2 tw-w-full
+			tw-justify-between md:tw-justify-center"
 		>
+			<div
+				class="tw-flex tw-gap-2 tw-w-full md:tw-w-auto"
+				:class="{'tw-justify-between md:tw-justify-center': !hasAutoplay}"
+			>
+				<button
+					class="tw-text-primary
+					tw-rounded-full
+					tw-border-2 tw-border-primary
+					tw-h-4 tw-w-4
+					tw-flex tw-items-center tw-justify-center
+					disabled:tw-opacity-low disabled:tw-cursor-default"
+					:disabled="embla && !embla.canScrollPrev()"
+					@click="handleUserInteraction(previousIndex, 'click-left-arrow')"
+				>
+					<kv-material-icon
+						class="tw-w-4"
+						:icon="mdiChevronUp"
+					/>
+					<span class="tw-sr-only">Show previous slide</span>
+				</button>
+				<button
+					class="tw-text-primary
+					tw-rounded-full
+					tw-border-2 tw-border-primary
+					tw-h-4 tw-w-4
+					tw-flex tw-items-center tw-justify-center
+					disabled:tw-opacity-low disabled:tw-cursor-default"
+					:disabled="embla && !embla.canScrollNext()"
+					@click="handleUserInteraction(nextIndex, 'click-right-arrow')"
+				>
+					<kv-material-icon
+						class="tw-w-4"
+						:icon="mdiChevronDown"
+					/>
+					<span class="tw-sr-only">Show next slide</span>
+				</button>
+			</div>
+
 			<button
+				v-if="hasAutoplay"
 				class="tw-text-primary
 					tw-rounded-full
 					tw-border-2 tw-border-primary
 					tw-h-4 tw-w-4
 					tw-flex tw-items-center tw-justify-center
 					disabled:tw-opacity-low disabled:tw-cursor-default"
-				:disabled="embla && !embla.canScrollPrev()"
-				@click="handleUserInteraction(previousIndex, 'click-left-arrow')"
+				@click.native.prevent="toggleAutoPlay()"
 			>
 				<kv-material-icon
+					v-if="isAutoplaying"
 					class="tw-w-4"
-					:icon="mdiChevronUp"
+					:icon="mdiPause"
+				/>
+				<kv-material-icon
+					v-else
+					class="tw-w-4"
+					:icon="mdiPlay"
 				/>
 				<span class="tw-sr-only">Show previous slide</span>
-			</button>
-			<button
-				class="tw-text-primary
-					tw-rounded-full
-					tw-border-2 tw-border-primary
-					tw-h-4 tw-w-4
-					tw-flex tw-items-center tw-justify-center
-					disabled:tw-opacity-low disabled:tw-cursor-default"
-				:disabled="embla && !embla.canScrollNext()"
-				@click="handleUserInteraction(nextIndex, 'click-right-arrow')"
-			>
-				<kv-material-icon
-					class="tw-w-4"
-					:icon="mdiChevronDown"
-				/>
-				<span class="tw-sr-only">Show next slide</span>
 			</button>
 		</div>
 	</div>
@@ -70,9 +99,15 @@
 
 <script>
 import {
+	toRefs,
+} from 'vue-demi';
+import {
+	mdiPause,
+	mdiPlay,
 	mdiChevronUp,
 	mdiChevronDown,
 } from '@mdi/js';
+import { computed } from 'vue';
 import { carouselUtil } from '../utils/carousels';
 import KvMaterialIcon from './KvMaterialIcon.vue';
 
@@ -130,6 +165,10 @@ export default {
 	],
 	setup(props, { emit, slots }) {
 		const {
+			autoplayOptions,
+		} = toRefs(props);
+
+		const {
 			componentSlotKeys,
 			currentIndex,
 			embla,
@@ -148,7 +187,12 @@ export default {
 			toggleAutoPlay,
 		} = carouselUtil(props, { emit, slots }, { axis: 'y' });
 
+		const hasAutoplay = computed(() => {
+			return Object.keys(autoplayOptions.value).length !== 0;
+		});
+
 		return {
+			hasAutoplay,
 			componentSlotKeys,
 			currentIndex,
 			embla,
@@ -156,6 +200,8 @@ export default {
 			handleUserInteraction,
 			isAriaHidden,
 			isAutoplaying,
+			mdiPause,
+			mdiPlay,
 			mdiChevronDown,
 			mdiChevronUp,
 			nextIndex,

--- a/@kiva/kv-components/vue/stories/KvCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvCarousel.stories.js
@@ -1,3 +1,4 @@
+import { watch } from 'vue';
 import KvCarousel from '../KvCarousel.vue';
 import KvLoadingSpinner from '../KvLoadingSpinner.vue';
 import KvButton from '../KvButton.vue';
@@ -444,14 +445,12 @@ export const AutoPlayButton = () => ({
 	components: {
 		KvCarousel,
 	},
-	data() {
-		return {
-			isPlaying: false,
-		};
-	},
+	data: () => ({
+		isAutoplaying: false,
+	}),
 	mounted() {
-		this.$nextTick(() => {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		watch(() => this.$refs?.sampleCarousel?.isAutoplaying, (newValue) => {
+			this.isAutoplaying = newValue;
 		});
 	},
 	template: `
@@ -461,33 +460,19 @@ export const AutoPlayButton = () => ({
 				style="max-width: 400px;"
 				:embla-options="{ loop: false }"
 				:autoplay-options="{ playOnInit: true, delay: 3000 }"
-				@interact-carousel="carouselInteraction"
 			>
 				${defaultCarouselSlides}
 			</kv-carousel>
-			<a href="#" @click.native.prevent="toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
+			<a href="#" @click.native.prevent="$refs.sampleCarousel.toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
 			<br/>
-			<p>AutoPlay is: {{ isPlaying ? 'ON' : 'OFF' }}</p>
+			<p>AutoPlay is: {{ isAutoplaying ? 'ON' : 'OFF' }}</p>
 		</div>
 	`,
-	methods: {
-		toggleAutoPlay() {
-			this.$refs.sampleCarousel.toggleAutoPlay();
-		},
-		carouselInteraction() {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
-		},
-	},
 });
 
 export const Fade = () => ({
 	components: {
 		KvCarousel,
-	},
-	mounted() {
-		this.$nextTick(() => {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
-		});
 	},
 	template: `
 		<div>

--- a/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
@@ -1,3 +1,4 @@
+import { watch } from 'vue';
 import KvVerticalCarousel from '../KvVerticalCarousel.vue';
 import KvButton from '../KvButton.vue';
 
@@ -186,14 +187,12 @@ export const AutoPlayButton = () => ({
 	components: {
 		KvVerticalCarousel,
 	},
-	data() {
-		return {
-			isPlaying: false,
-		};
-	},
+	data: () => ({
+		isAutoplaying: false,
+	}),
 	mounted() {
-		this.$nextTick(() => {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
+		watch(() => this.$refs?.sampleCarousel?.isAutoplaying, (newValue) => {
+			this.isAutoplaying = newValue;
 		});
 	},
 	template: `
@@ -203,33 +202,20 @@ export const AutoPlayButton = () => ({
 				style="max-width: 400px;"
 				:embla-options="{ loop: false }"
 				:autoplay-options="{ playOnInit: true, delay: 3000 }"
-				@interact-carousel="carouselInteraction"
 			>
 				${defaultCarouselSlides}
 			</kv-vertical-carousel>
-			<a href="#" @click.native.prevent="toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
+			<a href="#" @click.native.prevent="$refs.sampleCarousel.toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
 			<br/>
-			<p>AutoPlay is: {{ isPlaying ? 'ON' : 'OFF' }}</p>
+			<p>AutoPlay is: {{ isAutoplaying ? 'ON' : 'OFF' }}</p>
 		</div>
 	`,
-	methods: {
-		toggleAutoPlay() {
-			this.$refs.sampleCarousel.toggleAutoPlay();
-		},
-		carouselInteraction() {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
-		},
-	},
 });
 
+/** Fade really only works when the carousel displays 1 slide at a time, this story is wonky as expected */
 export const Fade = () => ({
 	components: {
 		KvVerticalCarousel,
-	},
-	mounted() {
-		this.$nextTick(() => {
-			this.isPlaying = this.$refs.sampleCarousel.isAutoplaying();
-		});
 	},
 	template: `
 		<div>


### PR DESCRIPTION
Adds play/pause button to vertical carousel.
Modify carousel functionality a bit to allow for:

- the play/pause button to work
- the ability to play/pause from outside the carousel
- the ability to read the play/pause state from outside the carousel

Mobile alignment of buttons:
![Screenshot 2025-01-08 at 12 08 51 PM](https://github.com/user-attachments/assets/9fc8aadf-c01d-4963-9ec3-35310bdb9fae)
![Screenshot 2025-01-08 at 12 08 46 PM](https://github.com/user-attachments/assets/0708dec6-2ea7-46b4-a256-f69f04ac6f65)
Desktop alignment of buttons:
![Screenshot 2025-01-08 at 12 08 34 PM](https://github.com/user-attachments/assets/b6be04ea-7cac-4a92-acf4-224560122b8c)

I did not add the play/pause button to the regular carousel. I'm not sure we have a design of where it should go. 