### PR TITLE
chore: update KvCardFrame stories with configurable props and some ba…

### DIFF
--- a/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
@@ -28,32 +28,6 @@ export default {
 	},
 };
 
-// const DefaultTemplate = (args, { argTypes }) => ({
-// 	props: Object.keys(argTypes),
-// 	components: { KvCardFrame, KvButton },
-// 	setup() { return { args }; },
-// 	template: `
-// 		<div>
-// 			<kv-card-frame
-// 			>
-// 				<div class="tw-p-3 tw-flex tw-flex-col tw-items-center">
-// 					<div class="tw-w-10 tw-h-10 tw-mb-2"><picture class="tw-inline-block tw-relative tw-overflow-hidden tw-w-full tw-rounded-full tw-bg-brand" style="padding-bottom:100%;" data-testid="bp-summary-image" data-v-c516de63=""><source srcset="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg 80w, https://www.kiva.org/img/w160h160fz50/07f4ec319cb89eabe211cef6a7413931.jpg 160w, https://www.kiva.org/img/w72h72fz50/07f4ec319cb89eabe211cef6a7413931.jpg 72w, https://www.kiva.org/img/w144h144fz50/07f4ec319cb89eabe211cef6a7413931.jpg 144w, https://www.kiva.org/img/w64h64fz50/07f4ec319cb89eabe211cef6a7413931.jpg 64w, https://www.kiva.org/img/w128h128fz50/07f4ec319cb89eabe211cef6a7413931.jpg 128w" sizes="(min-width: 1024px) 80px, (min-width: 734px) 72px, 64px"><img class="tw-absolute tw-w-full tw-h-full tw-object-contain" src="https://www.kiva.org/img/w80h80fz50/07f4ec319cb89eabe211cef6a7413931.jpg" alt="Damary Lilibeth" loading="lazy"></picture></div>
-// 					<h2 style="margin-bottom:1rem;">{{ args.headline }}</h2>
-// 					<kv-button>{{ args.buttonText }}</kv-button>
-// 				</div>
-// 			</kv-card-frame>
-// 		</div>
-// 	`,
-// 	data() {
-// 		return {
-// 			headline: args.headline,
-// 			buttonText: args.buttonText,
-// 		};
-// 	},
-// });
-
-// export const Default = DefaultTemplate.bind({});
-
 export const CustomizableCardFrame = (args, { argTypes }) => ({
 	props: Object.keys(argTypes),
 	components: { KvCardFrame, KvButton },


### PR DESCRIPTION
…sic style options

- Setup top story with reactive props and controls to easily switch between some potential options
- Moved default state (no props pass, only slot content) to be second story
- Removed redundant story

<img width="1610" height="566" alt="image" src="https://github.com/user-attachments/assets/d99e427d-2aac-4c29-bf4e-b3411863941e" />
