### PR TITLE
fix: hide preset amount when adding loan to basket

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -60,7 +60,7 @@
 				data-testid="bp-lend-cta-select-and-button"
 			>
 				<div
-					v-if="showPresetAmounts"
+					v-if="showPresetAmounts && !isAdding"
 					class="tw-flex tw-gap-1 lg:tw-gap-2"
 					:class="{'tw-flex-wrap md:tw-flex-nowrap': enableHugeAmount}"
 				>
@@ -441,7 +441,7 @@ export default {
 		isLendAmountButton() {
 			return ((this.lendButtonVisibility || this.state === 'lent-to')
 				&& this.isAmountLessThan25(this.unreservedAmount))
-				|| (this.showPresetAmounts && this.presetButtonsPrices.length === 1);
+				|| (this.showPresetAmounts && this.presetButtonsPrices.length === 1 && !this.isAdding);
 		},
 		isFunded() {
 			return this.state === 'funded' || this.state === 'fully-reserved';


### PR DESCRIPTION
Fix issue when adding to basket for single options
<img width="370" alt="image" src="https://github.com/user-attachments/assets/bfc28621-0a5b-438b-b8fc-ce1fd5dfee25" />
<img width="347" alt="image" src="https://github.com/user-attachments/assets/a9ebd556-491d-4ef6-89dc-167c801fde50" />

