### PR TITLE
feat: add a prop to limit amounts shown in presets

### DIFF
--- a/@kiva/kv-components/src/vue/stories/KvLendCta.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvLendCta.stories.js
@@ -265,6 +265,30 @@ export const WithPresetOptionsLessThan200 = story({
 	showPresetAmounts: true,
 });
 
+export const WithPresetOptionsMaxAmount25 = story({
+	isLoading: false,
+	loan: {
+		id: 1,
+		borrowerCount: 2,
+	},
+	unreservedAmount: '525.00',
+	maxAmount: '25.00',
+	kvTrackFunction,
+	showPresetAmounts: true,
+});
+
+export const WithPresetOptionsMaxAmountMore = story({
+	isLoading: false,
+	loan: {
+		id: 1,
+		borrowerCount: 2,
+	},
+	unreservedAmount: '525.00',
+	maxAmount: '90.00',
+	kvTrackFunction,
+	showPresetAmounts: true,
+});
+
 export const WithPresetOptionsHugeAmount = story({
 	isLoading: false,
 	loan: {


### PR DESCRIPTION
Add yet another prop to this component. 

If max amount is set, only display amounts less than that in the presets. Examples: 

![Screenshot 2025-04-28 at 3 23 34 PM](https://github.com/user-attachments/assets/f4c685f5-8981-436f-bcef-edde39db999d)

___________________________________________________________________________________
![Screenshot 2025-04-28 at 3 23 44 PM](https://github.com/user-attachments/assets/51debd7d-e1d3-4cc3-9fea-04f8bae41c7c)
