### PR TITLE
fix: handle gifs better in kvContentfulImg

### DIFF
--- a/@kiva/kv-components/src/vue/KvContentfulImg.vue
+++ b/@kiva/kv-components/src/vue/KvContentfulImg.vue
@@ -10,17 +10,19 @@
 			<!-- Set of image sources -->
 			<template v-if="sourceSizes.length > 0">
 				<!-- browser supports webp -->
-				<source
-					v-for="(image, index) in sourceSizes"
-					:key="'webp-image'+index"
-					:media="'('+image.media+')'"
-					type="image/webp"
-					:width="image.width ? image.width : null"
-					:height="image.height ? image.height : null"
-					:srcset="`
-						${buildUrl(image, 2)}&fit=${fit}&f=${focus}&fm=webp&q=${setQuality(image.width, '2x')} 2x,
-						${buildUrl(image)}&fit=${fit}&f=${focus}&fm=webp&q=${setQuality(image.width, '1x')} 1x`"
-				>
+				<template v-if="!isAnimatedGif">
+					<source
+						v-for="(image, index) in sourceSizes"
+						:key="'webp-image'+index"
+						:media="'('+image.media+')'"
+						type="image/webp"
+						:width="image.width ? image.width : null"
+						:height="image.height ? image.height : null"
+						:srcset="`
+							${buildUrl(image, 2)}${fitFocusParams}&fm=webp&q=${setQuality(image.width, '2x')} 2x,
+							${buildUrl(image)}${fitFocusParams}&fm=webp&q=${setQuality(image.width, '1x')} 1x`"
+					>
+				</template>
 				<!-- browser doesn't support webp -->
 				<!-- eslint-disable max-len -->
 				<source
@@ -30,8 +32,8 @@
 					:width="image.width ? image.width : null"
 					:height="image.height ? image.height : null"
 					:srcset="`
-						${buildUrl(image, 2)}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(image.width, '2x')} 2x,
-						${buildUrl(image)}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(image.width, '1x')} 1x`"
+						${buildUrl(image, 2)}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, image.width, '2x')} 2x,
+						${buildUrl(image)}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, image.width, '1x')} 1x`"
 				>
 				<!-- eslint-enable max-len -->
 				<!-- browser doesn't support picture element -->
@@ -39,7 +41,7 @@
 				<img
 					class="tw-max-w-full tw-max-h-full"
 					style="width: inherit; height: inherit; object-fit: inherit;"
-					:src="`${buildUrl()}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(width, '1x')}`"
+					:src="`${buildUrl()}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, width, '1x')}`"
 					:alt="caption || alt"
 					:loading="loading"
 				>
@@ -50,24 +52,27 @@
 			<template v-if="sourceSizes.length === 0">
 				<!-- browser supports webp -->
 				<source
+					v-if="!isAnimatedGif"
 					type="image/webp"
 					:srcset="`
-						${buildUrl(null, 2)}&fit=${fit}&f=${focus}&fm=webp&q=${setQuality(width, '2x')} 2x,
-						${buildUrl()}&fit=${fit}&f=${focus}&fm=webp&q=${setQuality(width, '1x')} 1x`"
+						${buildUrl(null, 2)}${fitFocusParams}&fm=webp&q=${setQuality(width, '2x')} 2x,
+						${buildUrl()}${fitFocusParams}&fm=webp&q=${setQuality(width, '1x')} 1x`"
 				>
 				<!-- browser doesn't support webp or browser doesn't support picture element -->
+				<!-- eslint-disable max-len -->
 				<img
 					class="tw-max-w-full tw-max-h-full"
 					style="width: inherit; height: inherit; object-fit: inherit;"
 					:srcset="`
-						${buildUrl(null, 2)}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(width, '2x')} 2x,
-						${buildUrl()}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(width, '1x')} 1x`"
-					:src="`${buildUrl()}&fit=${fit}&f=${focus}&fm=${fallbackFormat}&q=${setQuality(width, '1x')}`"
+						${buildUrl(null, 2)}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, width, '2x')} 2x,
+						${buildUrl()}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, width, '1x')} 1x`"
+					:src="`${buildUrl()}${fitFocusParams}${buildFormatQualityParams(effectiveFallbackFormat, width, '1x')}`"
 					:width="width ? width : null"
 					:height="height ? height : null"
 					:alt="caption || alt"
 					:loading="loading"
 				>
