### PR TITLE
fix: update validator for KvSecondaryNav headinglink

### DIFF
--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -136,6 +136,11 @@ export default {
 			required: false,
 			default: () => ({}),
 			validator(value) {
+				// Allow empty object or undefined for optional prop
+				if (!value || Object.keys(value).length === 0) {
+					return true;
+				}
+				// If object has properties, validate required fields
 				return Object.prototype.hasOwnProperty.call(value, 'text')
 					&& Object.prototype.hasOwnProperty.call(value, 'href');
 			},


### PR DESCRIPTION
Update the validator to account for default value (empty object) or nonexistence of a value on the headingLink parameter 