### PR TITLE
feat: remove aggregate errors for add giving fund

### DIFF
--- a/@kiva/kv-shop/src/givingFunds.ts
+++ b/@kiva/kv-shop/src/givingFunds.ts
@@ -40,9 +40,8 @@ export async function addGivingFund({
 	});
 	if (result.errors) {
 		const errors = result.errors.map((error) => parseShopError(error));
-		const aggregate = new ShopError({ code: 'shop.failedAddGivingFund' });
-		aggregate.aggregateErrors(errors);
-		throw aggregate;
+		// return the first error
+		throw errors[0];
 	}
 
 	return result.data?.addGivingFund;


### PR DESCRIPTION
The aggregate shop errors are all returned in aggregate which makes them really hard to display to the user. We do this in checkout, but I think for addGivingFund we can just return the first error. 

After this fix and upcoming PR in cps: 

<img width="489" height="141" alt="Screenshot 2025-10-06 at 8 27 13 PM" src="https://github.com/user-attachments/assets/b5eff191-bfe2-421d-a292-c533849b3e11" />
