### PR TITLE
fix: resolve tab issues with kvtabs

### DIFF
--- a/@kiva/kv-components/src/vue/KvTabPanel.vue
+++ b/@kiva/kv-components/src/vue/KvTabPanel.vue
@@ -2,9 +2,9 @@
 	<transition
 		enter-active-class="tw-transition-opacity tw-duration-700"
 		leave-active-class=""
-		enter-class="tw-opacity-0 tw-absolute tw-top-0"
+		enter-from-class="tw-opacity-0 tw-absolute tw-top-0"
 		enter-to-class="tw-opacity-full"
-		leave-class=""
+		leave-from-class=""
 		leave-to-class="tw-opacity-0 tw-absolute tw-top-0"
 	>
 		<div

--- a/@kiva/kv-components/src/vue/KvTabs.vue
+++ b/@kiva/kv-components/src/vue/KvTabs.vue
@@ -24,10 +24,9 @@
 				"
 				:class="{ 'tw-hidden md:tw-block tw-top-0 md:tw-bg-action' : vertical}"
 				:style="`
-					width: ${selectedTabEl && !vertical ? selectedTabEl.clientWidth : 3}px;
-					height: ${selectedTabEl && vertical ? `${selectedTabEl.clientHeight}px` : '0.25rem'};
-					transform: ${selectedTabEl && !vertical ? `translateX(${selectedTabEl.offsetLeft}px)`
-				: selectedTabEl ? `translateY(${selectedTabEl.offsetTop}px)` : null};
+					width: ${indicatorStyle.width}px;
+					height: ${indicatorStyle.height};
+					transform: ${indicatorStyle.transform};
 				`"
 			></div>
 		</div>
@@ -65,10 +64,25 @@ import {
 	reactive,
 	provide,
 	computed,
+	watch,
+	nextTick,
 	onMounted,
-	getCurrentInstance,
 	onBeforeUnmount,
+	type ComponentPublicInstance,
 } from 'vue';
+
+interface TabNavItem extends ComponentPublicInstance {
+	forPanel?: string;
+	isActive?: boolean;
+	selected?: boolean;
+}
+
+interface TabContext {
+	selectedIndex: number;
+	// eslint-disable-next-line no-unused-vars
+	setTab: ((index: number) => void) | null;
+	navItems: TabNavItem[];
+}
 
 export default {
 	props: {
@@ -78,22 +92,35 @@ export default {
 		},
 	},
 	setup(props, { emit }) {
-		const tabContext = reactive({
+		const tabContext: TabContext = reactive({
 			selectedIndex: 0,
 			setTab: null,
 			navItems: [],
 		});
-		const selectedTabResizeObserver = ref(null);
+		const selectedTabResizeObserver = ref<ResizeObserver | null>(null);
 
 		const selectedTabEl = computed(() => {
 			const { navItems, selectedIndex } = tabContext;
 			return navItems[selectedIndex]?.$el ?? null;
 		});
 
-		const forceUpdate = () => {
-			const instance = getCurrentInstance();
-			if (instance) {
-				instance.proxy.$forceUpdate();
+		const indicatorStyle = reactive({
+			width: 3,
+			height: '0.25rem',
+			transform: '',
+		});
+
+		const updateIndicator = () => {
+			const el = selectedTabEl.value;
+			if (!el) return;
+			if (!props.vertical) {
+				indicatorStyle.width = el.clientWidth;
+				indicatorStyle.height = '0.25rem';
+				indicatorStyle.transform = `translateX(${el.offsetLeft}px)`;
+			} else {
+				indicatorStyle.width = 3;
+				indicatorStyle.height = `${el.clientHeight}px`;
+				indicatorStyle.transform = `translateY(${el.offsetTop}px)`;
 			}
 		};
 
@@ -151,6 +178,24 @@ export default {
 			}
 		};
 
+		// Tab size can change as @font-face fonts come in or
+		// the screen breakpoint changes the font size. If this happens
+		// we need to re-size and position the indicator bar.
+		const observeSelectedTab = () => {
+			selectedTabResizeObserver.value?.disconnect();
+			if (selectedTabEl.value) {
+				selectedTabResizeObserver.value = new ResizeObserver(() => {
+					updateIndicator();
+				});
+				selectedTabResizeObserver.value.observe(selectedTabEl.value);
+			}
+		};
+
+		watch(selectedTabEl, () => {
+			observeSelectedTab();
+			nextTick(updateIndicator);
+		});
+
 		onMounted(() => {
 			// check if any of the KvTab components are declaratively selected
 			tabContext.navItems.forEach((navItem, index) => {
@@ -159,22 +204,19 @@ export default {
 				}
 			});
 
-			// Tab size can change as @font-face fonts come in or
-			// the screen breakpoint changes the font size. If this happens
-			// we need to re-size and position the indicator bar.
-			selectedTabResizeObserver.value = new ResizeObserver(() => {
-				forceUpdate();
-			});
-			selectedTabResizeObserver.value.observe(selectedTabEl.value);
+			updateIndicator();
+			observeSelectedTab();
+			window.addEventListener('resize', updateIndicator);
 		});
 
 		onBeforeUnmount(() => {
-			selectedTabResizeObserver.value.disconnect();
+			selectedTabResizeObserver.value?.disconnect();
+			window.removeEventListener('resize', updateIndicator);
 		});
 
 		return {
 			handleKeyDown,
-			selectedTabEl,
+			indicatorStyle,
 			tabContext,
 		};
 	},

--- a/@kiva/kv-components/src/vue/stories/KvTabs.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvTabs.stories.js
@@ -5,9 +5,6 @@ import KvTabPanel from '../KvTabPanel.vue';
 export default {
 	title: 'Interface Elements/KvTabs',
 	component: KvTabs,
-	args: {
-		vertical: true,
-	},
 };
 
 export const DefaultTemplate = () => ({
@@ -60,16 +57,16 @@ export const InitialTabSelection = () => ({
 	},
 });
 
-export const VerticalOrientation = (args, { argTypes }) => ({
-	props: Object.keys(argTypes),
+export const VerticalOrientation = (args) => ({
 	components: { KvTabs, KvTab, KvTabPanel },
+	setup() { return { args }; },
 	template: `
