### PR TITLE
fix: menu scroll, avatar menu opening on resize and menu shadow height

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader.vue
@@ -1,11 +1,11 @@
 <template>
 	<kv-theme-provider
 		tag="div"
-		class="tw-bg-primary tw-relative"
+		class="tw-bg-primary"
 	>
 		<nav
-			class="tw-font-medium"
-			style="height: 3.75rem;"
+			class="tw-font-medium tw-relative"
+			:style="{ height: HEADER_HEIGHT }"
 		>
 			<kv-page-container>
 				<!-- link bar -->
@@ -55,11 +55,11 @@
 					tw-bg-eco-green-4
 					bg-opacity-50 tw-min-h-screen
 				"
-				style="top: 3.75rem;"
+				:style="{ top: HEADER_HEIGHT }"
 			>
 				<div
-					class="tw-bg-primary"
-					:style="menuPosition"
+					class="tw-bg-primary tw-overflow-y-auto"
+					:style="{ ...menuPosition, maxHeight: `calc(100vh - ${HEADER_HEIGHT})` }"
 					@mouseover="onHover(activeHeaderItem, menuComponent)"
 					@mouseout="onHover()"
 				>
@@ -87,6 +87,8 @@ import KvHeaderLinkBar from './KvWwwHeader/KvHeaderLinkBar.vue';
 import KvHeaderLogo from './KvWwwHeader/KvHeaderLogo.vue';
 import KvThemeProvider from './KvThemeProvider.vue';
 import KvPageContainer from './KvPageContainer.vue';
+
+const HEADER_HEIGHT = '3.75rem';
 
 export default {
 	components: {
@@ -194,6 +196,7 @@ export default {
 		};
 
 		return {
+			HEADER_HEIGHT,
 			emitLendMenuEvent,
 
 			linksVisible,

--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -38,7 +38,7 @@
 		<KvHeaderDropdownLink
 			v-kv-track-event="['TopNav', 'click-TakeAction']"
 			ref-name="takeActionButton"
-			base-class="tw-hidden lg:tw-inline-flex"
+			base-class="tw-hidden lg:tw-inline-flex tw-py-2"
 			:menu-component="KvHeaderTakeActionMenu"
 			:open-menu-item="openMenuItem"
 			:dropdown-icon="mdiChevronDown"
@@ -52,7 +52,7 @@
 		<KvHeaderDropdownLink
 			v-kv-track-event="['TopNav', 'click-About']"
 			ref-name="aboutUsLink"
-			base-class="tw-hidden lg:tw-inline-flex"
+			base-class="tw-hidden lg:tw-inline-flex tw-py-2"
 			:menu-component="KvHeaderAboutMenu"
 			:open-menu-item="openMenuItem"
 			:dropdown-icon="mdiChevronDown"
@@ -92,7 +92,7 @@
 			/>
 		</a>
 		<div
-			class="tw-cursor-pointer tw-flex tw-items-center tw-gap-1"
+			class="tw-cursor-pointer tw-flex tw-items-center tw-gap-1 tw-py-1.5"
 			@mouseover="handleAvatarMenuPosition"
 			@mouseout="handleMouseOut(AVATAR_MENU_ID)"
 			@touchstart="handleTouchStart(AVATAR_MENU_ID)"
@@ -234,7 +234,7 @@ export default {
 			const rightOverflow = menuLeft + AVATAR_MENU_WIDTH > window.outerWidth;
 			return {
 				...(rightOverflow ? { right: 0 } : { left: props.isMobile ? 0 : `${menuLeft}px` }),
-				borderRadius: '0px 0px 8px 8px',
+				borderRadius: props.isMobile ? 'auto' : '0px 0px 8px 8px',
 				width: props.isMobile ? '100%' : 'auto',
 			};
 		};
@@ -259,7 +259,7 @@ export default {
 		};
 
 		const handleAvatarMenuPositionThrottled = throttle(() => {
-			if (props.openMenuItem) {
+			if (openMenuId.value === AVATAR_MENU_ID) {
 				handleAvatarMenuPosition();
 			}
 		}, 50);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1976

Fixes:
- Avatar menu opening on screen resize
- Menus wasn't scrolling
- Dropdowns needed padding to keep menus open on mouse hover bellow them
- Remove border radius on mobile menu

