### PR TITLE
feat: fallback font styles adjusted to match primary styles

### DIFF
--- a/@kiva/kv-components/src/vue/stories/StyleguidePrimitives.stories.js
+++ b/@kiva/kv-components/src/vue/stories/StyleguidePrimitives.stories.js
@@ -1,6 +1,7 @@
 import resolveConfig from 'tailwindcss/resolveConfig'; // eslint-disable-line import/no-extraneous-dependencies
 import { tailwindConfig, textStyles } from '@kiva/kv-tokens';
 import { headerNumberCase, kebabCase, removeObjectProperty } from '#utils/themeUtils';
+import KvButton from '../KvButton.vue';
 import KvGrid from '../KvGrid.vue';
 import KvPageContainer from '../KvPageContainer.vue';
 import KvTab from '../KvTab.vue';
@@ -34,6 +35,7 @@ export default {
 export const Primitives = (templateArgs, { argTypes }) => ({
 	props: Object.keys(argTypes),
 	components: {
+		KvButton,
 		KvGrid,
 		KvPageContainer,
 		KvTab,
@@ -228,55 +230,105 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 		<hr>
 		<section class="tw-py-8">
 			<h2 class="tw-mb-4">Text Styles</h2>
+			<div class="tw-flex tw-gap-2 tw-sticky tw-top-0 tw-bg-white tw-py-2">
+				<kv-button variant="secondary" @click="newPangram">New Pangram</kv-button>
+			</div>
+			<br><br>
 			<ul class="tw-flex tw-flex-wrap tw-flex-col tw-gap-4">
 				<li
 					v-for="typeStyle in kivaTypography"
-					:key="buildClassName('text', typeStyle)"
+					:key="buildClassName('text', typeStyleKeyToClassName(typeStyle))"
 					class="tw-overflow-x-auto tw-w-full"
 				>
 					<button
 						class="tw-text-left tw-font-book hover:tw-text-action-highlight"
-						@click="copy(buildClassName('tw-text', typeStyle))"
+						@click="copy(buildClassName('tw-text', typeStyleKeyToClassName(typeStyle)))"
 					>
 						<p
 							class="tw-mb-1"
-							:class="buildClassName('tw-text', typeStyle)"
+							:class="buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))"
 							style="width: 12em;"
 						>
-							The quick brown fox jumps over the lazy dog
+							{{ pangram }}
 						</p>
-						<span>.{{buildClassName('tw-text', typeStyle)}}</span>
+						<span>.{{buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))}}</span>
 					</button>
 				</li>
 			</ul>
 		</section>
 		<section class="tw-py-8">
 			<h2 class="tw-mb-4">Text Styles <i>(Italics)</i></h2>
+			<div class="tw-flex tw-gap-2 tw-sticky tw-top-0 tw-bg-white tw-py-2">
+				<kv-button variant="secondary" @click="newPangram">New Pangram</kv-button>
+			</div>
 			<ul class="tw-flex tw-flex-wrap tw-flex-col tw-gap-4">
 				<li
 					v-for="typeStyle in kivaTypography"
-					:key="buildClassName('text', typeStyle)"
+					:key="buildClassName('text', typeStyleKeyToClassName(typeStyle))"
 					class="tw-overflow-x-auto tw-w-full"
 				>
 					<button
 						class="tw-text-left tw-font-book hover:tw-text-action-highlight"
-						@click="copy(buildClassName('tw-text', typeStyle))"
+						@click="copy(buildClassName('tw-text', typeStyleKeyToClassName(typeStyle)))"
 					>
 						<p
 							class="tw-mb-1 tw-italic"
-							:class="buildClassName('tw-text', typeStyle)"
+							:class="buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))"
 							style="width: 12em;"
 						>
-							The quick brown fox jumps over the lazy dog
+							{{ pangram }}
 						</p>
-						<span>.{{buildClassName('tw-text', typeStyle)}} .tw-italic</span>
+						<span>.{{buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))}} .tw-italic</span>
 					</button>
