### PR TITLE
fix: gap from fieldset when adding state in showPresetAmount variant

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -55,7 +55,10 @@
 		>
 			<fieldset
 				class="tw-w-full tw-flex"
-				:class="{'tw-flex-col tw-gap-1.5 md:tw-flex-row md:tw-justify-between': showPresetAmounts}"
+				:class="{
+					'tw-flex-col md:tw-flex-row md:tw-justify-between': showPresetAmounts,
+					'tw-gap-1.5': showPresetAmounts && !isLendAmountButton
+				}"
 				:disabled="isAdding"
 				data-testid="bp-lend-cta-select-and-button"
 			>


### PR DESCRIPTION
Single option is not full width because of gap

<img width="227" alt="image" src="https://github.com/user-attachments/assets/95852623-1e43-48eb-9dd0-aa44f3996a97" /> 