-		<kv-tabs @tab-changed="handleTabChanged" :vertical="vertical">
+		<kv-tabs @tab-changed="handleTabChanged" :vertical="args.vertical">
 			<template #tabNav>
-				<kv-tab :vertical="vertical" forPanel="demo-1-first">First</kv-tab>
-				<kv-tab :vertical="vertical" forPanel="demo-1-second">Second</kv-tab>
-				<kv-tab :vertical="vertical" forPanel="demo-1-third">Third</kv-tab>
-				<kv-tab :vertical="vertical" forPanel="demo-1-forth">Forth is longer</kv-tab>
+				<kv-tab :vertical="args.vertical" forPanel="demo-1-first">First</kv-tab>
+				<kv-tab :vertical="args.vertical" forPanel="demo-1-second">Second</kv-tab>
+				<kv-tab :vertical="args.vertical" forPanel="demo-1-third">Third</kv-tab>
+				<kv-tab :vertical="args.vertical" forPanel="demo-1-forth">Forth is longer</kv-tab>
 			</template>
 			<template #tabPanels>
 				<kv-tab-panel id="demo-1-first"><p>First Panel</p></kv-tab-panel>
@@ -85,6 +82,7 @@ export const VerticalOrientation = (args, { argTypes }) => ({
 		},
 	},
 });
+VerticalOrientation.args = { vertical: true };
 
 export const MultipleOnAPage = () => ({
 	components: { KvTabs, KvTab, KvTabPanel },


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2613

While building percentiles work recently, we encountered a couple bugs with KvTabs, this resolves them in storybook:
- Tab underlines don't follow tab on page resize (resize handler needed)
- Tab content flashes oddly instead of animating like expected (rename for Vue 3 needed)

Also fixed the story that didn't actually render the vertical mode.