+				</li>
+			</ul>
+		</section>
+		<section class="tw-py-8">
+			<h2 class="tw-mb-4">Fallback Text Styles</h2>
+			<div class="tw-flex tw-gap-2 tw-sticky tw-top-0 tw-bg-white tw-py-2">
+				<kv-button variant="secondary" @click="newPangram">New Pangram</kv-button>
+			</div>
+			<ul class="tw-flex tw-flex-wrap tw-flex-col tw-gap-4">
+				<li
+					v-for="typeStyle in kivaTypography"
+					:key="buildClassName('text', typeStyleKeyToClassName(typeStyle))"
+					class="tw-overflow-x-auto tw-w-full"
+				>
+					<p
+						class="tw-mb-1"
+						:class="[buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))]"
+						style="width: 12em;"
+					>
+						{{ pangram }}
+					</p>
+					<span>.{{buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))}}</span>
+					<p
+						class="tw-mb-1 tw-mt-1.5"
+						:class="[buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))]"
+						style="width: 12em;"
+						:style="fallbackStyle(typeStyle, true)"
+					>
+						{{ pangram }}
+					</p>
+					<span>.{{buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))}} with adjusted fallback font-family</span>
+					<p
+						class="tw-mb-1 tw-mt-1.5"
+						:class="[buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))]"
+						style="width: 12em;"
+						:style="fallbackStyle(typeStyle, false)"
+					>
+						{{ pangram }}
+					</p>
+					<span>.{{buildClassName('tw-text', typeStyleKeyToClassName(typeStyle))}} with non-adjusted fallback font-family</span>
 				</li>
 			</ul>
 		</section>
 		<hr>
 		<section class="tw-py-8">
 			<h2 class="tw-mb-4">Font Weights</h2>
+			<div class="tw-flex tw-gap-2 tw-sticky tw-top-0 tw-bg-white tw-py-2">
+				<kv-button variant="secondary" @click="newPangram">New Pangram</kv-button>
+			</div>
 			<ul class="tw-flex tw-flex-wrap tw-flex-col tw-gap-4">
 				<li
 					v-for="fontWeight in fontWeights"
@@ -287,7 +339,7 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 						@click="copy(buildClassName('tw-font', fontWeight[0]))"
 					>
 						<p :class="buildClassName('tw-font', fontWeight[0])">
-							The quick brown fox jumps over the lazy dog
+							{{ pangram }}
 						</p>
 						<span>.{{buildClassName('tw-font', fontWeight[0])}}</span>
 					</button>
@@ -297,6 +349,9 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 		<hr>
 		<section class="tw-py-8">
 			<h2 class="tw-mb-4">Font Weights (Serif)</h2>
+			<div class="tw-flex tw-gap-2 tw-sticky tw-top-0 tw-bg-white tw-py-2">
+				<kv-button variant="secondary" @click="newPangram">New Pangram</kv-button>
+			</div>
 			<ul class="tw-flex tw-flex-wrap tw-flex-col tw-gap-4">
 				<li
 					v-for="fontWeight in fontWeights"
@@ -307,7 +362,7 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 						@click="copy(buildClassName('tw-font', fontWeight[0]))"
 					>
 						<p :class="[buildClassName('tw-font', fontWeight[0]), 'tw-font-serif']">
-							The quick brown fox jumps over the lazy dog
+							{{ pangram }}
 						</p>
 						<span>.{{buildClassName('tw-font', fontWeight[0])}}</span>
 					</button>
@@ -451,12 +506,13 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 			textColor: buildValuesFromThemeObj(theme.textColor),
 			borderColor: buildValuesFromThemeObj(theme.borderColor),
 			space: buildValuesFromThemeObj(theme.spacing).sort((a, b) => a[0] - b[0]),
-			kivaTypography: Object.keys(textStyles).map((key) => headerNumberCase(kebabCase(key)).replace('text-', '')),
+			kivaTypography: Object.keys(textStyles),
 			fontWeights: buildValuesFromThemeObj(theme.fontWeight),
 			breakpoints: buildValuesFromThemeObj(removeObjectProperty(theme.screens, 'print')),
 			radii: buildValuesFromThemeObj(theme.borderRadius),
 			opacity: buildValuesFromThemeObj(theme.opacity),
 			zIndices: buildValuesFromThemeObj(theme.zIndex).sort((a, b) => a[1] - b[1]),
