### PR TITLE
feat: ignore kvuseravatar in chromatic

### DIFF
--- a/@kiva/kv-components/src/vue/.storybook/preview.js
+++ b/@kiva/kv-components/src/vue/.storybook/preview.js
@@ -24,6 +24,7 @@ export const parameters = {
 			order: ['Base Styling', '*'],
 		},
 	},
+	chromatic: { ignoreSelectors: ['#kv-user-avatar'] },
 }
 
 // Listen for events from the dark mode plugin

--- a/@kiva/kv-components/src/vue/KvUserAvatar.vue
+++ b/@kiva/kv-components/src/vue/KvUserAvatar.vue
@@ -1,5 +1,6 @@
 <template>
 	<div
+		id="kv-user-avatar"
 		class="data-hj-suppress tw-flex"
 		:class="{ 'tw-w-3': isSmall, 'tw-w-6': !isSmall }"
 	>


### PR DESCRIPTION
I noticed any PR is generating a lot of excessive diffs in chromatic. This is mostly due to KvUserAvatar using random colors for the user letter and circle background, so all stories that use that component will generate diffs in every PR. 

This will ignore the random color/backgrounds for the purposes of chromatics diff. 

Note, a diff will still be generated if the avatar changes in size

https://www.chromatic.com/docs/ignoring-elements/