### PR TITLE
fix: mp-1832 fixing responsive layout for KvLendCta

### DIFF
--- a/@kiva/kv-components/src/vue/KvLendCta.vue
+++ b/@kiva/kv-components/src/vue/KvLendCta.vue
@@ -457,7 +457,8 @@ export default {
 			),
 			selectedDropdownOption: OTHER_OPTION,
 			OTHER_OPTION,
-			viewportWidth: window.innerWidth,
+			// SSR-safe viewport width initialization
+			viewportWidth: typeof window !== 'undefined' ? window.innerWidth : 1024,
 			resizeHandler: undefined,
 		};
 	},
@@ -663,15 +664,17 @@ export default {
 		},
 	},
 	mounted() {
-		this.viewportWidth = window.innerWidth;
-		this.resizeHandler = throttle(() => {
+		if (typeof window !== 'undefined') {
 			this.viewportWidth = window.innerWidth;
-		}, 50);
+			this.resizeHandler = throttle(() => {
+				this.viewportWidth = window.innerWidth;
+			}, 50);
 
-		window.addEventListener('resize', this.resizeHandler);
+			window.addEventListener('resize', this.resizeHandler);
+		}
 	},
 	beforeDestroy() {
-		if (this.resizeHandler) {
+		if (this.resizeHandler && typeof window !== 'undefined') {
 			window.removeEventListener('resize', this.resizeHandler);
 		}
 	},


### PR DESCRIPTION
The KvLendCta component was split into separate mobile and desktop layouts - mobile screens stack preset buttons, dropdown, and CTA vertically with responsive positioning based on screen width, while desktop maintains the original horizontal layout unchanged, plus fixes for mobile-specific states and dropdown trimming at very small sizes.
<img width="423" height="137" alt="image" src="https://github.com/user-attachments/assets/cb037cf4-1de1-45dd-beeb-06c6005029ec" />
<img width="302" height="123" alt="image" src="https://github.com/user-attachments/assets/cf162936-bec8-491f-94ba-01ca1380609c" />