+			pangram: 'The quick brown fox jumps over the lazy dog',
 			isToastVisible: false,
 			toastMessage: '',
 		};
@@ -493,6 +549,37 @@ export const Primitives = (templateArgs, { argTypes }) => ({
 			];
 			const isStatic = staticColors.some((staticColor) => colorName[0].includes(staticColor));
 			return isStatic;
+		},
+		newPangram() {
+			const pangrams = [
+				'The quick brown fox jumps over the lazy dog',
+				'Sphinx of black quartz, judge my vow',
+				'How vexingly quick daft zebras jump',
+				'The five boxing wizards jump quickly',
+				'Jackdaws love my big sphinx of quartz',
+				'Fix problem quickly with galvanized jets',
+				'Heavy boxes perform quick waltzes and jigs',
+				'Sixty zippers were quickly picked from the woven jute bag',
+				'Jinxed wizards pluck ivy from the big quilt',
+				'Adjusting quiver and bow, Zombyx fought the ghouls',
+				'All questions asked by five watched experts amaze the judge',
+				'The public was amazed to view the quickness and dexterity of the juggler',
+				'William said that everything about his jacket was in quite good condition except for the zipper',
+			];
+			const randomIndex = Math.floor(Math.random() * pangrams.length);
+			this.pangram = pangrams[randomIndex];
+		},
+		typeStyleKeyToClassName(key) {
+			return headerNumberCase(kebabCase(key)).replace('text-', '');
+		},
+		fallbackStyle(key, adjusted = false) {
+			const style = {};
+			if (!textStyles[key].fontFamily || textStyles[key].fontFamily?.startsWith('Post')) {
+				style.fontFamily = adjusted ? 'PostGrotesk-fallback' : "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif";
+			} else if (textStyles[key].fontFamily?.startsWith('dove')) {
+				style.fontFamily = adjusted ? 'dovetail-mvb-fallback' : "ui-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Palatino', Georgia, 'Times New Roman', serif";
+			}
+			return style;
 		},
 	},
 });

