### PR TITLE
Revert "feat: add secondary button text with show presets"

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -431,7 +431,7 @@ export default {
 			}
 		},
 		loanInBasketButtonText() {
-			return this.secondaryButtonText ? this.secondaryButtonText : 'Continue to basket';
+			return this.showPresetAmounts ? 'Continue to basket' : this.secondaryButtonText;
 		},
 		useFormSubmit() {
 			if (this.hideShowLendDropdown


### PR DESCRIPTION
Reverts kiva/kv-ui-elements#545

Actually `this.secondaryButtonText`  always has a default value, so this will prevent `Continue to basket` from ever showing. My bad