### PR TITLE
fix: can't query metadata in response

### DIFF
--- a/@kiva/kv-shop/src/basketItems.ts
+++ b/@kiva/kv-shop/src/basketItems.ts
@@ -36,7 +36,6 @@ export async function setTipDonation({ amount, apollo, metadata }: SetTipDonatio
 					id
 					price
 					isTip
-					metadata
 				}
 			}
 		}`,


### PR DESCRIPTION
Getting a ""message": "Cannot query field \"metadata\" on type \"Donation\"."," 

Which I see we aren't adding it to the response. Which is fine, I don't need the metadata on the response. 