+				<!-- eslint-enable max-len -->
 			</template>
 		</picture>
 		<figcaption
@@ -137,11 +142,12 @@ export default {
 		},
 		/**
 		 * If the browser can't support webp we fallback to this image format.
-		 * `jpg, png, webp`
+		 * Defaults to the format derived from the source URL: gif→gif, png→png, jpg→jpg, webp→jpg.
+		 * `jpg, png, gif`
 		* */
 		fallbackFormat: {
 			type: String,
-			default: 'jpg',
+			default: null,
 			validator(value: string) {
 				// The value must match one of these strings
 				return value === null || ['jpg', 'png', 'gif'].indexOf(value) !== -1;
@@ -230,8 +236,29 @@ export default {
 			height,
 		} = toRefs(props);
 
+		const isAnimatedGif = computed(() => {
+			const path = contentfulSrc.value?.split('?')[0] ?? '';
+			return path.toLowerCase().endsWith('.gif');
+		});
+
+		const effectiveFallbackFormat = computed(() => {
+			if (props.fallbackFormat) return props.fallbackFormat;
+			const ext = contentfulSrc.value?.split('?')[0].split('.').pop()?.toLowerCase();
+			if (ext === 'png') return 'png';
+			if (ext === 'gif') return 'gif';
+			return 'jpg'; // jpg and webp both fall back to jpg
+		});
+
+		const fitFocusParams = computed(() => {
+			if (isAnimatedGif.value) return '';
+			return `&fit=${props.fit}&f=${props.focus}`;
+		});
+
 		const buildUrl = (image = null, multiplier = 1) => {
-			let src = image && image.url ? `${image.url}?` : `${contentfulSrc.value}?`;
+			const baseSrc = image && image.url ? image.url : contentfulSrc.value;
+			// For animated GIFs, skip dimension params — resizing may break animation
+			if (isAnimatedGif.value) return baseSrc;
+			let src = `${baseSrc}?`;
 			let imgWidth = image ? image.width : width.value;
 			let imgHeight = image ? image.height : height.value;
 			// The max contentful image size is 4000px so we have to
@@ -271,6 +298,13 @@ export default {
 			return 80;
 		};
 
+		// Contentful does not support `fm` or `q` params for GIF format.
+		// Requesting fm=webp for an animated GIF also strips the animation (returns first frame only).
+		const buildFormatQualityParams = (format: string, imgWidth: string | number, scale: string) => {
+			if (isAnimatedGif.value) return '';
+			return `&fm=${format}&q=${setQuality(imgWidth, scale)}`;
+		};
+
 		// Caption is derived from alt text starting with ^
 		// e.g. ^This is the caption text
 		const caption = computed(() => {
@@ -291,8 +325,12 @@ export default {
 		});
 
 		return {
+			buildFormatQualityParams,
 			buildUrl,
 			caption,
+			effectiveFallbackFormat,
+			fitFocusParams,
+			isAnimatedGif,
 			removeLeafIcon,
 			setQuality,
 		};

--- a/@kiva/kv-components/src/vue/stories/KvContentfulImg.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvContentfulImg.stories.js
@@ -224,3 +224,25 @@ GiantImage.args = {
 	height: 2000,
 	sourceSizes: [],
 };
+
+export const GiantGif = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		KvContentfulImg,
+	},
+	setup() { return { args }; },
+	template: `
+		<kv-contentful-img
+			alt="Descriptive alt text"
+			v-bind="args"
+		/>
+	`,
+});
+
+GiantGif.args = {
+	contentfulSrc: 'https://images.ctfassets.net/j0p9a6ql0rn7/4q5zPRN6hi0KJDTUXmcB2n/b9fd6b1b81f2c88e215f540c0fe2bb0d/loan-loop-1200w.gif',
+	fallbackFormat: 'gif',
+	width: 1200,
+	height: 1000,
+	sourceSizes: [],
+};

--- a/@kiva/kv-components/tests/unit/specs/components/KvContentfulImg.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvContentfulImg.spec.js
@@ -179,6 +179,111 @@ describe('KvContentfulImg', () => {
 		});
 	});
 
