### PR TITLE
fix: add gender to loan card data to simplify where the fragment is used

### DIFF
--- a/@kiva/kv-components/src/vue/KvClassicLoanCard.vue
+++ b/@kiva/kv-components/src/vue/KvClassicLoanCard.vue
@@ -295,6 +295,7 @@ import KvLoanActivities, { KV_LOAN_ACTIVITIES_FRAGMENT } from './KvLoanActivitie
 export const KV_CLASSIC_LOAN_CARD_FRAGMENT = gql`
 	fragment KvClassicLoanCard on LoanBasic {
 		id
+		gender
 		image {
 			id
 			hash # for imageHash


### PR DESCRIPTION
Tracking down Apollo cache conflicts and `gender` fields seems central to the issues. We use `gender` in ATB modal, which is now a permanent feature, so we might as well add it to the shared fragment for multiple reasons.