### PR TITLE
feat: add new secondary nav component 

### DIFF
--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -1,0 +1,209 @@
+<template>
+	<kv-theme-provider
+		:theme="themeStyle"
+		class="kv-tailwind"
+	>
+		<div
+			class="tw-z-1 tw-w-full"
+			:class="{
+				'tw-fixed': isBelowElement,
+				'tw-absolute': !isBelowElement,
+			}"
+		>
+			<div class="tw-w-full tw-text-primary tw-bg-primary tw-overflow-x-auto kv-secondary-nav">
+				<div
+					ref="navInner"
+					class="
+						kv-secondary-nav__inner
+						tw-flex tw-gap-2 md:tw-gap-4 tw-items-center tw-flex-wrap
+						tw-px-2 md:tw-px-8 tw-py-2"
+					:class="navAlignmentClass"
+				>
+					<div
+						v-if="heading && heading.length > 0"
+						class="kv-secondary-nav__heading-container"
+					>
+						<div class="kv-secondary-nav__heading tw-text-h3">
+							{{ heading }}
+						</div>
+					</div>
+					<button
+						class="
+							kv-secondary-nav__toggle
+							tw-flex md:tw-hidden
+							tw-text-primary tw-bg-transparent tw-border-none tw-cursor-pointer"
+						@click="toggleSubNavigation"
+					>
+						<kv-material-icon
+							:icon="subNavigationOpen ? mdiChevronUp : mdiChevronDown"
+						/>
+					</button>
+					<div
+						ref="subNavigation"
+						class="kv-secondary-nav__links-container tw-pt-1 md:tw-pt-0 md:tw-block tw-w-full md:tw-w-auto"
+						:class="subNavigationOpen ? '' : 'tw-hidden' "
+					>
+						<ul class="kv-secondary-nav__links tw-flex tw-flex-col md:tw-flex-row tw-items-center tw-gap-3">
+							<li
+								v-for="(link, index) in links"
+								:key="index"
+								class="kv-secondary-nav__link-item tw-w-full md:tw-w-auto"
+							>
+								<router-link
+									:to="link.href"
+									class="
+										kv-secondary-nav__link
+										tw-py-2 md:tw-py-n
+										tw-text-primary tw-font-medium
+										hover:tw-underline hover:tw-text-primary
+									"
+									:class="{
+										'tw-underline': link.isActive ,
+										'tw-no-underline': !link.isActive,
+									}"
+								>
+									{{ link.text }}
+								</router-link>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div
+			id="threshold"
+			ref="thresholdRef"
+		></div>
+	</kv-theme-provider>
+</template>
+<script>
+// Vue core
+import {
+	ref, computed, toRefs, onMounted, onUnmounted,
+} from 'vue';
+
+// Theme
+import { defaultTheme, greenDarkTheme } from '@kiva/kv-tokens';
+
+// Components
+import { mdiChevronUp, mdiChevronDown } from '@mdi/js';
+import KvThemeProvider from './KvThemeProvider.vue';
+import KvMaterialIcon from './KvMaterialIcon.vue';
+
+// Icons
+
+export default {
+	name: 'KvSecondaryNav',
+	components: {
+		KvMaterialIcon,
+		KvThemeProvider,
+	},
+	props: {
+		heading: {
+			type: String,
+			default: '',
+		},
+		links: {
+			type: Array,
+			default: () => [],
+			validator(value) {
+				return value.every(
+					(link) => Object.prototype.hasOwnProperty.call(link, 'text')
+						&& Object.prototype.hasOwnProperty.call(link, 'href'),
+				);
+			},
+		},
+		linkAlignment: {
+			type: String,
+			default: '',
+			validator(value) {
+				return ['left', 'right', 'center'].includes(value);
+			},
+		},
+		theme: {
+			type: String,
+			default: 'default',
+			validator(value) {
+				return ['default', 'dark'].includes(value);
+			},
+		},
+	},
+	setup(props) {
+		const {
+			heading, linkAlignment, theme,
+		} = toRefs(props);
+
+		const thresholdRef = ref(null);
+		const isBelowElement = ref(false);
+		const navInner = ref(null);
+		const navPlaceholder = ref(null);
+		const headerOffset = ref(0);
+		const subNavigation = ref(null);
+		const subNavigationOpen = ref(false);
+
+		const navAlignmentClass = computed(() => {
+			if (linkAlignment.value === 'right') {
+				return (heading.value && heading.value.length > 0)
+					? 'tw-justify-between'
+					: 'tw-justify-end';
+			}
+			if (linkAlignment.value === 'left') {
+				return 'tw-justify-start';
+			}
+			if (linkAlignment.value === 'center') {
+				return 'tw-justify-center';
+			}
+			return '';
+		});
+
+		const themeStyle = computed(() => {
+			const themeMapper = {
+				default: defaultTheme,
+				dark: greenDarkTheme,
+			};
+			return themeMapper[theme.value];
+		});
+
+		const updateHeaderPosition = () => {
+			const thresholdClientRectTop = thresholdRef.value?.getBoundingClientRect()?.top;
+			isBelowElement.value = thresholdClientRectTop ? thresholdClientRectTop < 0 : false;
+		};
+
+		const toggleSubNavigation = () => {
+			subNavigationOpen.value = !subNavigationOpen.value;
+		};
+
+		onMounted(() => {
+			updateHeaderPosition();
+			window.addEventListener('scroll', updateHeaderPosition);
+			window.addEventListener('resize', updateHeaderPosition);
+		});
+
+		onUnmounted(() => {
+			window.removeEventListener('scroll', updateHeaderPosition);
+			window.removeEventListener('resize', updateHeaderPosition);
+		});
+
+		return {
+			navAlignmentClass,
+			toggleSubNavigation,
+			subNavigationOpen,
+			mdiChevronUp,
+			mdiChevronDown,
+			isBelowElement,
+			navInner,
+			subNavigation,
+			thresholdRef,
+			navPlaceholder,
+			headerOffset,
+			themeStyle,
+		};
+	},
+};
+</script>
+<style scoped>
+#threshold, .kv-secondary-nav {
+	min-height: 62px;
+	width: 100%;
+}
+</style>

