### PR TITLE
Feat content card frame

### DIFF
--- a/@kiva/kv-components/src/vue/KvCardFrame.vue
+++ b/@kiva/kv-components/src/vue/KvCardFrame.vue
@@ -1,0 +1,82 @@
+<template>
+	<kv-theme-provider
+		:theme="themeStyle"
+		class="kv-tailwind"
+	>
+		<div :class="['kv-card-frame tw-overflow-hidden', bgColorClass, radiusClass, shadowClass, borderClass]">
+			<slot></slot>
+		</div>
+	</kv-theme-provider>
+</template>
+
+<script>
+import { computed } from 'vue';
+
+import {
+	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
+} from '@kiva/kv-tokens';
+
+import KvThemeProvider from './KvThemeProvider.vue';
+
+export default {
+	components: {
+		KvThemeProvider,
+	},
+	props: {
+		bgColorClass: {
+			type: String,
+			default: 'tw-bg-primary',
+		},
+		borderClass: {
+			type: String,
+			default: '',
+		},
+		radiusClass: {
+			type: String,
+			default: 'tw-rounded',
+		},
+		shadowClass: {
+			type: String,
+			default: 'tw-shadow-lg',
+		},
+		theme: {
+			type: String,
+			default: 'default',
+			validator(value) {
+				return [
+					'default', 'greenLight', 'greenDark', 'marigoldLight', 'stoneLight', 'stoneDark',
+				].includes(value);
+			},
+		},
+	},
+	setup(props) {
+		const themeStyle = computed(() => {
+			switch (props.theme) {
+				case 'default':
+					return defaultTheme;
+				case 'greenDark':
+					return greenDarkTheme;
+				case 'greenLight':
+					return greenLightTheme;
+				case 'marigoldLight':
+					return marigoldLightTheme;
+				case 'stoneLight':
+					return stoneLightTheme;
+				case 'stoneDark':
+					return stoneDarkTheme;
+				default:
+					return defaultTheme;
+			}
+		});
+
+		return { themeStyle };
+	},
+};
+</script>
+
+<style scoped></style>

--- a/@kiva/kv-components/src/vue/KvCardFrame.vue
+++ b/@kiva/kv-components/src/vue/KvCardFrame.vue
@@ -1,7 +1,7 @@
 <template>
 	<kv-theme-provider
 		:theme="themeStyle"
-		class="kv-tailwind"
+		class="kv-card-frame-theme-provider"
 	>
 		<div :class="['kv-card-frame tw-overflow-hidden', bgColorClass, radiusClass, shadowClass, borderClass]">
 			<slot></slot>

--- a/@kiva/kv-components/src/vue/index.js
+++ b/@kiva/kv-components/src/vue/index.js
@@ -2,6 +2,7 @@ export { default as KvAccordionItem } from './KvAccordionItem.vue';
 export { default as KvActivityRow } from './KvActivityRow.vue';
 export { default as KvBorrowerImage } from './KvBorrowerImage.vue';
 export { default as KvButton } from './KvButton.vue';
+export { default as KvCardFrame } from './KvCardFrame.vue';
 export { default as KvCarousel } from './KvCarousel.vue';
 export { default as KvCartModal } from './KvCartModal.vue';
 export { default as KvCartPill } from './KvCartPill.vue';

