### PR TITLE
fix: use commonjs braintree dropin instead of amd browser build

### DIFF
--- a/@kiva/kv-shop/src/useBraintreeDropIn.ts
+++ b/@kiva/kv-shop/src/useBraintreeDropIn.ts
@@ -125,7 +125,7 @@ function initBraintreeDropin(): DropInWrapper {
 		paypalFlow = 'checkout',
 	}: DropInInitOptions) {
 		formattedAmount = numeral(amount).format('0.00');
-		const { default: DropIn } = await import('braintree-web-drop-in');
+		const { default: DropIn } = await import('braintree-web-drop-in/index.js');
 
 		try {
 			instance = await (DropIn.create({

--- a/@kiva/kv-shop/vite.config.ts
+++ b/@kiva/kv-shop/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
 		noBundlePlugin({
 			// Dependencies that should be included in the final build. Update package.json bundleDependencies when changing this list.
 			internal: [
-				'braintree-web-drop-in',
+				'braintree-web-drop-in/index.js',
 			],
 		}),
 		// Ensure component css is imported into the final build


### PR DESCRIPTION
Trying to address this error from the dropin import line:
> Cannot destructure property 'default' of '(intermediate value)' as it is undefined.