--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -5,12 +5,12 @@
 	>
 		<div
 			class="tw-z-1 tw-w-full"
-			:class="{
-				'tw-fixed': isBelowElement,
-				'tw-absolute': !isBelowElement,
-			}"
+			:class="isBelowElement ? 'tw-fixed' : 'tw-absolute'"
 		>
-			<div class="tw-w-full tw-text-primary tw-bg-primary tw-overflow-x-auto kv-secondary-nav">
+			<div
+				class="tw-w-full tw-text-primary tw-overflow-x-auto kv-secondary-nav"
+				:class="theme === 'default' ? 'tw-bg-secondary' : 'tw-bg-primary'"
+			>
 				<div
 					ref="navInner"
 					class="
@@ -22,6 +22,7 @@
 					<div
 						v-if="heading && heading.length > 0"
 						class="kv-secondary-nav__heading-container"
+						:class="linkAlignment === 'left' || linkAlignment === 'center' ? 'tw-block md:tw-hidden' : ''"
 					>
 						<div class="kv-secondary-nav__heading tw-text-h3">
 							{{ heading }}
@@ -41,7 +42,7 @@
 					<div
 						ref="subNavigation"
 						class="kv-secondary-nav__links-container tw-pt-1 md:tw-pt-0 md:tw-block tw-w-full md:tw-w-auto"
-						:class="subNavigationOpen ? '' : 'tw-hidden' "
+						:class="!subNavigationOpen ? 'tw-hidden' : '' "
 					>
 						<ul class="kv-secondary-nav__links tw-flex tw-flex-col md:tw-flex-row tw-items-center tw-gap-3">
 							<li
@@ -145,13 +146,13 @@ export default {
 			if (linkAlignment.value === 'right') {
 				return (heading.value && heading.value.length > 0)
 					? 'tw-justify-between'
-					: 'tw-justify-end';
+					: 'tw-justify-between md:tw-justify-end';
 			}
 			if (linkAlignment.value === 'left') {
-				return 'tw-justify-start';
+				return 'tw-justify-between md:tw-justify-start';
 			}
 			if (linkAlignment.value === 'center') {
-				return 'tw-justify-center';
+				return 'tw-justify-between md:tw-justify-center';
 			}
 			return '';
 		});

--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -50,8 +50,10 @@
 								:key="index"
 								class="kv-secondary-nav__link-item tw-w-full md:tw-w-auto"
 							>
-								<router-link
-									:to="link.href"
+								<component
+									:is="link.isExternal ? 'a' : 'router-link'"
+									:to="link.isExternal ? undefined : link.href"
+									:href="link.isExternal ? link.href : undefined"
 									class="
 										kv-secondary-nav__link
 										tw-py-2 md:tw-py-n
@@ -64,7 +66,7 @@
 									}"
 								>
 									{{ link.text }}
-								</router-link>
+								</component>
 							</li>
 						</ul>
 					</div>

--- a/@kiva/kv-components/src/vue/index.js
+++ b/@kiva/kv-components/src/vue/index.js
@@ -71,3 +71,4 @@ export { default as KvVotingCardV2 } from './KvVotingCardV2.vue';
 export { default as KvWideLoanCard } from './KvWideLoanCard.vue';
 export * from './KvWideLoanCard.vue';
 export { default as KvAtbModal } from './KvAtbModal.vue';
+export { default as KvSecondaryNav } from './KvSecondaryNav.vue';

--- a/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
@@ -23,7 +23,7 @@ export default {
 			},
 		],
 		linkAlignment: 'right',