--- a/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
@@ -1,0 +1,148 @@
+import KvCardFrame from '../KvCardFrame.vue';
+import KvButton from '../KvButton.vue';
+
+export default {
+	title: 'KvCardFrame',
+	component: KvCardFrame,
+	args: {
+		bgColorClass: null,
+		borderClass: null,
+		radiusClass: null,
+		shadowClass: null,
+		theme: null,
+		headline: 'Generic Headline',
+		buttonText: 'Click Me',
+	},
+	argTypes: {
+		bgColorClass: { control: 'text' },
+		borderClass: { control: 'text' },
+		radiusClass: { control: 'text' },
+		shadowClass: { control: 'text' },
+		headline: { control: 'text' },
+		buttonText: { control: 'text' },
+		theme: { control: 'text' },
+	},
+};
+
+const DefaultTemplate = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvCardFrame, KvButton },
+	setup() { return { args }; },
+	template: `
+		<div>
+			<kv-card-frame
+			>
+				<div class="tw-p-3 tw-flex tw-flex-col tw-items-center">
+					<div class="tw-w-10 tw-h-10 tw-mb-2"><picture class="tw-inline-block tw-relative tw-overflow-hidden tw-w-full tw-rounded-full tw-bg-brand" style="padding-bottom:100%;" data-testid="bp-summary-image" data-v-c516de63=""><source srcset="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg 80w, https://www.kiva.org/img/w160h160fz50/07f4ec319cb89eabe211cef6a7413931.jpg 160w, https://www.kiva.org/img/w72h72fz50/07f4ec319cb89eabe211cef6a7413931.jpg 72w, https://www.kiva.org/img/w144h144fz50/07f4ec319cb89eabe211cef6a7413931.jpg 144w, https://www.kiva.org/img/w64h64fz50/07f4ec319cb89eabe211cef6a7413931.jpg 64w, https://www.kiva.org/img/w128h128fz50/07f4ec319cb89eabe211cef6a7413931.jpg 128w" sizes="(min-width: 1024px) 80px, (min-width: 734px) 72px, 64px"><img class="tw-absolute tw-w-full tw-h-full tw-object-contain" src="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg" alt="Damary Lilibeth" loading="lazy"></picture></div>
+					<h2 style="margin-bottom:1rem;">{{ headline }}</h2>
+					<kv-button>{{ buttonText }}</kv-button>
+				</div>
+			</kv-card-frame>
+		</div>
+	`,
+	data() {
+		return {
+			bgColorClass: args.bgColorClass,
+			borderClass: args.borderClass,
+			radiusClass: args.radiusClass,
+			shadowClass: args.shadowClass,
+			theme: args.theme,
+			headline: args.headline,
+			buttonText: args.buttonText,
+		};
+	},
+});
+
+export const Default = DefaultTemplate.bind({});
+
+export const CustomThemeBorderAndShadow = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvCardFrame, KvButton },
+	setup() { return { args }; },
+	template: `
+		<div>
+			<kv-card-frame
+				:bg-color-class="bgColorClass"
+				:radius-class="radiusClass"
+				:shadow-class="shadowClass"
+				:border-class="borderClass"
+				:theme="theme"
+			>
+				<div class="tw-p-3 tw-flex tw-flex-col tw-items-center">
+					<div class="tw-w-10 tw-h-10 tw-mb-2"><picture class="tw-inline-block tw-relative tw-overflow-hidden tw-w-full tw-rounded-full tw-bg-brand" style="padding-bottom:100%;" data-testid="bp-summary-image" data-v-c516de63=""><source srcset="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg 80w, https://www.kiva.org/img/w160h160fz50/07f4ec319cb89eabe211cef6a7413931.jpg 160w, https://www.kiva.org/img/w72h72fz50/07f4ec319cb89eabe211cef6a7413931.jpg 72w, https://www.kiva.org/img/w144h144fz50/07f4ec319cb89eabe211cef6a7413931.jpg 144w, https://www.kiva.org/img/w64h64fz50/07f4ec319cb89eabe211cef6a7413931.jpg 64w, https://www.kiva.org/img/w128h128fz50/07f4ec319cb89eabe211cef6a7413931.jpg 128w" sizes="(min-width: 1024px) 80px, (min-width: 734px) 72px, 64px"><img class="tw-absolute tw-w-full tw-h-full tw-object-contain" src="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg" alt="Damary Lilibeth" loading="lazy"></picture></div>
+					<h2 style="margin-bottom:1rem;">{{ headline }}</h2>
+					<kv-button variant="secondary">{{ buttonText }}</kv-button>
+				</div>
+			</kv-card-frame>
+		</div>
+	`,
+	data() {
+		return {
+			bgColorClass: args.bgColorClass,
+			borderClass: args.borderClass,
+			radiusClass: args.radiusClass,
+			shadowClass: args.shadowClass,
+			theme: args.theme,
+			headline: args.headline,
+			buttonText: args.buttonText,
+		};
+	},
+});
+CustomThemeBorderAndShadow.args = {
+	bgColorClass: 'tw-bg-primary',
+	borderClass: 'tw-border-primary tw-border',
+	radiusClass: 'tw-rounded-sm',
+	shadowClass: 'tw-shadow',
+	theme: 'marigoldLight',
+	buttonText: 'Secondary Action',
+};
+
+export const CustomContentAndThemeNoShadow = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvCardFrame, KvButton },
+	setup() { return { args }; },
+	template: `
+		<div>
+			<kv-card-frame
+				:theme="theme"
+			>
+				<div class="tw-p-2">
+					<h2>{{ headline }}</h2>
+					<p style="margin-top:1rem;">Extra custom content!</p>
+				</div>
+			</kv-card-frame>
+		</div>
+	`,
+	data() {
+		return {
+			headline: args.headline,
+			buttonText: args.buttonText,
+			theme: args.theme,
+		};
+	},
+});
+CustomContentAndThemeNoShadow.args = {
+	theme: 'stoneDark',
+	headline: 'Custom Headline',
+	buttonText: 'Custom Button',
+};
+
+export const FullImageCard = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: { KvCardFrame, KvButton },
+	setup() { return { args }; },
+	template: `
+		<div>
+			<kv-card-frame class="tw-w-16 tw-h-16">
+				<a href="https://www.kiva.org/team/impact" target="_blank" rel="noopener noreferrer">
+					<img src="https://www.kiva.org/img/team_impact_fb_share2.png" alt="Kiva Team Impact" />
+				</a>
+			</kv-card-frame>
+		</div>
+	`,
+	data() {
+		return {
+
+		};
+	},
+});


### PR DESCRIPTION
We've been making a lot of content cards and there are more coming. This component is a configurable frame that allows customizing a card-like container. Content is recieved by a slot so can be anything.

- Allows setting one of our newer approved themes
- Allows passing in the backround, border, shadow and rounded classes you'd like used for the frame.

A few stories to illustrate, [Interact with them in the storybook build](https://608b4cf87f686c00213841b1-vesohuzdzu.chromatic.com/?path=/docs/kvcardframe--kv-components)

Default:
<img width="650" height="284" alt="image" src="https://github.com/user-attachments/assets/4c18b63e-1792-429e-9d81-edbe70b992a2" />

Custom Theme, Border, Background + Shadow
<img width="650" height="286" alt="image" src="https://github.com/user-attachments/assets/f02ddf98-45c1-4956-9a92-514e0456d440" />

Custom Theme + Background, No Border, No Shadow
<img width="651" height="151" alt="image" src="https://github.com/user-attachments/assets/3227b052-8124-44f3-9ca7-48d26f18d26a" />

Full Bleed Image as a link:
<img width="164" height="160" alt="image" src="https://github.com/user-attachments/assets/a5449dc0-7d06-4364-9346-a99c5ac5e691" />
