### PR TITLE
fix: menus stuck when mouse leaves in desktop

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -220,6 +220,8 @@ export default {
 
 		const handleOnHover = (item, menu, targetPosition = null) => {
 			if (!props.isMobile) {
+				openMenuId.value = item;
+
 				onHover(
 					item,
 					menu,


### PR DESCRIPTION
Fix the issue when menu is still open when mouse leave the page in desktop