### PR TITLE
feat: use Alea to get consistent 'random' value for loan callouts and user avatars

### DIFF
--- a/@kiva/kv-components/src/utils/imageUtils.js
+++ b/@kiva/kv-components/src/utils/imageUtils.js
@@ -1,3 +1,5 @@
+import Alea from './Alea';
+
 /**
  * Determines if the users avatar is the default legacy placeholder image from the monolith.
  * The legacy avatars are found exclusively at the following urls:
@@ -28,7 +30,8 @@ export function isLegacyPlaceholderAvatar(filename) {
  * Returns a class string to style a user avatar
  * @returns Random user avatar class string
  */
-export function randomizedUserAvatarClass() {
+export function randomizedUserAvatarClass(displayName = '') {
+	const rng = new Alea(displayName);
 	const userCardStyleOptions = [
 		{ color: 'tw-text-action', bg: 'tw-bg-brand-100' },
 		{ color: 'tw-text-black', bg: 'tw-bg-brand-100' },
@@ -38,6 +41,6 @@ export function randomizedUserAvatarClass() {
 		{ color: 'tw-text-white', bg: 'tw-bg-black' },
 		{ color: 'tw-text-action', bg: 'tw-bg-black' },
 	];
-	const randomStyle = userCardStyleOptions[Math.floor(Math.random() * userCardStyleOptions.length)];
+	const randomStyle = userCardStyleOptions[Math.floor(rng() * userCardStyleOptions.length)];
 	return `${randomStyle.color} ${randomStyle.bg}`;
 }

--- a/@kiva/kv-components/src/utils/loanCard.js
+++ b/@kiva/kv-components/src/utils/loanCard.js
@@ -4,8 +4,8 @@ import {
 	computed,
 	toRefs,
 } from 'vue';
-
 import { mdiMapMarker } from '@mdi/js';
+import Alea from './Alea';
 
 const LSE_LOAN_KEY = 'N/A';
 const ECO_FRIENDLY_KEY = 'ECO-FRIENDLY';
@@ -124,6 +124,7 @@ export function loanCardComputedProperties(props, hideUnitedStatesText = false) 
 
 	const loanCallouts = computed(() => {
 		const callouts = [];
+		const rng = new Alea(loanId.value, fundraisingPercent.value);
 
 		const activityName = loan.value?.activity?.name ?? '';
 		const activityId = loan.value?.activity?.id ?? null;
@@ -148,7 +149,7 @@ export function loanCardComputedProperties(props, hideUnitedStatesText = false) 
 		// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents
 		// Tag as first option for LSE loans
 		if (isLseLoan && tags.length) {
-			const position = Math.floor(Math.random() * tags.length);
+			const position = Math.floor(rng() * tags.length);
 			const p1Tag = tags[position];
 			const tagData = findCalloutData(tagsData, p1Tag);
 			const id = tagData?.id ?? null;
@@ -183,7 +184,7 @@ export function loanCardComputedProperties(props, hideUnitedStatesText = false) 
 
 		// P4 Tag
 		if (!!tags.length && callouts.length < 2) {
-			const position = Math.floor(Math.random() * tags.length);
+			const position = Math.floor(rng() * tags.length);
 			const p4Tag = tags[position];
 			const tagData = findCalloutData(tagsData, p4Tag);
 			const id = tagData?.id ?? null;
@@ -194,7 +195,7 @@ export function loanCardComputedProperties(props, hideUnitedStatesText = false) 
 
 		// P5 Theme
 		if (!!themes.length && callouts.length < 2) {
-			const position = Math.floor(Math.random() * themes.length);
+			const position = Math.floor(rng() * themes.length);
 			const theme = themes[position];
 			const themeData = findCalloutData(themesData, theme);
 			const id = themeData?.id ?? null;

--- a/@kiva/kv-components/src/vue/.storybook/preview.js
+++ b/@kiva/kv-components/src/vue/.storybook/preview.js
@@ -24,7 +24,6 @@ export const parameters = {
 			order: ['Base Styling', '*'],
 		},
 	},
-	chromatic: { ignoreSelectors: ['#kv-user-avatar'] },
 }
 
 // Listen for events from the dark mode plugin

--- a/@kiva/kv-components/src/vue/KvUserAvatar.vue
+++ b/@kiva/kv-components/src/vue/KvUserAvatar.vue
@@ -130,7 +130,7 @@ export default {
 
 		const avatarClass = () => {
 			const smallClass = isSmall?.value ? 'tw-w-3 tw-h-3 tw-text-h4' : 'tw-w-6 tw-h-6 tw-text-h2';
-			return `${randomizedUserAvatarClass()} ${smallClass}`;
+			return `${randomizedUserAvatarClass(lenderName.value)} ${smallClass}`;
 		};
 
 		const imageFilename = computed(() => {

--- a/@kiva/kv-components/src/vue/KvUserAvatar.vue
+++ b/@kiva/kv-components/src/vue/KvUserAvatar.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		id="kv-user-avatar"
 		class="data-hj-suppress tw-flex"
 		:class="{ 'tw-w-3': isSmall, 'tw-w-6': !isSmall }"
 	>

--- a/@kiva/kv-components/src/vue/stories/KvMap.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvMap.stories.js
@@ -16,6 +16,13 @@ export default {
 		zoomLevel: 4,
 		advancedAnimation: {},
 	},
+	parameters: {
+		chromatic: {
+			// Default threshold is 0.63 (0 is most strict, 1 is least strict)
+			// Increase threshold to 0.75 to allow for more variation in the map
+			diffThreshold: 0.75,
+		},
+	},
 };
 
 const Template = (templateArgs, { argTypes }) => ({

--- a/@kiva/kv-components/tests/unit/specs/utils/imageUtils.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/utils/imageUtils.spec.js
@@ -25,5 +25,11 @@ describe('imageUtils.ts', () => {
 			expect(class1).toContain('tw-text-');
 			expect(class1).toContain('tw-bg-');
 		});
+
+		it('should return same classes for same displayName', () => {
+			expect(randomizedUserAvatarClass('test')).toBe(randomizedUserAvatarClass('test'));
+			expect(randomizedUserAvatarClass('test2')).toBe(randomizedUserAvatarClass('test2'));
+			expect(randomizedUserAvatarClass('Lender')).toBe(randomizedUserAvatarClass('Lender'));
+		});
 	});
 });


### PR DESCRIPTION
Making these methods use consistent 'random' values avoids client-side hydration mis-matches caused by different random values returned on the server and the client. This will also make the stories using loan callouts and user avatars consistent, so they will no longer show up as false-positives in chromatic.

The end result is that users will have a consistent avatar instead of it changing on every page load, and loan cards will only display different random callouts when their fundraising progress changes.