### PR TITLE
feat: make sidesheet back button optional

### DIFF
--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -29,8 +29,11 @@
 						'tw-opacity-full': open,
 					}"
 				>
-					<div class="tw-flex tw-items-cente tw-gap-1.5">
+					<div
+						class="tw-flex tw-gap-1.5"
+					>
 						<button
+							v-if="showBackButton"
 							class="hover:tw-text-action-highlight tw-flex tw-items-center tw-justify-center"
 							@click="closeSideSheet"
 						>
@@ -44,7 +47,7 @@
 						</h2>
 					</div>
 
-					<div class="tw-flex tw-items-cente tw-gap-1.5">
+					<div class="tw-flex tw-gap-1.5">
 						<button
 							v-if="showGoToLink"
 							class="hover:tw-text-action-highlight tw-flex tw-items-center tw-justify-center"
@@ -108,6 +111,13 @@ export default {
 		 * Whether the side sheet is open or not
 		 * */
 		visible: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Show the go to link button
+		 * */
+		showBackButton: {
 			type: Boolean,
 			default: false,
 		},

--- a/@kiva/kv-components/src/vue/stories/KvSideSheet.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSideSheet.stories.js
@@ -24,10 +24,9 @@ const Template = (args, {
 				:visible="isVisible"
 				:kv-track-function="kvTrackMock"
 				track-event-category="new-loan-card"
-				:show-go-to-link="true"
 				@side-sheet-closed="isVisible = false"
 				:animation-source-element="animationSourceElement"
-				:headline="headline"
+				v-bind="args"
 			>
 				<div>
 					Some content
@@ -38,7 +37,6 @@ const Template = (args, {
 	data() {
 		return {
 			isVisible: args.visible,
-			expandEffect: args.expandEffect,
 			animationSourceElement: null,
 		};
 	},
@@ -66,6 +64,9 @@ export const Default = Template.bind({});
 export const ExpandEffect = Template.bind({});
 ExpandEffect.args = {
 	expandEffect: true,
+	headline: 'Headline',
+	showGoToLink: true,
+	showBackButton: true,
 };
 
 const TemplateWithControls = (args, {
@@ -86,10 +87,9 @@ const TemplateWithControls = (args, {
 				:visible="isVisible"
 				:kv-track-function="kvTrackMock"
 				track-event-category="new-loan-card"
-				:show-go-to-link="true"
 				@side-sheet-closed="isVisible = false"
 				:animation-source-element="animationSourceElement"
-				:headline="headline"
+				v-bind="args"
 			>
 				<div>
 					Some content
@@ -116,7 +116,6 @@ const TemplateWithControls = (args, {
 			isVisible: args.visible,
 			expandEffect: args.expandEffect,
 			animationSourceElement: null,
-			headline: args.headline,
 		};
 	},
 	methods: {
@@ -142,4 +141,6 @@ export const WithControls = TemplateWithControls.bind({});
 
 WithControls.args = {
 	headline: 'Headline',
+	showGoToLink: true,
+	showBackButton: true,
 };


### PR DESCRIPTION
- Made the back button optional via a prop. 
- Removed misspelled classes which werent having an effect anyway.
- Modified stories to work with storybook controls

For our context in the impact dashboard and for the upcoming badge journeys, the back button should be optional

![Screenshot 2025-05-12 at 9 12 34 AM](https://github.com/user-attachments/assets/82cae5d6-4fff-4964-be4d-3e1083cefb10)
