### PR TITLE
fix: private menu query error and style issues

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader.vue
@@ -1,7 +1,7 @@
 <template>
 	<kv-theme-provider
-		tag="header"
-		class="tw-bg-secondary"
+		tag="div"
+		class="tw-bg-secondary tw-border-b tw-border-tertiary"
 	>
 		<nav
 			class="
@@ -58,7 +58,7 @@
 						tw-absolute
 						tw-left-1/2 tw--translate-x-1/2
 						tw-top-1/2 tw--translate-y-1/2
-						tw-h-full tw-w-full
+						tw-h-full tw-w-full tw-min-h-screen
 					"
 					:style="{
 						'max-width': '600px',

--- a/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendListMenu.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendListMenu.vue
@@ -252,6 +252,6 @@ export default {
 
 <style lang="postcss" scoped>
 .lend-link {
-	@apply tw-text-primary hover:tw-text-action tw-block tw-w-full tw-py-1 tw-no-underline;
+	@apply tw-text-primary hover:tw-text-action tw-block tw-w-full tw-py-1 tw-no-underline hover:tw-underline;
 }
 </style>

--- a/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendMegaMenu.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendMegaMenu.vue
@@ -93,13 +93,14 @@
 											v-kv-track-event="['TopNav','click-Lend-Favorites']"
 											:href="`/lend?lenderFavorite=${userId}`"
 											class="tw-text-primary tw-text-left hover:tw-text-action
-												tw-py-1 tw-inline-block"
+												tw-py-1 tw-inline-block tw-no-underline hover:tw-underline"
 										>
 											Saved loans
 										</a>
 										<span
 											v-else
-											class="tw-text-secondary tw-py-1 tw-inline-block"
+											class="tw-text-secondary tw-py-1 tw-inline-block
+												tw-no-underline hover:tw-underline"
 										>
 											Saved loans
 										</span>
@@ -126,7 +127,7 @@
 											v-kv-track-event="['TopNav','click-Lend-Countries_Not_Lent']"
 											href="/lend/countries-not-lent"
 											class="tw-text-primary tw-text-left hover:tw-text-action
-												tw-py-1 tw-inline-block"
+												tw-py-1 tw-inline-block tw-no-underline hover:tw-underline"
 										>
 											Countries I haven't lent to
 										</a>
@@ -336,10 +337,11 @@ export default {
 }
 
 .mega-menu-link {
-	@apply tw-text-primary hover:tw-text-action tw-inline-block tw-py-1 tw-no-underline;
+	@apply tw-text-primary hover:tw-text-action tw-inline-block tw-py-1 tw-no-underline hover:tw-underline;
 }
 
 .link-item {
 	width: 11rem;
+	@apply hover:tw-text-action tw-no-underline hover:tw-underline;
 }
 </style>

--- a/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendMenu.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/LendMenu/KvLendMenu.vue
@@ -115,7 +115,9 @@ export default {
 					query: gql`
 						query lendMenuPrivateData($userId: Int!) {
 							lend {
-								loans(userId: $userId, limit: 0) {
+								loans(limit: 1, filters: {
+									lenderFavorite: $userId
+								}) {
 									totalCount
 								}
 							}


### PR DESCRIPTION
- Error in private menu query, change it to the current one in TheHeader component
- Style inconsistencies related to links
- Changing tag to div, because of header for now. (If we add the header tag again we should restructure TheHeader file component.
- Sticky position in pages like mykiva was blocking the full height shadow when a menu is open
