### PR TITLE
fix: sidesheet does not work with SSR

### DIFF
--- a/@kiva/kv-components/src/vue/KvSideSheet.vue
+++ b/@kiva/kv-components/src/vue/KvSideSheet.vue
@@ -210,8 +210,8 @@ export default {
 		const sideSheetRef = ref(null);
 		const controlsRef = ref(null);
 		const headlineRef = ref(null);
-		const windowHeight = ref(window.innerHeight);
-		const windowWidth = ref(window.innerWidth);
+		const windowHeight = ref(null);
+		const windowWidth = ref(null);
 
 		const heights = reactive({
 			headline: 0,
@@ -334,7 +334,7 @@ export default {
 			setTimeout(() => {
 				updateHeights();
 			}, 100);
-		}, { deep: true, immediate: true });
+		}, { deep: true });
 
 		// Use animationWidth for consistent width calculation
 		const sideSheetStyles = computed(() => {
@@ -362,7 +362,7 @@ export default {
 				document.removeEventListener('keyup', onKeyUp);
 				modalStyles.value = {};
 			}
-		}, { immediate: true });
+		});
 
 		// Watch width changes when component is open (resize without animation)
 		watch(animationWidth, (newWidth) => {


### PR DESCRIPTION
The sidesheet is breaking SSR pages. For example: 

https://www.development.kiva.org/impact-dashboard/uswntpa/upc/lfg

This removes `immediate` and accessing `window` during setup so our code can run server side. 