### PR TITLE
feat: change secondary text logic on lendcta

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -315,7 +315,7 @@ export default {
 		},
 		secondaryButtonText: {
 			type: String,
-			default: 'Checkout now',
+			default: undefined,
 		},
 		secondaryButtonHandler: {
 			type: Function,
@@ -431,7 +431,11 @@ export default {
 			}
 		},
 		loanInBasketButtonText() {
-			return this.showPresetAmounts ? 'Continue to basket' : this.secondaryButtonText;
+			if (this.secondaryButtonText) {
+				return this.secondaryButtonText;
+			}
+
+			return this.showPresetAmounts ? 'Continue to basket' : 'Checkout now';
 		},
 		useFormSubmit() {
 			if (this.hideShowLendDropdown


### PR DESCRIPTION
Ok trying this again. 

if secondaryButtonText prop value exists, always return that, else, show `'Continue to basket'` if showPresets, or `'Checkout now'` if no showPresets
