### PR TITLE
fix(KvContentfulImg): using scale fit changes aspect ratio

### DIFF
--- a/@kiva/kv-components/src/vue/KvContentfulImg.vue
+++ b/@kiva/kv-components/src/vue/KvContentfulImg.vue
@@ -184,7 +184,7 @@ export default {
 		* */
 		fit: {
 			type: String,
-			default: 'scale',
+			default: 'fill',
 			validator(value) {
 				// The value must match one of these strings
 				return ['pad', 'fill', 'scale', 'crop', 'thumb'].indexOf(value) !== -1;


### PR DESCRIPTION
The current default for the fit option is scale, but that can distort the image. Contentful descriptions of the fit options (emphasis mine):
- `pad`: Resize the image to the specified dimensions, padding the image if needed.
- `fill`: Resize the image to the specified dimensions, cropping the image if needed.
- `scale`: Resize the image to the specified dimensions, **changing the original aspect ratio if needed**.
- `crop`: Crop a part of the original image to fit into the specified dimensions.
- `thumb`: Create a thumbnail from the image.

It's better to crop than to scale, especially because most of our images are of people, so this changes the default to `fill`.