### PR TITLE
chore: ensure kv-components can properly install kv-tokens v4, update…

### DIFF
--- a/@kiva/kv-components/docs/make-to-vue.md
+++ b/@kiva/kv-components/docs/make-to-vue.md
@@ -85,7 +85,7 @@ Decide: new component, v2 of existing, or enhancement to existing.
 Figma Make output is presentational/demo code. Determine what needs to change:
 
 - **Hardcoded data** -> Dynamic props
-- **Hardcoded colors** -> Design system tokens from `@kiva/kv-tokens/primitives.js`
+- **Hardcoded colors** -> Design system tokens from `@kiva/kv-tokens`
 - **Fixed dimensions** -> Container-responsive sizing
 - **Presentational strings** -> Configurable via props/slots
 - **React animation libraries** -> CSS transitions or Vue composables (prefer no extra deps)
@@ -123,7 +123,7 @@ Figma Make outputs raw Tailwind classes. Convert to kv-components patterns:
 - **Replace hardcoded font families** with design system fonts (`tw-font-sans`, `tw-font-serif`)
 - **Replace hardcoded colors** with token references where possible
 - **Replace pixel values** in Tailwind classes with spacing scale values (8px increments)
-- **Use design tokens** from `@kiva/kv-tokens/primitives.js` for colors, spacing, typography
+- **Use design tokens** from `@kiva/kv-tokens` for colors, spacing, typography
 
 ### 2.4 Animation Translation
 
@@ -184,7 +184,7 @@ Extract into `src/utils/` when:
 
 ### 4.1 Colors
 
-Always check `@kiva/kv-tokens/primitives.js` for existing color tokens before using hardcoded hex values. Map Figma Make colors to the closest token:
+Always check `@kiva/kv-tokens` for existing color tokens before using hardcoded hex values. Map Figma Make colors to the closest token:
 
 ```js
 import kvTokensPrimitives from '@kiva/kv-tokens';

--- a/@kiva/kv-components/package.json
+++ b/@kiva/kv-components/package.json
@@ -106,7 +106,7 @@
   },
   "peerDependencies": {
     "@apollo/client": "3.x",
-    "@kiva/kv-tokens": "3.x",
+    "@kiva/kv-tokens": "4.x",
     "@mdi/js": "7.x",
     "@vuepic/vue-datepicker": "^11.0.2",
     "@vueuse/integrations": "14.x",


### PR DESCRIPTION
… references to tokens in docs.

I've verified by running tests and reviewing storybook that the new kv-tokens exports were already compatible with existing import usages across kv-components as intended :) 