### PR TITLE
feat: add secondary button text with show presets

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -431,7 +431,7 @@ export default {
 			}
 		},
 		loanInBasketButtonText() {
-			return this.showPresetAmounts ? 'Continue to basket' : this.secondaryButtonText;
+			return this.secondaryButtonText ? this.secondaryButtonText : 'Continue to basket';
 		},
 		useFormSubmit() {
 			if (this.hideShowLendDropdown


### PR DESCRIPTION
For the in-context BP in the impact dashboard, we want to use the `showPresetAmounts` and also show the secondary button text, this is not possible at the moment. 

I looked around the codebase for uses of showPresetAmounts and I believe this is a safe change to make. 