### PR TITLE
feat: initial work to add additional possible filters coming through …

### DIFF
--- a/@kiva/kv-loan-filters/src/city.ts
+++ b/@kiva/kv-loan-filters/src/city.ts
@@ -1,0 +1,39 @@
+export const facetsKey = 'city';
+
+export const stateKey = 'city';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.city?.length && { city: { any: loanSearchState.city } }),
+	}),
+	getValidatedSearchState: (loanSearchState, allFacets) => ({
+		city: loanSearchState?.city?.filter((c) => allFacets?.city?.includes(c)) ?? [],
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/@kiva/kv-loan-filters/src/daysUntilExpiration.ts
+++ b/@kiva/kv-loan-filters/src/daysUntilExpiration.ts
@@ -1,0 +1,59 @@
+import { getMinMaxRangeFilter, createMinMaxRange } from './minMaxRangeUtils';
+
+/**
+ * The min daysUntilExpiration value
+ */
+export const MIN = 0;
+
+/**
+ * The max daysUntilExpiration value
+ */
+export const MAX = 45;
+
+export const facetsKey = 'daysUntilExpiration';
+
+export const stateKey = 'daysUntilExpiration';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ({ min: MIN, max: MAX, step: 1 }),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.daysUntilExpiration && {
+			daysUntilExpiration: { range: getMinMaxRangeFilter(loanSearchState.daysUntilExpiration) },
+		}),
+	}),
+	getValidatedSearchState: (loanSearchState) => {
+		const min = loanSearchState?.daysUntilExpiration?.min ?? MIN;
+		const max = loanSearchState?.daysUntilExpiration?.max ?? MAX;
+		return {
+			daysUntilExpiration: loanSearchState?.daysUntilExpiration
+				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
+				: null,
+		};
+	},
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/@kiva/kv-loan-filters/src/loanAmount.ts
+++ b/@kiva/kv-loan-filters/src/loanAmount.ts
@@ -1,0 +1,59 @@
+import { getMinMaxRangeFilter, createMinMaxRange } from './minMaxRangeUtils';
+
+/**
+ * The min risk rating value
+ */
+export const MIN = 25;
+
+/**
+ * The max risk rating value
+ */
+export const MAX = 1000000;
+
+export const facetsKey = 'loanAmount';
+
+export const stateKey = 'loanAmount';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ({ min: MIN, max: MAX, step: 25 }),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.loanAmount && {
+			loanAmount: { range: getMinMaxRangeFilter(loanSearchState.loanAmount) },
+		}),
+	}),
+	getValidatedSearchState: (loanSearchState) => {
+		const min = loanSearchState?.loanAmount?.min ?? MIN;
+		const max = loanSearchState?.loanAmount?.max ?? MAX;
+		return {
+			partnerRiskRating: loanSearchState?.loanAmount
+				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
+				: null,
+		};
+	},
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/@kiva/kv-loan-filters/src/loanAmount.ts
+++ b/@kiva/kv-loan-filters/src/loanAmount.ts
@@ -49,7 +49,7 @@ export default {
 		const min = loanSearchState?.loanAmount?.min ?? MIN;
 		const max = loanSearchState?.loanAmount?.max ?? MAX;
 		return {
-			partnerRiskRating: loanSearchState?.loanAmount
+			loanAmount: loanSearchState?.loanAmount
 				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
 				: null,
 		};

--- a/@kiva/kv-loan-filters/src/loanAmount.ts
+++ b/@kiva/kv-loan-filters/src/loanAmount.ts
@@ -1,12 +1,12 @@
 import { getMinMaxRangeFilter, createMinMaxRange } from './minMaxRangeUtils';
 
 /**
- * The min risk rating value
+ * The min loanAmount value
  */
 export const MIN = 25;
 
 /**
- * The max risk rating value
+ * The max loanAmount value
  */
 export const MAX = 1000000;
 

--- a/@kiva/kv-loan-filters/src/postalCode.ts
+++ b/@kiva/kv-loan-filters/src/postalCode.ts
@@ -1,0 +1,39 @@
+export const facetsKey = 'postalCode';
+
+export const stateKey = 'postalCode';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.postalCode?.length && { postalCode: { any: loanSearchState.postalCode } }),
+	}),
+	getValidatedSearchState: (loanSearchState, allFacets) => ({
+		postalCode: loanSearchState?.postalCode?.filter((c) => allFacets?.postalCode?.includes(c)) ?? [],
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/@kiva/kv-loan-filters/src/state.ts
+++ b/@kiva/kv-loan-filters/src/state.ts
@@ -1,0 +1,39 @@
+export const facetsKey = 'state';
+
+export const stateKey = 'state';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.state?.length && { state: { any: loanSearchState.state } }),
+	}),
+	getValidatedSearchState: (loanSearchState, allFacets) => ({
+		state: loanSearchState?.state?.filter((c) => allFacets?.state?.includes(c)) ?? [],
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/@kiva/kv-loan-filters/src/tests/city.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/city.spec.ts
@@ -1,0 +1,34 @@
+import city from '../city';
+import { mockAllFacets } from './fixtures/mockLoanSearchData';
+
+describe('city.ts', () => {
+	describe('default', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(city.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(city.getFlssFilter({ city: [] })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(city.getFlssFilter({ city: ['test'] })).toEqual({ city: { any: ['test'] } });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				expect(city.getValidatedSearchState(undefined, mockAllFacets)).toEqual({ city: [] });
+			});
+
+			it('should handle missing', () => {
+				expect(city.getValidatedSearchState({}, mockAllFacets)).toEqual({ city: [] });
+			});
+
+			it('should return value', () => {
+				expect(city.getValidatedSearchState({ city: ['Atlanta'] }, mockAllFacets)).toEqual({ city: ['Atlanta'] });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/daysUntilExpiration.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/daysUntilExpiration.spec.ts
@@ -1,0 +1,36 @@
+import daysUntilExpiration, { MIN, MAX } from '../daysUntilExpiration';
+
+describe('daysUntilExpiration.ts', () => {
+	describe('default', () => {
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				const result = daysUntilExpiration.getValidatedSearchState({});
+
+				expect(result).toEqual({ daysUntilExpiration: null });
+			});
+
+			it('should validate risk rating', () => {
+				const state = { daysUntilExpiration: { min: 0, max: 45 } };
+
+				const result = daysUntilExpiration.getValidatedSearchState(state);
+
+				expect(result).toEqual({ daysUntilExpiration: { min: MIN, max: MAX, __typename: 'MinMaxRange' } });
+			});
+		});
+
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(daysUntilExpiration.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(daysUntilExpiration.getFlssFilter({ daysUntilExpiration: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(daysUntilExpiration.getFlssFilter({ daysUntilExpiration: { min: 5, max: 12, __typename: 'MinMaxRange' } }))
+					.toEqual({ daysUntilExpiration: { range: { gte: 5, lte: 12 } } });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
+++ b/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
@@ -27,6 +27,7 @@ export const savedSearchParams = {
 };
 
 export const mockAllFacets = {
+	city: ['Atlanta', 'Boston'],
 	countryFacets: [
 		{
 			country: {
@@ -111,6 +112,8 @@ export const mockAllFacets = {
 	],
 	partnerIds: [1, 2, 3],
 	partnerNames: ['AAA', 'BBB', 'CCC'],
+	state: ['Georgia', 'California'],
+	postalCode: ['30301', '90210'],
 	categoryIds: [28],
 };
 

--- a/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
+++ b/@kiva/kv-loan-filters/src/tests/fixtures/mockLoanSearchData.ts
@@ -114,6 +114,7 @@ export const mockAllFacets = {
 	partnerNames: ['AAA', 'BBB', 'CCC'],
 	state: ['Georgia', 'California'],
 	postalCode: ['30301', '90210'],
+	trusteeId: [1, 2],
 	categoryIds: [28],
 };
 

--- a/@kiva/kv-loan-filters/src/tests/loanAmount.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/loanAmount.spec.ts
@@ -1,0 +1,36 @@
+import loanAmount, { MIN, MAX } from '../loanAmount';
+
+describe('loanAmount.ts', () => {
+	describe('default', () => {
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				const result = loanAmount.getValidatedSearchState({});
+
+				expect(result).toEqual({ loanAmount: null });
+			});
+
+			it('should validate risk rating', () => {
+				const state = { loanAmount: { min: 25, max: 1000000 } };
+
+				const result = loanAmount.getValidatedSearchState(state);
+
+				expect(result).toEqual({ loanAmount: { min: MIN, max: MAX, __typename: 'MinMaxRange' } });
+			});
+		});
+
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(loanAmount.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(loanAmount.getFlssFilter({ loanAmount: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(loanAmount.getFlssFilter({ loanAmount: { min: 25, max: 50, __typename: 'MinMaxRange' } }))
+					.toEqual({ loanAmount: { range: { gte: 25, lte: 50 } } });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/postalCode.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/postalCode.spec.ts
@@ -1,0 +1,34 @@
+import postalCode from '../postalCode';
+import { mockAllFacets } from './fixtures/mockLoanSearchData';
+
+describe('postalCode.ts', () => {
+	describe('default', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(postalCode.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(postalCode.getFlssFilter({ postalCode: [] })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(postalCode.getFlssFilter({ postalCode: [1] })).toEqual({ postalCode: { any: [1] } });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				expect(postalCode.getValidatedSearchState(undefined, mockAllFacets)).toEqual({ postalCode: [] });
+			});
+
+			it('should handle missing', () => {
+				expect(postalCode.getValidatedSearchState({}, mockAllFacets)).toEqual({ postalCode: [] });
+			});
+
+			it('should return value', () => {
+				expect(postalCode.getValidatedSearchState({ postalCode: ['90210'] }, mockAllFacets)).toEqual({ postalCode: ['90210'] });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/state.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/state.spec.ts
@@ -1,0 +1,34 @@
+import state from '../state';
+import { mockAllFacets } from './fixtures/mockLoanSearchData';
+
+describe('state.ts', () => {
+	describe('default', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(state.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(state.getFlssFilter({ state: [] })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(state.getFlssFilter({ state: ['test'] })).toEqual({ state: { any: ['test'] } });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				expect(state.getValidatedSearchState(undefined, mockAllFacets)).toEqual({ state: [] });
+			});
+
+			it('should handle missing', () => {
+				expect(state.getValidatedSearchState({}, mockAllFacets)).toEqual({ state: [] });
+			});
+
+			it('should return value', () => {
+				expect(state.getValidatedSearchState({ state: ['California'] }, mockAllFacets)).toEqual({ state: ['California'] });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/tests/trusteeId.spec.ts
+++ b/@kiva/kv-loan-filters/src/tests/trusteeId.spec.ts
@@ -1,0 +1,34 @@
+import trusteeId from '../trusteeId';
+import { mockAllFacets } from './fixtures/mockLoanSearchData';
+
+describe('trusteeId.ts', () => {
+	describe('default', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(trusteeId.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(trusteeId.getFlssFilter({ trusteeId: [] })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(trusteeId.getFlssFilter({ trusteeId: [2] })).toEqual({ trusteeId: { any: [2] } });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				expect(trusteeId.getValidatedSearchState(undefined, mockAllFacets)).toEqual({ trusteeId: [] });
+			});
+
+			it('should handle missing', () => {
+				expect(trusteeId.getValidatedSearchState({}, mockAllFacets)).toEqual({ trusteeId: [] });
+			});
+
+			it('should return value', () => {
+				expect(trusteeId.getValidatedSearchState({ trusteeId: [2] }, mockAllFacets)).toEqual({ trusteeId: [2] });
+			});
+		});
+	});
+});

--- a/@kiva/kv-loan-filters/src/trusteeId.ts
+++ b/@kiva/kv-loan-filters/src/trusteeId.ts
@@ -29,12 +29,10 @@ export default {
 	getRemovedFacet: () => ({}),
 	getSavedSearch: () => ({}),
 	getFlssFilter: (loanSearchState) => ({
-		...(loanSearchState?.trusteeId?.length && { city: { any: loanSearchState.trusteeId } }),
+		...(loanSearchState?.trusteeId?.length && { trusteeId: { any: loanSearchState.trusteeId } }),
 	}),
-	getValidatedSearchState: (loanSearchState) => ({
-		// Don't worry about validating the filter for now against available facets
-		// We don't display the filter in the UI and only pass it through for baseline campaign searches
-		trusteeId: loanSearchState?.trusteeId ?? [],
+	getValidatedSearchState: (loanSearchState, allFacets) => ({
+		trusteeId: loanSearchState?.trusteeId?.filter((c) => allFacets?.trusteeId?.includes(c)) ?? [],
 	}),
 	getFilterFromQuery: () => ({}),
 	getQueryFromFilter: () => ({}),

--- a/@kiva/kv-loan-filters/src/trusteeId.ts
+++ b/@kiva/kv-loan-filters/src/trusteeId.ts
@@ -1,0 +1,41 @@
+export const facetsKey = 'state';
+
+export const stateKey = 'trusteeId';
+
+export const getUiConfig = (options) => ({
+	type: undefined,
+	hasAccordion: undefined,
+	topLine: false,
+	bottomLine: false,
+	title: undefined,
+	shouldDisplayTitle: false,
+	itemHeaderKey: undefined,
+	placeholder: undefined,
+	facetsKey,
+	stateKey,
+	eventAction: undefined,
+	allOptionsTitle: undefined,
+	valueMap: undefined,
+	isPercentage: false,
+	displayedUnit: undefined,
+	...options,
+});
+
+export default {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+	getOptions: (allFacets: any = {}, filteredFacets: any = {}) => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: (loanSearchState) => ({
+		...(loanSearchState?.trusteeId?.length && { city: { any: loanSearchState.trusteeId } }),
+	}),
+	getValidatedSearchState: (loanSearchState) => ({
+		// Don't worry about validating the filter for now against available facets
+		// We don't display the filter in the UI and only pass it through for baseline campaign searches
+		trusteeId: loanSearchState?.trusteeId ?? [],
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};


### PR DESCRIPTION
…campaign saved searches

There are several new potential filter values that could be present in the category/saved-search associted with campaign contexts. In order to continue using our loan filter interfaces, these definitions need to exist when the loanSearchState validation method is called.

Note: I think I've got all the new definitions here but am still working on some additional tests.