### PR TITLE
feat: make sure autoplay stops on carousel interactions

### DIFF
--- a/@kiva/kv-components/utils/carousels.js
+++ b/@kiva/kv-components/utils/carousels.js
@@ -57,6 +57,11 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 	 * @public This is a public method
 	 */
 	const goToSlide = (index) => {
+		/** Stop autoplay on go to slide interaction */
+		const autoplay = embla.value?.plugins()?.autoplay;
+		if (autoplay) {
+			autoplay.stop();
+		}
 		embla.value.scrollTo(index);
 	};
 
@@ -198,7 +203,6 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 		});
 
 		embla?.value?.on('autoplay:play', () => {
-			console.log('autoplay:play');
 			/**
 			 * Fires when autoplay starts
 			 * @event autoplay-play
@@ -208,7 +212,6 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 		});
 
 		embla?.value?.on('autoplay:stop', () => {
-			console.log('autoplay:stop');
 			/**
 			 * Fires when autoplay starts
 			 * @event autoplay-play

--- a/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
@@ -208,6 +208,7 @@ export const AutoPlayButton = () => ({
 			<a href="#" @click.native.prevent="$refs.sampleCarousel.toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
 			<br/>
 			<p>AutoPlay is: {{ isAutoplaying ? 'ON' : 'OFF' }}</p>
+			<a href="#" @click.native.prevent="$refs.sampleCarousel.goToSlide(0)">Go To Slide 0</a>
 		</div>
 	`,
 });


### PR DESCRIPTION
Ran into some more issues when trying to implement this. 

Embla docs say autoplay should stop by default on carousel interactions, but I found that to not be the case with our setup. This makes sure the autoplay stops when goToSlide is called, either from within the carousel itself or from external components. Also remove log statements