### PR TITLE
fix: avoid sending mouseover event on mobile in DropdownLink component

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderDropdownLink.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderDropdownLink.vue
@@ -73,21 +73,23 @@ export default {
 		});
 
 		const handleMouseOver = () => {
-			let linkPos = null;
-			if (props.sendLinkPosition) {
-				const linkEl = proxy.$refs[props.refName];
-				if (linkEl) {
-					const linkRect = linkEl.getBoundingClientRect();
-					const centerX = linkRect?.left + linkRect?.width / 2;
-					linkPos = {
-						left: `${centerX}px`,
-						transform: 'translateX(-50%)',
-						borderRadius: '0px 0px 8px 8px',
-					};
+			if (!navigator.maxTouchPoints) {
+				let linkPos = null;
+				if (props.sendLinkPosition) {
+					const linkEl = proxy.$refs[props.refName];
+					if (linkEl) {
+						const linkRect = linkEl.getBoundingClientRect();
+						const centerX = linkRect?.left + linkRect?.width / 2;
+						linkPos = {
+							left: `${centerX}px`,
+							transform: 'translateX(-50%)',
+							borderRadius: '0px 0px 8px 8px',
+						};
+					}
 				}
-			}
 
-			emit('on-hover', props.refName, props.menuComponent, linkPos);
+				emit('on-hover', props.refName, props.menuComponent, linkPos);
+			}
 		};
 		return {
 			computedClass,


### PR DESCRIPTION
Mouseover event should only be emitted on desktop