### PR TITLE
fix: remove important from placeholder size classes

### DIFF
--- a/@kiva/kv-components/src/vue/KvUserAvatar.vue
+++ b/@kiva/kv-components/src/vue/KvUserAvatar.vue
@@ -141,7 +141,7 @@ export default {
 		});
 
 		const onImgLoad = () => {
-			// isLoading.value = false;
+			isLoading.value = false;
 		};
 
 		return {


### PR DESCRIPTION
- removing the !important from placeholder, this causing conflicts in thanks page overwritting size
- onMounted fix didn't work as expected, passing imageRef to handle if image is present