### PR TITLE
feat: when calling one time checkout and create gf, return all the data

### DIFF
--- a/@kiva/kv-shop/src/basketItems.ts
+++ b/@kiva/kv-shop/src/basketItems.ts
@@ -33,9 +33,14 @@ export async function setTipDonation({ amount, apollo, metadata }: SetTipDonatio
 					metadata: $metadata,
 				})
 				{
+					basketItemType
 					id
-					price
 					isTip
+					isUserEdited
+					metadata {
+						campaignId
+					}
+					price
 				}
 			}
 		}`,


### PR DESCRIPTION
Adds more data to the return of `executeOneTimeCheckoutForGivingFund`. This will make it much easier to route to the newly created giving fund on success. 

Returned data now looks like: 
<img width="622" height="376" alt="Screenshot 2025-08-14 at 3 03 18 PM" src="https://github.com/user-attachments/assets/82ec1cb6-7e3f-4c86-a5d3-1fbea6d30c28" />

And includes everything about the multistep process of `executeOneTimeCheckoutForGivingFund`