### PR TITLE
fix: test id syntax and using show for basket for kvAtbModal query

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -51,7 +51,7 @@
 		<KvHeaderDropdownLink
 			v-kv-track-event="['TopNav', 'click-About']"
 			ref-name="aboutUsLink"
-			test-id="header-about"
+			data-testid="header-about"
 			base-class="tw-hidden lg:tw-inline-flex tw-py-2"
 			:menu-component="KvHeaderAboutMenu"
 			:open-menu-item="openMenuItem"
@@ -79,13 +79,13 @@
 		</a>
 		<!-- basket (items) -->
 		<a
-			v-if="basketCount > 0"
+			v-show="basketCount > 0"
 			ref="basketLink"
 			v-kv-track-event="['TopNav', 'click-Basket']"
 			href="/basket"
 			class="header-link tw-relative"
 			:class="{'tw-text-tertiary': !!openMenuItem}"
-			test-id="header-basket"
+			data-testid="header-basket"
 		>
 			<kv-icon-bag
 				class="tw-w-3 tw-h-3 tw-pointer-events-none"


### PR DESCRIPTION
Fixing test-id syntax and using v-show on basket link since ATB modal fallback target (About dropdown) isn't next to the basket in the new design