### PR TITLE
fix: improve SideSheet component for BadgeJourneys

### DIFF
--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -101,7 +101,7 @@ import { ref, toRefs, watch } from 'vue';
 import {
 	mdiClose, mdiArrowLeft, mdiExportVariant,
 } from '@mdi/js';
-import { KvMaterialIcon } from '@kiva/kv-components';
+import KvMaterialIcon from './KvMaterialIcon.vue';
 
 export default {
 	name: 'KvSideSheet',

--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -104,7 +104,6 @@ import {
 import KvMaterialIcon from './KvMaterialIcon.vue';
 
 export default {
-	name: 'KvSideSheet',
 	components: {
 		KvMaterialIcon,
 	},

--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -191,6 +191,7 @@ export default {
 		const modalStyles = ref({});
 		const controlsRef = ref(null);
 		const headlineRef = ref(null);
+		const windowHeight = ref(window.innerHeight);
 
 		const heights = reactive({
 			headline: 0,
@@ -198,8 +199,8 @@ export default {
 		});
 
 		const contentHeight = computed(() => {
-			const height = window.innerHeight - heights.headline - heights.controls;
-			return Math.max(height, 0); // Ensure non-negative height
+			const height = windowHeight.value - heights.headline - heights.controls;
+			return Math.max(height, 0);
 		});
 
 		// Debounce function to limit rapid ResizeObserver calls
@@ -212,7 +213,7 @@ export default {
 		};
 
 		const updateHeights = () => {
-			// Use setTimeout to wait for DOM rendering and styling
+			windowHeight.value = window.innerHeight;
 			setTimeout(() => {
 				nextTick(() => {
 					if (headlineRef.value) {
@@ -221,7 +222,6 @@ export default {
 					} else {
 						heights.headline = 0;
 					}
-
 					if (slots.controls?.() && controlsRef.value) {
 						const controlsRect = controlsRef.value.getBoundingClientRect();
 						heights.controls = controlsRect.height;
@@ -247,18 +247,15 @@ export default {
 			open.value = false;
 			avoidBodyScroll();
 			kvTrackFunction.value(trackEventCategory.value, 'click', 'side-sheet-closed');
-
 			if (animationSourceElement.value) {
 				modalStyles.value = {
 					...initialStyles.value,
 					transition: 'all 0.5s ease-in-out',
 				};
 			}
-
 			setTimeout(() => {
 				emit('side-sheet-closed');
 			}, 700);
-
 			// eslint-disable-next-line no-use-before-define
 			document.removeEventListener('keyup', onKeyUp);
 		};
@@ -275,11 +272,9 @@ export default {
 
 		// Set up resize listeners
 		onMounted(() => {
-			// Initial measurement after a delay to ensure hydration
 			setTimeout(() => {
 				updateHeights();
 			}, 100);
-
 			if (controlsRef.value) {
 				const controlsObserver = new ResizeObserver(debouncedUpdateHeights);
 				controlsObserver.observe(controlsRef.value);

--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -23,10 +23,11 @@
 			>
 				<div
 					class="tw-flex tw-justify-between tw-transition-opacity tw-duration-500 tw-delay-200
-					tw-px-3 tw-py-2 tw-border-b tw-border-tertiary"
+					tw-px-3 tw-py-2 tw-border-tertiary"
 					:class="{
 						'tw-opacity-0': !open,
 						'tw-opacity-full': open,
+						'tw-border-b': showHeadlineBorder
 					}"
 				>
 					<div
@@ -70,7 +71,7 @@
 					</div>
 				</div>
 				<div
-					class="tw-p-4 tw-overflow-y-auto tw-transition-opacity tw-duration-500 tw-delay-200
+					class="tw-p-2 tw-overflow-y-auto tw-transition-opacity tw-duration-500 tw-delay-200
 						tw-overscroll-y-contain"
 					:class="{
 						'tw-opacity-0': !open,
@@ -100,9 +101,10 @@ import { ref, toRefs, watch } from 'vue';
 import {
 	mdiClose, mdiArrowLeft, mdiExportVariant,
 } from '@mdi/js';
-import KvMaterialIcon from './KvMaterialIcon.vue';
+import { KvMaterialIcon } from '@kiva/kv-components';
 
 export default {
+	name: 'KvSideSheet',
 	components: {
 		KvMaterialIcon,
 	},
@@ -127,6 +129,10 @@ export default {
 		showGoToLink: {
 			type: Boolean,
 			default: false,
+		},
+		showHeadlineBorder: {
+			type: Boolean,
+			default: true,
 		},
 		/**
 		 * Tracking event function

--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -1,4 +1,3 @@
-```vue
 <template>
 	<div
 		v-if="visible"
@@ -316,4 +315,3 @@ export default {
 	},
 };
 </script>
-```


### PR DESCRIPTION
Adds a new prop to the SideSheet component to allow for the Headline border to be hidden if specified. Also reduces the y padding on the headline slightly to conform to latest Figma designs.