### PR TITLE
fix: carousel autoplay issues

### DIFF
--- a/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
+++ b/@kiva/kv-components/vue/stories/KvVerticalCarousel.stories.js
@@ -189,11 +189,17 @@ export const AutoPlayButton = () => ({
 	},
 	data: () => ({
 		isAutoplaying: false,
+		currentSlide: 0,
 	}),
 	mounted() {
 		watch(() => this.$refs?.sampleCarousel?.isAutoplaying, (newValue) => {
 			this.isAutoplaying = newValue;
 		});
+	},
+	methods: {
+		changeEvent(index) {
+			this.currentSlide = index;
+		},
 	},
 	template: `
 		<div>
@@ -202,6 +208,7 @@ export const AutoPlayButton = () => ({
 				style="max-width: 400px;"
 				:embla-options="{ loop: false }"
 				:autoplay-options="{ playOnInit: true, delay: 3000 }"
+				@change="changeEvent"
 			>
 				${defaultCarouselSlides}
 			</kv-vertical-carousel>
@@ -209,6 +216,60 @@ export const AutoPlayButton = () => ({
 			<br/>
 			<p>AutoPlay is: {{ isAutoplaying ? 'ON' : 'OFF' }}</p>
 			<a href="#" @click.native.prevent="$refs.sampleCarousel.goToSlide(0)">Go To Slide 0</a>
+			<p>Current Slide: {{ currentSlide }}</p>
+		</div>
+	`,
+});
+
+export const AutoPlayWithDynamicSlides = () => ({
+	components: {
+		KvVerticalCarousel,
+	},
+	data: () => ({
+		isAutoplaying: false,
+		currentSlide: 0,
+	}),
+	mounted() {
+		watch(() => this.$refs?.sampleCarousel?.isAutoplaying, (newValue) => {
+			this.isAutoplaying = newValue;
+		});
+	},
+	methods: {
+		changeEvent(index) {
+			this.currentSlide = index;
+		},
+	},
+	template: `
+		<div>
+			<kv-vertical-carousel
+				ref="sampleCarousel"
+				style="max-width: 400px;"
+				:embla-options="{ loop: false }"
+				:autoplay-options="{ playOnInit: true, delay: 3000 }"
+				@change="changeEvent"
+			>
+					<template #slide1 >
+						<img src="https://placehold.co/400x150/${randomHexColor(1)}/000000">
+						<p style="background-color: #${randomHexColor(1)};" v-if="currentSlide === 0" >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+					</template>
+					<template #slide2>
+						<img src="https://placehold.co/400x150/${randomHexColor(2)}/000000">
+						<p style="background-color: #${randomHexColor(2)};" v-if="currentSlide === 1">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+					</template>
+					<template #slide3>
+						<img src="https://placehold.co/400x150/${randomHexColor(3)}/000000">
+						<p style="background-color: #${randomHexColor(3)};" v-if="currentSlide === 2">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+					</template>
+					<template #slide4>
+						<img src="https://placehold.co/400x150/${randomHexColor(4)}/000000">
+						<p style="background-color: #${randomHexColor(4)};" v-if="currentSlide === 3">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+					</template>
+			</kv-vertical-carousel>
+			<a href="#" @click.native.prevent="$refs.sampleCarousel.toggleAutoPlay()" role="toggleAutoPlayButton">Toggle AutoPlay</a>
+			<br/>
+			<p>AutoPlay is: {{ isAutoplaying ? 'ON' : 'OFF' }}</p>
+			<a href="#" @click.native.prevent="$refs.sampleCarousel.goToSlide(0)">Go To Slide 0</a>
+			<p>Current Slide: {{ currentSlide }}</p>
 		</div>
 	`,
 });


### PR DESCRIPTION
I had a hard time getting autoplay to work in the context of our impact-dashboard globe. This fixes those issues. 

1. Remove `clickAllowed` method - this was deprecated in embla here: https://github.com/davidjerleke/embla-carousel/releases/tag/v8.0.0-rc01 - embla now handles this automatically. 

2. Remove extra autoplay stop code in `handleUserInteraction` - We just need this in the `goToSlide` function

3. Create a story to replicate issue on impact dashboard, add fixes for this scenario

The Issue:
The problem has to do with the way the slides in the impact-dashboard change dimensions when selected. When the slide dimensions are changed, embla now automatically fires a reInit event. When the carousel was reInit, the autoplay `playOnInit` setting was reset to whatever the initial value was. So the flow of events would be: 

```
1. Carousel Starts Playing, playOnInit: true. 
2. User Pauses autoplay. 
3. User changes to the next slide. 
4. Embla changes the slide, reInits the carousel, 
5. Carousel starts auto playing again. 
```

Now we are listening to the slide selection event, and preemptively setting the playOnInit setting to whatever the current play status is. 