--- a/@kiva/kv-tokens/configs/kivaTypography.js
+++ b/@kiva/kv-tokens/configs/kivaTypography.js
@@ -12,9 +12,106 @@ const {
 } = designTokens;
 
 /**
+ * Calculates the necessary font adjustments for a fallback font to match
+ * the appearance of a web font as closely as possible.
+ * For more info, see https://developer.chrome.com/blog/font-fallbacks
+ *
+ * @param {Object} params - The parameters for the calculation.
+ * @param {number} params.ascent - The ascent value of the web font.
+ * @param {number} params.descent - The descent value of the web font.
+ * @param {number} params.lineGap - The line gap value of the web font.
+ * @param {number} params.unitsPerEm - The units per em value of the web font.
+ * @param {number} params.avgCharWidth - The average character width of the web font.
+ * @param {number} params.fallbackUnitsPerEm - The units per em value of the fallback font.
+ * @param {number} params.fallbackAvgCharWidth - The average character width of the fallback font.
+ * @returns {Object} CSS properties for font adjustments to be spread into a @font-face rule.
+ */
+export const adjustFallbackFont = ({
+	ascent,
+	descent,
+	lineGap,
+	unitsPerEm,
+	avgCharWidth = 1,
+	fallbackUnitsPerEm = unitsPerEm,
+	fallbackAvgCharWidth = avgCharWidth,
+} = {}) => {
+	const asPercent = (value) => `${value * 100}%`;
+	// avgCharacterWidth of web font / avgCharacterWidth of fallback font
+	const sizeAdjust = ((avgCharWidth / unitsPerEm) / (fallbackAvgCharWidth / fallbackUnitsPerEm));
+	return {
+		sizeAdjust: asPercent(sizeAdjust),
+		// web font ascent / (web font UPM * size-adjust)
+		ascentOverride: asPercent(ascent / (unitsPerEm * sizeAdjust)),
+		// web font descent / (web font UPM * size-adjust)
+		descentOverride: asPercent(descent / (unitsPerEm * sizeAdjust)),
+		// web font lineGap / (web font UPM * size-adjust)
+		lineGapOverride: asPercent(lineGap / (unitsPerEm * sizeAdjust)),
+	};
+};
+
+/**
  WEB FONT DEFINITIONS
 */
 export const webFonts = [
+	/**
+	 * Fallback for Dovetail MVB Medium
+	 *
+	 * Dovetail MVB Medium metrics:
+	 * - ascent: 1081
+	 * - descent: -253
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 453
+	 *
+	 * Georgia metrics:
+	 * - unitPerEm: 2048
+	 * - xWidthAvg: 913
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'dovetail-mvb-fallback',
+			src: 'local("Georgia")',
+			...adjustFallbackFont({
+				ascent: 1081,
+				descent: 253,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 453,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 913,
+			}),
+		},
+	},
+	/**
+	 * Fallback for Dovetail MVB Medium Italic
+	 *
+	 * Dovetail MVB Medium Italic metrics:
+	 * - ascent: 1081
+	 * - descent: -253
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 430
+	 *
+	 * Georgia Italic metrics:
+	 * - unitPerEm: 2048
+	 * - xWidthAvg: 931
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'dovetail-mvb-fallback',
+			src: 'local("Georgia Italic")',
+			fontStyle: 'italic',
+			...adjustFallbackFont({
+				ascent: 1081,
+				descent: 253,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 430,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 931,
+			}),
+		},
+	},
 	// Note corresponding font weight in Tailwind is "normal"
 	{
 		'@font-face': {
@@ -24,6 +121,36 @@ export const webFonts = [
 			fontDisplay: 'swap',
 			// eslint-disable-next-line max-len
 			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-Medium.8c8a585.woff2) format(\'woff2\')',
+		},
+	},
+	/**
+	 * Fallback for Post Grotesk Medium
+	 *
+	 * Post Grotesk Medium metrics:
+	 * - ascent:948
+	 * - descent: -262
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 451
+	 *
+	 * Arial Bold metrics:
+	 * - unitsPerEm: 2048
+	 * - xWidthAvg: 983
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'PostGrotesk-fallback',
+			src: 'local("Arial Bold")',
+			fontWeight: '400',
+			...adjustFallbackFont({
+				ascent: 948,
+				descent: 262,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 451,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 983,
+			}),
 		},
 	},
 	// Note corresponding font weight in Tailwind is "normal"
@@ -37,6 +164,37 @@ export const webFonts = [
 			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-MediumItalic.133f41d.woff2) format(\'woff2\')',
 		},
 	},
+	/**
+	 * Fallback for Post Grotesk Medium Italic
+	 *
+	 * Post Grotesk Medium Italic metrics:
+	 * - ascent: 949
+	 * - descent: -259
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 451
+	 *
+	 * Arial Bold Italic metrics:
+	 * - unitsPerEm: 2048
+	 * - xWidthAvg: 983
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'PostGrotesk-fallback',
+			src: 'local("Arial Bold Italic")',
+			fontWeight: '400',
+			fontStyle: 'italic',
+			...adjustFallbackFont({
+				ascent: 949,
+				descent: 259,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 451,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 983,
+			}),
+		},
+	},
 	// Note corresponding font weight in Tailwind is "light"
 	{
 		'@font-face': {
@@ -45,6 +203,36 @@ export const webFonts = [
 			fontStyle: 'normal',
 			fontDisplay: 'swap',
 			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-Book.246fc8e.woff2) format(\'woff2\')',
+		},
+	},
+	/**
+	 * Fallback for Post Grotesk Book
+	 *
+	 * Post Grotesk Book metrics:
+	 * - ascent: 927
+	 * - descent: -252
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 440
+	 *
+	 * Arial metrics:
+	 * - unitsPerEm: 2048
+	 * - xWidthAvg: 913
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'PostGrotesk-fallback',
+			src: 'local("Arial")',
+			fontWeight: '300',
+			...adjustFallbackFont({
+				ascent: 927,
+				descent: 252,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 440,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 913,
+			}),
 		},
 	},
 	// Note corresponding font weight in Tailwind is "light"
@@ -56,6 +244,37 @@ export const webFonts = [
 			fontDisplay: 'swap',
 			// eslint-disable-next-line max-len
 			src: 'url(//www.kiva.org/static/fonts/PostGrotesk-BookItalic.4d06d39.woff2) format(\'woff2\')',
+		},
+	},
+	/**
+	 * Fallback for Post Grotesk Book Italic
+	 *
+	 * Post Grotesk Book Italic metrics:
+	 * - ascent: 927
+	 * - descent: -251
+	 * - lineGap: 0
+	 * - unitsPerEm: 1000
+	 * - xWidthAvg: 439
+	 *
+	 * Arial Italic metrics:
+	 * - unitsPerEm: 2048
+	 * - xWidthAvg: 913
+	 */
+	{
+		'@font-face': {
+			fontFamily: 'PostGrotesk-fallback',
+			src: 'local("Arial Italic")',
+			fontWeight: '300',
+			fontStyle: 'italic',
+			...adjustFallbackFont({
+				ascent: 927,
+				descent: 251,
+				lineGap: 0,
+				unitsPerEm: 1000,
+				avgCharWidth: 439,
+				fallbackUnitsPerEm: 2048,
+				fallbackAvgCharWidth: 913,
+			}),
 		},
 	},
 ];

