### PR TITLE
fix: fix for braintree drop in error in local dev

### DIFF
--- a/@kiva/kv-shop/src/useBraintreeDropIn.ts
+++ b/@kiva/kv-shop/src/useBraintreeDropIn.ts
@@ -6,6 +6,14 @@ import type { ApplePayPaymentRequest } from 'braintree-web';
 import type { Dropin, PaymentMethodPayload } from 'braintree-web-drop-in';
 import { ShopError, parseShopError } from './shopError';
 
+declare global {
+	interface Window {
+		braintree?: {
+			dropin: typeof import('braintree-web-drop-in');
+		};
+	}
+}
+
 export type PaymentType = 'card' | 'paypal' | 'paypalCredit' | 'venmo' | 'applePay' | 'googlePay';
 export type PayPalFlowType = 'checkout' | 'vault';
 
@@ -125,10 +133,11 @@ function initBraintreeDropin(): DropInWrapper {
 		paypalFlow = 'checkout',
 	}: DropInInitOptions) {
 		formattedAmount = numeral(amount).format('0.00');
-		const { default: DropIn } = await import('braintree-web-drop-in/index.js');
+		const { default: DropIn } = await import('braintree-web-drop-in');
 
+		const dropinInstance = window?.braintree?.dropin || DropIn;
 		try {
-			instance = await (DropIn.create({
+			instance = await (dropinInstance.create({
 				authorization: authToken,
 				container,
 				dataCollector: {


### PR DESCRIPTION
I tested this in CPS by editing the file in my node modules/@kiva/kv-shop there directly, this seems to work. I also ran the build in kv-ui-elements and that also builds fine. 

@emuvente Thoughts on this? Seems a bit silly that the fix is so minor. Am I missing anything here? Is there any way to test the build version in CPS more directly? 