### PR TITLE
feat: using fallback icon when user has no profile photo

### DIFF
--- a/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
+++ b/@kiva/kv-components/src/vue/KvWwwHeader/KvHeaderLinkBar.vue
@@ -107,13 +107,20 @@
 				{{ numeral(balance).format('$0') }}
 			</span>
 			<!-- avatar (sm, auth) -->
-			<KvUserAvatar
-				v-if="loggedIn"
-				ref="avatar"
-				:lender-name="lenderName"
-				:lender-image-url="lenderImageUrl"
-				is-small
-			/>
+			<template v-if="loggedIn">
+				<KvUserAvatar
+					v-if="lenderImageUrl"
+					ref="avatar"
+					:lender-name="lenderName"
+					:lender-image-url="lenderImageUrl"
+					is-small
+				/>
+				<kv-material-icon
+					v-else
+					:icon="mdiAccountCircle"
+					class="tw-w-3"
+				/>
+			</template>
 		</div>
 		<!-- sign in (lg, no-auth) -->
 		<a


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2057

<img width="325" height="86" alt="image" src="https://github.com/user-attachments/assets/243506fc-f81e-40ee-8b8d-b53364e9f857" />
