### PR TITLE
fix(kv-components): include import line for component css files

### DIFF
--- a/@kiva/kv-components/build/libCss.js
+++ b/@kiva/kv-components/build/libCss.js
@@ -1,0 +1,59 @@
+import { writeFileSync } from 'node:fs';
+import {
+	basename,
+	dirname,
+	relative,
+	resolve,
+} from 'node:path';
+
+let viteConfig;
+
+export default function libCss() {
+	return {
+		name: 'lib-css',
+		apply: 'build',
+		enforce: 'post',
+
+		// Get Vite config when it's resolved to use later
+		configResolved(config) {
+			viteConfig = config;
+		},
+
+		// Write css import statements to files with imported css after bundle is created
+		writeBundle(option, bundle) {
+			// Only run for es format in library mode
+			if (!viteConfig.build?.lib || option.format !== 'es') {
+				return;
+			}
+
+			const { root } = viteConfig;
+			const { outDir } = viteConfig.build;
+			const cssReplaceRegex = /\/\* empty css \s*\*\//;
+			const files = Object.keys(bundle);
+
+			// Find files with imported css
+			const filesWithImportedCss = files.filter((file) => bundle[file].viteMetadata?.importedCss?.size > 0);
+
+			// Replace empty css comment with css import statement in each file
+			filesWithImportedCss.forEach((file) => {
+				if (bundle[file].viteMetadata.importedCss.size > 1) {
+					console.warn(`Multiple css file imports not supported yet, skipping ${file}`);
+					return;
+				}
+
+				// Get css import path relative to current file
+				const [cssPath] = bundle[file].viteMetadata.importedCss;
+				const cssImportPath = relative(dirname(file), cssPath);
+
+				// Add prefix for current directory to css import path if necessary
+				const prefix = cssImportPath === basename(cssPath) ? './' : '';
+
+				// Replace empty css comment with css import statement
+				const fileContent = bundle[file].code.replace(cssReplaceRegex, `import "${prefix}${cssImportPath}";`);
+
+				// Write updated file content
+				writeFileSync(resolve(root, outDir, file), fileContent);
+			});
+		},
+	};
+}

--- a/@kiva/kv-components/vite.config.js
+++ b/@kiva/kv-components/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import libAssetsPlugin from '@laynezh/vite-plugin-lib-assets'
 import noBundlePlugin from 'vite-plugin-no-bundle';
 import vue from '@vitejs/plugin-vue';
+import libCss from './build/libCss';
 
 export default defineConfig({
 	resolve: {
@@ -54,5 +55,7 @@ export default defineConfig({
 			outputPath: 'kvui',
 			publicUrl: 'https://www.kiva.org/',
 		}),
+		// Ensure component css is imported into the final build
+		libCss(),
 	],
 });


### PR DESCRIPTION
Vite library mode does not include imports for generated css files (see https://github.com/vitejs/vite/issues/1579), and instead requires library users to manually import every needed css file. This PR avoids that by using a custom vite plugin to replace the placeholder comment for the css file with an import line. The plugin is based on the various plugins that have already been created to deal with this issue, but tailored for our needs.