### PR TITLE
fix(kv-shop): require braintree-web-drop-in as a peer dependency

### DIFF
--- a/@kiva/kv-shop/package.json
+++ b/@kiva/kv-shop/package.json
@@ -51,10 +51,8 @@
         "@apollo/client": "3.x",
         "@kiva/kv-analytics": "1.x",
         "@kiva/kv-components": "5 || 6",
+        "braintree-web-drop-in": "1.x",
         "numeral": "2.x",
         "vue": "3.x"
-    },
-    "bundleDependencies": [
-        "braintree-web-drop-in"
-    ]
+    }
 }

--- a/@kiva/kv-shop/vite.config.ts
+++ b/@kiva/kv-shop/vite.config.ts
@@ -34,12 +34,7 @@ export default defineConfig({
 		// Support Vue 3 single-file components
 		vue(),
 		// Make the output match the src file structure instead of bundling into one large file
-		noBundlePlugin({
-			// Dependencies that should be included in the final build. Update package.json bundleDependencies when changing this list.
-			internal: [
-				'braintree-web-drop-in/index.js',
-			],
-		}),
+		noBundlePlugin(),
 		// Ensure component css is imported into the final build
 		vueLibCss(),
 		// Generate type declarations for the final build


### PR DESCRIPTION
Main issue seen on the donate page appears to be from running vite/rollup twice on kv-shop (once in this repo for the node module, and a second time in CPS or UI). Exports are renamed but where they are imported is not renamed. Confirmed that forcing CPS to build the drop-in instead resolves the issue.

We probably could have stuck with tsup and just changed the braintree import line to `await import('braintree-web-drop-in/index.js')` to resolve the original issue we encountered when using the drop-in locally 🤷 