### PR TITLE
fix: migrate prior sm radii usages to be xs to restore the 4px radius

### DIFF
--- a/@kiva/kv-components/src/vue/KvCheckbox.vue
+++ b/@kiva/kv-components/src/vue/KvCheckbox.vue
@@ -30,7 +30,7 @@
 					tw-w-3 tw-h-3
 					tw-mr-2
 					tw-flex-shrink-0
-					tw-rounded-sm
+					tw-rounded-xs
 					tw-border
 					tw-flex tw-justify-center tw-items-center tw-overflow-hidden
 					tw-transition-all tw-duration-100

--- a/@kiva/kv-components/src/vue/KvCheckoutReceipt.vue
+++ b/@kiva/kv-components/src/vue/KvCheckoutReceipt.vue
@@ -3,7 +3,7 @@
 		<h2 class="checkout-receipt__headline">
 			Order Confirmation
 		</h2>
-		<div class="checkout-receipt__wrapper tw-bg-primary tw-p-4 tw-rounded-sm tw-border tw-border-tertiary">
+		<div class="checkout-receipt__wrapper tw-bg-primary tw-p-4 tw-rounded-xs tw-border tw-border-tertiary">
 			<section
 				data-testid="lender-info"
 				class="section section--lender-info"

--- a/@kiva/kv-components/src/vue/KvInlineActivityCard.vue
+++ b/@kiva/kv-components/src/vue/KvInlineActivityCard.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="tw-flex tw-items-center tw-gap-1 tw-py-0.5 tw-px-1 tw-shadow-lg tw-rounded-sm tw-bg-white"
+		class="tw-flex tw-items-center tw-gap-1 tw-py-0.5 tw-px-1 tw-shadow-lg tw-rounded-xs tw-bg-white"
 	>
 		<KvUserAvatar
 			:lender-image-url="lenderImageUrl"

--- a/@kiva/kv-components/src/vue/KvLoadingPlaceholder.vue
+++ b/@kiva/kv-components/src/vue/KvLoadingPlaceholder.vue
@@ -6,7 +6,7 @@
 			tw-relative
 			tw-overflow-hidden
 			tw-bg-tertiary
-			tw-rounded-sm
+			tw-rounded-xs
 		"
 	>
 	</div>

--- a/@kiva/kv-components/src/vue/KvTextInput.vue
+++ b/@kiva/kv-components/src/vue/KvTextInput.vue
@@ -17,7 +17,7 @@
 					tw-h-6 tw-w-full
 					tw-px-2
 					tw-border
-					tw-rounded-sm
+					tw-rounded-xs
 					tw-appearance-none
 					tw-text-base
 					tw-ring-inset

--- a/@kiva/kv-components/src/vue/KvTreeMapChart.vue
+++ b/@kiva/kv-components/src/vue/KvTreeMapChart.vue
@@ -13,7 +13,7 @@
 			/>
 			<p
 				v-if="!loading"
-				class="tw-rounded-sm tw-box-border tw-overflow-hidden tw-text-small"
+				class="tw-rounded-xs tw-box-border tw-overflow-hidden tw-text-small"
 				:class="colorClasses(index)"
 				style="width: calc(100% - 0.25rem); height: calc(100% - 0.25rem);"
 				@mouseenter="setHoverBlock(block)"

--- a/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
@@ -18,7 +18,7 @@ export default {
 	argTypes: {
 		bgColorClass: { control: 'select', options: ['tw-bg-primary', 'tw-bg-secondary', 'tw-bg-tertiary', 'tw-bg-action', 'tw-bg-caution', 'tw-bg-danger'] },
 		borderClass: { control: 'select', options: ['tw-border-none', 'tw-border', 'tw-border tw-border-secondary', 'tw-border tw-border-tertiary', 'tw-border tw-border-action', 'tw-border-2 tw-border-caution', 'tw-border-2 tw-border-danger', 'tw-border tw-border-2'] },
-		radiusClass: { control: 'select', options: ['tw-rounded-sm', 'tw-rounded', 'tw-rounded-lg', 'tw-rounded-full'] },
+		radiusClass: { control: 'select', options: ['tw-rounded-xs', 'tw-rounded-sm', 'tw-rounded-md', 'tw-rounded', 'tw-rounded-lg', 'tw-rounded-xl', 'tw-rounded-full'] },
 		shadowClass: { control: 'select', options: ['tw-shadow', 'tw-shadow-lg', 'tw-shadow-none'] },
 		theme: { control: 'select', options: ['default', 'greenLight', 'greenDark', 'marigoldLight', 'stoneLight', 'stoneDark'] },
 		headline: { control: 'text' },

--- a/@kiva/kv-components/src/vue/stories/KvMaterialIcon.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvMaterialIcon.stories.js
@@ -167,7 +167,7 @@ export const WithAccessibleText = (templateArgs, { argTypes }) => ({
 	template: `
 		<div>
 			<p class="tw-mb-2">If you don't include text and your icon is not decorative, be sure to include screen-reader text</p>
-			<button class="tw-rounded-sm tw-bg-secondary hover:tw-bg-tertiary tw-p-1 tw-inline-flex">
+			<button class="tw-rounded-xs tw-bg-secondary hover:tw-bg-tertiary tw-p-1 tw-inline-flex">
 				<kv-material-icon class="tw-w-3" :icon="mdiClose" />
 				<span class="tw-sr-only">Close modal</span>
 			</button>


### PR DESCRIPTION
Updates prior usages of the `sm` radius to be `xs` which is our new 4px variable.

Also verified that storybook sizes are correct now:
<img width="888" height="607" alt="image" src="https://github.com/user-attachments/assets/e11468b4-6e73-4cf8-8cea-b387328b8406" />
