### PR TITLE
fix: expose new tw-text-label class

### DIFF
--- a/@kiva/kv-tokens/configs/kivaTypography.js
+++ b/@kiva/kv-tokens/configs/kivaTypography.js
@@ -533,7 +533,7 @@ export const textStyles = (() => {
 
 	const textCaption = {
 		fontFamily: fonts.sans,
-		fontWeight: fontWeights.normal,
+		fontWeight: fontWeights.light,
 		fontSize: rem(semanticFontSizes.small.small),
 		letterSpacing: em(letterSpacings.normal, semanticFontSizes.small.small),
 		lineHeight: em(lineHeightsAbsolute.caption.sm, semanticFontSizes.small.small),

--- a/@kiva/kv-tokens/configs/tailwind.config.js
+++ b/@kiva/kv-tokens/configs/tailwind.config.js
@@ -259,6 +259,7 @@ export default {
 				'.text-button-link': textStyles.textButtonLink,
 				'.text-upper': textStyles.textUpper,
 				'.text-caption': textStyles.textCaption,
+				'.text-label': textStyles.textLabel,
 			}, ['responsive']);
 		}),
 	],


### PR DESCRIPTION
Makes available new semantic styles for label.

Also updates font-weight for `tw-text-caption` which was changed to use "book/light"

Future updates will apply these styles to the `label` element which will bring some disruption as the element level override is not currently in place.