### PR TITLE
fix: click events after removal of clickAllowed

### DIFF
--- a/@kiva/kv-components/utils/carousels.js
+++ b/@kiva/kv-components/utils/carousels.js
@@ -126,13 +126,7 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 		slides.value = embla.value.slideNodes();
 		slideIndicatorListLength();
 	};
-	const onCarouselContainerClick = (e) => {
-		// If we're dragging, block click handlers within slides
-		if (embla.value) {
-			e.preventDefault();
-			e.stopPropagation();
-		}
-	};
+
 	/**
 	 * If the slide is not completely in view in the carousel
 	 * it should be aria-hidden
@@ -250,7 +244,6 @@ export function carouselUtil(props, { emit, slots }, extraEmblaOptions) {
 		goToSlide,
 		reInit,
 		reInitVisible,
-		onCarouselContainerClick,
 		isAriaHidden,
 		isAutoplaying,
 		slideIndicatorListLength,

--- a/@kiva/kv-components/vue/KvCarousel.vue
+++ b/@kiva/kv-components/vue/KvCarousel.vue
@@ -12,7 +12,6 @@
 				'tw-mx-auto aside-controls-content': asideControls,
 				'circle-carousel': inCircle
 			}"
-			@click.capture="onCarouselContainerClick"
 		>
 			<div
 				v-for="(slotName, index) in componentSlotKeys"
@@ -251,7 +250,6 @@ export default {
 			isAriaHidden,
 			isAutoplaying,
 			nextIndex,
-			onCarouselContainerClick,
 			previousIndex,
 			reInit,
 			reInitVisible,
@@ -275,7 +273,6 @@ export default {
 			mdiChevronLeft,
 			mdiChevronRight,
 			nextIndex,
-			onCarouselContainerClick,
 			previousIndex,
 			reInit,
 			reInitVisible,

--- a/@kiva/kv-components/vue/KvVerticalCarousel.vue
+++ b/@kiva/kv-components/vue/KvVerticalCarousel.vue
@@ -9,7 +9,6 @@
 			<div
 				class="tw-flex tw-flex-col"
 				:style="`height: ${heightStyle}`"
-				@click.capture="onCarouselContainerClick"
 			>
 				<div
 					v-for="(slotName, index) in componentSlotKeys"
@@ -177,7 +176,6 @@ export default {
 			isAriaHidden,
 			isAutoplaying,
 			nextIndex,
-			onCarouselContainerClick,
 			previousIndex,
 			reInit,
 			reInitVisible,
@@ -205,7 +203,6 @@ export default {
 			mdiChevronDown,
 			mdiChevronUp,
 			nextIndex,
-			onCarouselContainerClick,
 			previousIndex,
 			reInit,
 			reInitVisible,


### PR DESCRIPTION
I removed clickAllowed from onCarouselContainerClick but now the clicks arent triggering inside the slides. Embla now handles what was our `onCarouselContainerClick` logic, so we can just remove all of this to get clicks working again. 