### PR TITLE
feat: add metadata input to donation mutation

### DIFF
--- a/@kiva/kv-shop/src/basketItems.ts
+++ b/@kiva/kv-shop/src/basketItems.ts
@@ -4,6 +4,7 @@ import { callShopMutation } from './shopQueries';
 
 export interface SetTipDonationOptions {
 	amount: string | number,
+	metadata?: string | null,
 	apollo: ApolloClient<any>,
 }
 
@@ -14,29 +15,32 @@ export interface SetTipDonationData {
 			id: string,
 			price: string,
 			isTip: boolean,
+			metadata: string | null,
 		} | null,
 	} | null,
 }
 
-export async function setTipDonation({ amount, apollo }: SetTipDonationOptions) {
+export async function setTipDonation({ amount, apollo, metadata }: SetTipDonationOptions) {
 	const donationAmount = numeral(amount).format('0.00');
 	const data = await callShopMutation<SetTipDonationData>(apollo, {
 		awaitRefetchQueries: true,
-		mutation: gql`mutation setTipDonation($price: Money!, $basketId: String) {
+		mutation: gql`mutation setTipDonation($price: Money!, $basketId: String, $metadata: String) {
 			shop (basketId: $basketId) {
 				id
 				updateDonation (donation: {
 					price: $price,
-					isTip: true
+					isTip: true,
+					metadata: $metadata,
 				})
 				{
 					id
 					price
 					isTip
+					metadata
 				}
 			}
 		}`,
-		variables: { price: donationAmount },
+		variables: { price: donationAmount, metadata },
 	});
 
 	return data?.shop?.updateDonation;

--- a/@kiva/kv-shop/src/tests/basketItems.spec.ts
+++ b/@kiva/kv-shop/src/tests/basketItems.spec.ts
@@ -21,6 +21,18 @@ describe('basketItem.ts', () => {
 		expect(donation).toEqual({ id: 123 });
 	});
 
+	it('should set tip donation with metadata', async () => {
+		const apollo = new MockApolloClient({ data: { shop: { updateDonation: { id: 123 } } } });
+		const donation = await setTipDonation({ amount: 25, metadata: 'test metadata', apollo });
+		expect(apollo.mutate).toHaveBeenCalledWith({
+			mutation: expect.anything(),
+			awaitRefetchQueries: true,
+			refetchQueries: expect.anything(),
+			variables: { basketId: '', price: '25.00', metadata: 'test metadata' },
+		});
+		expect(donation).toEqual({ id: 123 });
+	});
+
 	it('retry then throw an error for missing baskets', async () => {
 		const apollo = new MockApolloClient({ data: {}, errors: [{ code: 'shop.basketRequired' }] });
 		expect(setTipDonation({ amount: 25, apollo })).rejects.toThrow('There was a problem with your basket.');


### PR DESCRIPTION
Adds new input to this mutation which will allow us to "tag" donations with a metadata string. 