+	describe('animated gif handling', () => {
+		const gifSrc = 'https://images.ctfassets.net/test/animation.gif';
+
+		it('should not render a webp source element for animated gifs', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc: gifSrc,
+					width: 400,
+					height: 300,
+					alt: 'Animated gif',
+				},
+			});
+
+			const webpSource = container.querySelector('source[type="image/webp"]');
+			expect(webpSource).toBeNull();
+		});
+
+		it('should render a webp source element for non-gif images', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc,
+					width: 400,
+					height: 300,
+					alt: 'Regular image',
+				},
+			});
+
+			const webpSource = container.querySelector('source[type="image/webp"]');
+			expect(webpSource).not.toBeNull();
+		});
+
+		it('should use the raw gif url without query params on the img src', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc: gifSrc,
+					width: 400,
+					height: 300,
+					alt: 'Animated gif',
+				},
+			});
+
+			const img = container.querySelector('img');
+			expect(img.getAttribute('src')).toBe(gifSrc);
+		});
+	});
+
+	describe('fallbackFormat default param handling', () => {
+		it('should default to jpg for a .jpg source url', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc,
+					width: 400,
+					height: 300,
+					alt: 'Test image',
+				},
+			});
+
+			const img = container.querySelector('img');
+			expect(img.getAttribute('src')).toContain('fm=jpg');
+		});
+
+		it('should default to png for a .png source url', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc: 'https://images.ctfassets.net/test/image.png',
+					width: 400,
+					height: 300,
+					alt: 'Test image',
+				},
+			});
+
+			const img = container.querySelector('img');
+			expect(img.getAttribute('src')).toContain('fm=png');
+		});
+
+		it('should default to jpg for a .webp source url', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc: 'https://images.ctfassets.net/test/image.webp',
+					width: 400,
+					height: 300,
+					alt: 'Test image',
+				},
+			});
+
+			const img = container.querySelector('img');
+			expect(img.getAttribute('src')).toContain('fm=jpg');
+		});
+
+		it('should use explicit fallbackFormat prop over url-derived format', () => {
+			const { container } = render(KvContentfulImg, {
+				props: {
+					contentfulSrc,
+					width: 400,
+					height: 300,
+					alt: 'Test image',
+					fallbackFormat: 'png',
+				},
+			});
+
+			const img = container.querySelector('img');
+			expect(img.getAttribute('src')).toContain('fm=png');
+		});
+	});
+
 	describe('alt text behavior', () => {
 		it('should use regular alt text on img element when no caption', () => {
 			const { container } = render(KvContentfulImg, {


### PR DESCRIPTION
See CIT-4083 for relevant link to slack. 

TLDR: we discovered a gif image embedded into a rich text field in a contentful page is not working: https://www.development.kiva.org/about/partner-with-us?preview=true

I discovered a couple of things:
1. If an image file is greater than 20MB, contentful ignores all query params. This was throwing me off a little since I was trying to compare the gif that was working with the one that wasn't 
2. Contentful just refuses to resize GIFs with the height/width query param. For example: 
https://www.development.kiva.org/ctfassets/images/4q5zPRN6hi0KJDTUXmcB2n/b9fd6b1b81f2c88e215f540c0fe2bb0d/loan-loop-1200w.gif?w=1000&h=1000 Just returns bad request. This, in conjunction with our retina resizing was causing issues. 
3. If the w/h param is the same as the original image, contentful will return the image since no resizing is needed, in that case, I also discovered that contentful does not support the `q` quality parameter for gifs either, and will return a bad request. 
4. for animated images webp or gif, contentful can't convert them to jpg without losing the animation (obviously)

This PR does a couple of things. 
- If an image if a GIF, just remove all the query params. We should only be using gifs for animations, and rarely in that case, the query params are just going to break everything anyway. 
- Be a little smarter about the fallback format if it is not explicitly passed in as a prop. pngs should fall back to png's and gifs should fall back to gifs, not jpgs
