### PR TITLE
fix: menu getting closed when hover on header edge and adding test id…

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderDropdownLink.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderDropdownLink.vue
@@ -2,9 +2,9 @@
 	<a
 		:ref="refName"
 		class="
-			tw-no-underline hover:tw-no-underline
+			tw-py-1 tw-no-underline hover:tw-no-underline
 			tw-text-primary hover:tw-text-action
-			tw-items-center tw-rounded tw-cursor-pointer
+			tw-items-center tw-cursor-pointer
 		"
 		:href="href"
 		:class="computedClass"

--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -21,13 +21,12 @@
 		<!-- lend -->
 		<KvHeaderDropdownLink
 			v-kv-track-event="['TopNav', 'click-Lend']"
-			class="tw-border tw-rounded-md tw-px-1.5 tw-py-1"
 			ref-name="lendButton"
 			:href="lendUrl"
 			:menu-component="KvLendMenu"
 			:open-menu-item="openMenuItem"
 			:dropdown-icon="mdiChevronDown"
-			base-class="tw-inline-flex"
+			base-class="tw-inline-flex tw-border tw-rounded-md tw-px-1.5 tw-py-1"
 			@on-hover="handleOnHover"
 			@mouseout="handleMouseOut('lendButton')"
 			@touchstart="handleTouchStart('lendButton', KvLendMenu)"
@@ -43,8 +42,8 @@
 			:open-menu-item="openMenuItem"
 			:dropdown-icon="mdiChevronDown"
 			send-link-position
-			@on-hover="onHover"
-			@mouseout="onHover()"
+			@on-hover="handleOnHover"
+			@mouseout="handleMouseOut('takeActionButton')"
 		>
 			Take action
 		</KvHeaderDropdownLink>
@@ -52,13 +51,14 @@
 		<KvHeaderDropdownLink
 			v-kv-track-event="['TopNav', 'click-About']"
 			ref-name="aboutUsLink"
+			test-id="header-about"
 			base-class="tw-hidden lg:tw-inline-flex tw-py-2"
 			:menu-component="KvHeaderAboutMenu"
 			:open-menu-item="openMenuItem"
 			:dropdown-icon="mdiChevronDown"
 			send-link-position
-			@on-hover="onHover"
-			@mouseout="onHover()"
+			@on-hover="handleOnHover"
+			@mouseout="handleMouseOut('aboutUsLink')"
 		>
 			About
 		</KvHeaderDropdownLink>
@@ -85,6 +85,7 @@
 			href="/basket"
 			class="header-link tw-relative"
 			:class="{'tw-text-tertiary': !!openMenuItem}"
+			test-id="header-basket"
 		>
 			<kv-icon-bag
 				class="tw-w-3 tw-h-3 tw-pointer-events-none"
@@ -234,6 +235,7 @@ export default {
 			const rightOverflow = menuLeft + AVATAR_MENU_WIDTH > window.outerWidth;
 			return {
 				...(rightOverflow ? { right: 0 } : { left: props.isMobile ? 0 : `${menuLeft}px` }),
+				marginTop: '-2px', // Avoid closing avatar menu on header edge
 				borderRadius: props.isMobile ? 'auto' : '0px 0px 8px 8px',
 				width: props.isMobile ? '100%' : 'auto',
 			};


### PR DESCRIPTION
…s to header elements

https://kiva.atlassian.net/browse/MP-1986
https://kiva.atlassian.net/browse/MP-1987

- Even though seems like it's currently happening on prod, if you go to the bottom edge of a header dropdown, the menu closes. Adding some extra padding to ensure not being closed on the edge

- ATB issue was because it's looking at these test-ids to calculate its position