### PR TITLE
feat: preload menu headers to avoid delay in showing menu

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -145,7 +145,7 @@
 </template>
 
 <script>
-import { defineAsyncComponent, ref } from 'vue';
+import { defineAsyncComponent, onMounted, ref } from 'vue';
 import {
 	mdiAccountCircle, mdiMenu, mdiChevronDown, mdiMagnify,
 } from '@mdi/js';
@@ -203,6 +203,12 @@ export default {
 		const openSearch = () => {
 			emit('open-search', searchButton.value?.offsetLeft);
 		};
+
+		onMounted(() => {
+			import('./KvHeaderMobileMenu.vue');
+			import('./KvHeaderMyKivaMenu.vue');
+			import('./LendMenu/KvLendMenu.vue');
+		});
 
 		return {
 			mdiAccountCircle,


### PR DESCRIPTION
Issue: Header menu was taking some time to load, user just seeing the opacity background while loading

https://github.com/user-attachments/assets/111c475d-7960-4dd0-adc4-2197888c605a

After preloading components:

https://github.com/user-attachments/assets/58e18a42-e65a-4a9b-a4ba-59718b31cd4d


