### PR TITLE
fix: sidesheet width on mobile after adding loan to basket

### DIFF
--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -192,7 +192,7 @@ export default {
 					setTimeout(() => {
 						modalStyles.value = {
 							top: '0',
-							width: '100vw',
+							width: '100%',
 							height: '100%',
 							transition: 'all 0.5s ease-in-out',
 						};


### PR DESCRIPTION
Odd behavior when adding a loan, happens when changes to a small width on mobile

Issue:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/f32960f4-8a4f-4779-a64a-a04261cdda8e" />