--- a/@kiva/kv-tokens/configs/tailwind.config.js
+++ b/@kiva/kv-tokens/configs/tailwind.config.js
@@ -89,10 +89,8 @@ export default {
 			16: rem(space['16']),
 		},
 		fontFamily: {
-			// eslint-disable-next-line max-len
-			sans: [`${fonts.sans}, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif`],
-			// eslint-disable-next-line max-len
-			serif: [`${fonts.serif}, ui-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Palatino', Georgia, 'Times New Roman', serif`],
+			sans: [fonts.sans],
+			serif: [fonts.serif],
 		},
 		fontWeight: {
 			// Keeping "book" defined here for backwards compatibility

--- a/@kiva/kv-tokens/primitives.js
+++ b/@kiva/kv-tokens/primitives.js
@@ -414,8 +414,10 @@ export default {
 		16: 128,
 	},
 	fonts: {
-		sans: 'PostGrotesk',
-		serif: 'dovetail-mvb',
+		// eslint-disable-next-line max-len
+		sans: "PostGrotesk, PostGrotesk-fallback, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif",
+		// eslint-disable-next-line max-len
+		serif: "dovetail-mvb, dovetail-mvb-fallback, ui-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Palatino', Georgia, 'Times New Roman', serif",
 	},
 	fontSizes: {
 		base: {


### PR DESCRIPTION
This PR introduces fallback font styles for PostGrotesk and Dovetail MVB with adjustments to match the primary font style in size as closely possible. This minimizes layout shift and repaints, improving performance. See https://developer.chrome.com/blog/font-fallbacks for more details

The fallback font can't match the size of the primary font perfectly, because the exact sizing adjustments differ based on the content of the text. Instead, this uses the average character width, weighted against their occurrence in English. I used the calculation provided by [Capsize](https://seek-oss.github.io/capsize/) for this PR. I also added the ability to switch which pangram is used for displaying text styles in the primitives story, so that the difference between different text content can be seen.

<img width="625" height="492" alt="Screenshot 2025-09-24 at 11 32 37 AM" src="https://github.com/user-attachments/assets/c5c9e531-e2cd-404a-be80-df62ab048484" />
<img width="456" height="333" alt="Screenshot 2025-09-24 at 11 41 25 AM" src="https://github.com/user-attachments/assets/84a04f59-e225-4864-ba92-85a43b4e7ab4" />