-		theme: 'mint',
+		theme: 'default',
 	},
 };
 
@@ -44,26 +44,13 @@ const Template = (args, { argTypes }) => ({
 		};
 	},
 });
+
 export const Default = Template.bind({});
 Default.args = {
-	heading: 'Due Diligence',
-	links: [
-		{
-			text: 'Overview',
-			href: '#',
-			isActive: true,
-		},
-		{
-			text: 'Documents',
-			href: '#',
-			isActive: false,
-		},
-		{
-			text: 'Team',
-			href: '#',
-			isActive: false,
-		},
-	],
-	linkAlignment: 'right',
-	theme: 'mint',
+	theme: 'default',
+};
+
+export const Dark = Template.bind({});
+Dark.args = {
+	theme: 'dark',
 };

--- a/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
@@ -8,18 +8,21 @@ export default {
 		links: [
 			{
 				text: 'Overview',
-				href: '#',
-				isActive: true,
+				href: 'https://www.kiva.org',
+				isActive: false,
+				isExternal: true,
 			},
 			{
 				text: 'Documents',
 				href: '#',
 				isActive: false,
+				isExternal: false,
 			},
 			{
 				text: 'Team',
 				href: '#',
 				isActive: false,
+				isExternal: false,
 			},
 		],
 		linkAlignment: 'right',
@@ -53,4 +56,14 @@ Default.args = {
 export const Dark = Template.bind({});
 Dark.args = {
 	theme: 'dark',
+};
+
+export const Centered = Template.bind({});
+Centered.args = {
+	linkAlignment: 'center',
+};
+
+export const LeftAlignment = Template.bind({});
+LeftAlignment.args = {
+	linkAlignment: 'left',
 };

--- a/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
@@ -1,0 +1,69 @@
+import KvSecondaryNav from '../KvSecondaryNav.vue';
+
+export default {
+	title: 'KvSecondaryNav',
+	component: KvSecondaryNav,
+	args: {
+		heading: 'Due Diligence',
+		links: [
+			{
+				text: 'Overview',
+				href: '#',
+				isActive: true,
+			},
+			{
+				text: 'Documents',
+				href: '#',
+				isActive: false,
+			},
+			{
+				text: 'Team',
+				href: '#',
+				isActive: false,
+			},
+		],
+		linkAlignment: 'right',
+		theme: 'mint',
+	},
+};
+
+const Template = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvSecondaryNav },
+	setup() {
+		return args;
+	},
+	template: `
+		<div style="height: 300vh; overflow: auto;position:relative;">
+			<KvSecondaryNav :heading="heading" :links="links" :linkAlignment="linkAlignment" :theme="theme" />
+		</div>
+	`,
+	data() {
+		return {
+			...args,
+		};
+	},
+});
+export const Default = Template.bind({});
+Default.args = {
+	heading: 'Due Diligence',
+	links: [
+		{
+			text: 'Overview',
+			href: '#',
+			isActive: true,
+		},
+		{
+			text: 'Documents',
+			href: '#',
+			isActive: false,
+		},
+		{
+			text: 'Team',
+			href: '#',
+			isActive: false,
+		},
+	],
+	linkAlignment: 'right',
+	theme: 'mint',
+};

--- a/@kiva/kv-components/src/vue/stories/StyleguidePrimitives.stories.js
+++ b/@kiva/kv-components/src/vue/stories/StyleguidePrimitives.stories.js
@@ -7,6 +7,7 @@ import KvTab from '../KvTab.vue';
 import KvTabs from '../KvTabs.vue';
 import KvTabPanel from '../KvTabPanel.vue';
 import KvToast from '../KvToast.vue';
+import KvSecondaryNav from '../KvSecondaryNav.vue';
 
 const config = resolveConfig(tailwindConfig);
 const { theme } = config;
@@ -39,6 +40,7 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 		KvTabs,
 		KvTabPanel,
 		KvToast,
+		KvSecondaryNav,
 	},
 	setup() { return { theme, args: { ...templateArgs } }; },
 	template: `


### PR DESCRIPTION
this branch introduces a new “KvSecondaryNav” component with sticky scrolling outlined in [this proposal ](https://kiva.atlassian.net/wiki/spaces/LW/pages/3730833415/Proposal+Contentful+Secondary+Menu)

In it's current state the component takes a few params, we will probably need to modify it a bit once the contentful fields/setup is complete but the current params are:
- Heading - The heading text, hidden for >= medium viewport size if linkAlignment is left/center
- linkAlignment - left/right/center alignment for the links section on browsers >= medium viewport size
- Links
- - Title - link title
- - href - link location
- - isExternal - if link should render as an <a> or <router-link> 
- - isActive - if link should get active styling (underline)
- Theme - default/dark which adjusts the style passed to kv-theme-provider
