### PR TITLE
build: faster chromatic github action builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,3 +32,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test --workspaces",
     "build": "rimraf dist && npm run build --workspaces",
     "prepare": "husky install",
-    "publish-release": "lerna publish -m 'chore: publish'",
+    "publish-release": "lerna publish -m 'chore: publish [skip ci]'",
     "prepare-storybook": "npm run build -w @kiva/kv-tokens && npm run prebuild -w @kiva/kv-components",
     "prestorybook": "npm run prepare-storybook",
     "storybook": "npm run storybook -w @kiva/kv-components",


### PR DESCRIPTION
- Added exitOnceUploaded, as noted in the latest chromatic builds:
> ℹ Speed up Continuous Integration
Your project is linked to GitHub so Chromatic will report results there.
This means you can pass the --exit-once-uploaded flag to skip waiting for build results.
Read more here: https://www.chromatic.com/docs/cli#chromatic-options

- Added `[skip ci]` to publish commit message to avoid extra chromatic builds