### PR TITLE
fix: ensure we import and map default theme on KvToolTip, add new themes

### DIFF
--- a/@kiva/kv-components/src/vue/KvTooltip.vue
+++ b/@kiva/kv-components/src/vue/KvTooltip.vue
@@ -36,6 +36,12 @@
 import { ref, toRefs, computed } from 'vue';
 import {
 	darkTheme,
+	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
 	mintTheme,
 } from '@kiva/kv-tokens';
 import KvPopper from './KvPopper.vue';
@@ -64,7 +70,16 @@ export default {
 			default: 'default',
 			validator(value) {
 				// The value must match one of these strings
-				return ['default', 'mint', 'dark'].indexOf(value) !== -1;
+				return [
+					'default',
+					'ecoGreenLight',
+					'ecoGreenDark',
+					'ecoLightMarigold',
+					'ecoStoneLight',
+					'ecoStoneDark',
+					'mint',
+					'dark',
+				].indexOf(value) !== -1;
 			},
 		},
 	},
@@ -81,6 +96,12 @@ export default {
 
 		const themeStyle = computed(() => {
 			const themeMapper = {
+				default: defaultTheme,
+				ecoGreenLight: greenLightTheme,
+				ecoGreenDark: greenDarkTheme,
+				ecoLightMarigold: marigoldLightTheme,
+				ecoStoneLight: stoneLightTheme,
+				ecoStoneDark: stoneDarkTheme,
 				mint: mintTheme,
 				dark: darkTheme,
 			};
@@ -88,8 +109,14 @@ export default {
 		});
 
 		return {
-			darkTheme,
+			defaultTheme,
+			greenLightTheme,
+			greenDarkTheme,
+			marigoldLightTheme,
+			stoneLightTheme,
+			stoneDarkTheme,
 			mintTheme,
+			darkTheme,
 			popperModifiers,
 			themeStyle,
 		};
@@ -105,7 +132,7 @@ export default {
 
 .tooltip-arrow {
 	@apply tw-m-1;
-	@apply tw-border-white;
+	border-color: rgba(var(--bg-primary), var(--tw-bg-opacity, 1));
 }
 
 /* Top Tooltip Arrow appears on Bottom */

--- a/@kiva/kv-components/src/vue/stories/KvTooltip.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvTooltip.stories.js
@@ -3,16 +3,36 @@ import KvTooltip from '../KvTooltip.vue';
 export default {
 	title: 'KvTooltip',
 	component: KvTooltip,
+	args: {
+		theme: 'default',
+	},
+	argTypes: {
+		theme: {
+			options: [
+				'default',
+				'ecoGreenLight',
+				'ecoGreenDark',
+				'ecoLightMarigold',
+				'ecoStoneLight',
+				'ecoStoneDark',
+				'mint',
+				'dark',
+			],
+			control: { type: 'select' },
+		},
+	},
 };
 
-export const Default = () => ({
+export const Default = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
 	components: {
 		KvTooltip,
 	},
+	setup() { return { args }; },
 	template: `
 		<div>
 			<button id="my-cool-btn">Hover of Focus Me!</button>
-			<kv-tooltip controller="my-cool-btn">
+			<kv-tooltip v-bind="args" controller="my-cool-btn">
 				<template #title>
 					What is an Experimental Field Partner?
 				</template>


### PR DESCRIPTION
Previously we weren't importing or mapping the `default` theme for our KvToolTip. That theme is supposed to be used by "default" so it's always selected. _It's a bit of a long-shot to think this will fix the issue with using it in rtp-nuxt but it might!_

Otherwise, we now import the default theme and map it. I've also imported and mapped all our new themes and updated the story with a selector control so you can test them all out. Also, made a fix for the arrow color which wasn't getting applied.