### PR TITLE
feat: ensure icon in kvselect in centered

### DIFF
--- a/@kiva/kv-components/src/vue/KvSelect.vue
+++ b/@kiva/kv-components/src/vue/KvSelect.vue
@@ -20,7 +20,7 @@
 			</select>
 			<kv-material-icon
 				:icon="mdiChevronDown"
-				class="tw-w-4 tw-absolute tw-top-0 tw-right-0 tw-pt-1.5 tw-pr-1 tw-pointer-events-none"
+				class="tw-w-4 tw-absolute tw-right-0 tw-pr-1 tw-pointer-events-none"
 				:class="{ 'tw-opacity-low': disabled }"
 			/>
 		</div>
@@ -115,7 +115,7 @@ export default {
 
 <style lang="postcss" scoped>
 .container {
-	@apply tw-relative tw-w-full;
+	@apply tw-relative tw-w-full tw-flex tw-items-center;
 }
 
 .container > select {


### PR DESCRIPTION
Ensuring KvSelect content is centered

<img width="203" height="77" alt="image" src="https://github.com/user-attachments/assets/c6d2b2ea-77dd-4d9d-84fc-0b931f8b7485" />
