### PR TITLE
fix: smoothed out animation for side sheet usage and got design review

### DIFF
--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -170,13 +170,6 @@ export default {
 			default: '',
 		},
 		/**
-		 * Source element position for expand animation
-		 * */
-		animationSourceElement: {
-			type: Object,
-			default: () => ({}),
-		},
-		/**
 		 * The headline of the side sheet
 		 * */
 		headline: {
@@ -209,12 +202,10 @@ export default {
 			visible,
 			kvTrackFunction,
 			trackEventCategory,
-			animationSourceElement,
 			widthDimensions,
 		} = toRefs(props);
 
 		const open = ref(false);
-		const initialStyles = ref({});
 		const modalStyles = ref({});
 		const sideSheetRef = ref(null);
 		const controlsRef = ref(null);
@@ -365,52 +356,11 @@ export default {
 					avoidBodyScroll();
 					updateHeights();
 				}, 10); // Reduced delay for smoother animation
-
-				const rect = animationSourceElement.value?.getBoundingClientRect();
-				const top = rect?.top ?? 0;
-				const left = rect?.left ?? 0;
-				const width = rect?.width ?? 0;
-				const height = rect?.height ?? 0;
-
-				// Only apply custom animation if source element is provided
-				if (rect && (top || left || width || height)) {
-					initialStyles.value = {
-						position: 'fixed',
-						top: `${top}px`,
-						width: `${width}px`,
-						height: `${height}px`,
-						transform: `translateX(${animationWidth.value})`,
-					};
-
-					modalStyles.value = {
-						...initialStyles.value,
-						transition: 'none',
-					};
-
-					setTimeout(() => {
-						modalStyles.value = {
-							top: '0',
-							width: animationWidth.value,
-							height: '100%',
-							transform: 'translateX(0)',
-							transition: 'all 0.3s ease-in-out',
-						};
-					}, 10);
-				}
 			} else {
 				open.value = false;
 				avoidBodyScroll();
 				document.removeEventListener('keyup', onKeyUp);
-
-				// Reset modal styles when closing
-				if (animationSourceElement.value && Object.keys(initialStyles.value).length > 0) {
-					modalStyles.value = {
-						...initialStyles.value,
-						transition: 'all 0.3s ease-in-out',
-					};
-				} else {
-					modalStyles.value = {};
-				}
+				modalStyles.value = {};
 			}
 		}, { immediate: true });
 

--- a/@kiva/kv-components/src/vue/stories/KvSideSheet.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSideSheet.stories.js
@@ -23,7 +23,6 @@ const Template = (args, { argTypes }) => ({
 				:kv-track-function="kvTrackMock"
 				track-event-category="new-loan-card"
 				@side-sheet-closed="isVisible = false"
-				:animation-source-element="animationSourceElement"
 				v-bind="args"
 			>
 				<div>
@@ -35,7 +34,6 @@ const Template = (args, { argTypes }) => ({
 	data() {
 		return {
 			isVisible: args.visible,
-			animationSourceElement: null,
 		};
 	},
 	methods: {
@@ -48,24 +46,13 @@ const Template = (args, { argTypes }) => ({
 		) {
 			console.log(category, action, label, property, value);
 		},
-		openModal(event) {
-			if (this.expandEffect) {
-				this.animationSourceElement = event.currentTarget;
-			}
+		openModal() {
 			this.isVisible = true;
 		},
 	},
 });
 
 export const Default = Template.bind({});
-
-export const ExpandEffect = Template.bind({});
-ExpandEffect.args = {
-	expandEffect: true,
-	headline: 'Headline',
-	showGoToLink: true,
-	showBackButton: true,
-};
 
 const TemplateWithControls = (args, { argTypes }) => ({
 	props: Object.keys(argTypes),
@@ -84,7 +71,6 @@ const TemplateWithControls = (args, { argTypes }) => ({
 				:kv-track-function="kvTrackMock"
 				track-event-category="new-loan-card"
 				@side-sheet-closed="isVisible = false"
-				:animation-source-element="animationSourceElement"
 				v-bind="args"
 			>
 				<div>
@@ -110,8 +96,6 @@ const TemplateWithControls = (args, { argTypes }) => ({
 	data() {
 		return {
 			isVisible: args.visible,
-			expandEffect: args.expandEffect,
-			animationSourceElement: null,
 		};
 	},
 	methods: {
@@ -124,10 +108,7 @@ const TemplateWithControls = (args, { argTypes }) => ({
 		) {
 			console.log(category, action, label, property, value);
 		},
-		openModal(event) {
-			if (this.expandEffect) {
-				this.animationSourceElement = event.currentTarget;
-			}
+		openModal() {
 			this.isVisible = true;
 		},
 	},
@@ -145,7 +126,6 @@ FixedWidth.args = {
 	headline: 'Fixed Width',
 	showGoToLink: true,
 	showBackButton: true,
-	expandEffect: true,
 	widthDimensions: '33.33%',
 };
 
@@ -154,7 +134,6 @@ ResponsiveWidths.args = {
 	headline: 'Responsive Widths',
 	showGoToLink: true,
 	showBackButton: true,
-	expandEffect: true,
 	widthDimensions: { lg: '480px', md: '460px', sm: '100%' },
 };
 
@@ -163,7 +142,6 @@ ResponsiveWidthsWithControls.args = {
 	headline: 'Responsive Widths with Controls',
 	showGoToLink: true,
 	showBackButton: true,
-	expandEffect: true,
 	widthDimensions: { lg: '480px', md: '460px', sm: '100%' },
 };
 
@@ -172,7 +150,6 @@ CustomResponsiveWidths.args = {
 	headline: 'Custom Responsive Widths',
 	showGoToLink: true,
 	showBackButton: true,
-	expandEffect: true,
 	widthDimensions: {
 		default: '100%', sm: '80%', md: '500px', lg: '600px',
 	},


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1643

- The animation source was used previously for the loan card iOS-like animation but wasn't compatible with the new side panel slide in and out, content was animating from source instead of having a smooth sheet animation
- During the onsite I removed the animation source and got design review in person
- `expandEffect` wasn't being used, so I removed the related code
