### PR TITLE
fix: add basic loading state to pie chart v2, previously wasn't working

### DIFF
--- a/@kiva/kv-components/src/utils/pieChartColors.ts
+++ b/@kiva/kv-components/src/utils/pieChartColors.ts
@@ -2,7 +2,7 @@ import kvTokensPrimitives from '@kiva/kv-tokens';
 
 const { colors } = kvTokensPrimitives;
 
-export const LOADING_BG_COLOR: string = colors.gray[100]; // #F5F5F5
+export const LOADING_BG_COLOR: string = colors.gray[200]; // #E0E0E0
 export const OTHER_SEGMENT_BG_COLOR: string = colors.gray[300]; // #C4C4C4
 /**
  * Tiered chart color palette drawn from kv-tokens design primitives.

--- a/@kiva/kv-components/src/vue/KvPieChartV2.vue
+++ b/@kiva/kv-components/src/vue/KvPieChartV2.vue
@@ -21,8 +21,8 @@
 					:stroke="LOADING_BG_COLOR"
 					:stroke-width="strokeWidth"
 					fill="none"
-					class="skeleton-ring tw-opacity-0"
-					:class="{ 'skeleton-ring--hidden': animatedIn }"
+					class="skeleton-ring"
+					:class="{ 'skeleton-ring--loading': loading }"
 				/>
 
 				<!-- Colored segments -->
@@ -618,10 +618,33 @@ export default {
 }
 
 .skeleton-ring {
+	opacity: 1;
 	transition: opacity 500ms ease-in-out;
+}
+
+.skeleton-ring--loading {
+	animation: skeleton-ring-pulse 1.4s ease-in-out infinite;
+	transform-origin: center;
 }
 
 .legend-dot {
 	transition: background-color 500ms ease-in-out;
+}
+
+@keyframes skeleton-ring-pulse {
+	0%,
+	100% {
+		opacity: 0.45;
+	}
+
+	50% {
+		opacity: 1;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.skeleton-ring--loading {
+		animation: none;
+	}
 }
 </style>

--- a/@kiva/kv-components/src/vue/stories/KvPieChartV2.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvPieChartV2.stories.js
@@ -303,12 +303,20 @@ export const AllVariations = {
  * Loading State - Skeleton ring while data is unavailable.
  */
 export const LoadingState = {
-	render: () => ({
+	args: {
+		values: [],
+		loading: true,
+		strokeWidth: 56,
+	},
+	render: (args) => ({
 		components: { KvPieChartV2 },
+		setup() {
+			return { args };
+		},
 		template: `
 			<div class="tw-bg-gray-50 tw-rounded-md tw-p-6 tw-inline-block">
 				<div style="width: 262px;">
-					<KvPieChartV2 :values="[]" :loading="true" />
+					<KvPieChartV2 v-bind="args" />
 				</div>
 			</div>
 		`,

--- a/@kiva/kv-components/tests/unit/specs/components/KvPieChartV2.spec.ts
+++ b/@kiva/kv-components/tests/unit/specs/components/KvPieChartV2.spec.ts
@@ -50,12 +50,16 @@ describe('KvPieChartV2', () => {
 		getByRole('button', { name: /Other/i });
 	});
 
-	it('shows skeleton ring when loading is true', () => {
+	it('shows animated gray-200 skeleton ring when loading is true', () => {
 		const { container } = render(KvPieChartV2, {
-			props: { values: [], loading: true },
+			props: { values: [], loading: true, strokeWidth: 88 },
 		});
 		const skeletonRing = container.querySelector('.skeleton-ring');
 		expect(skeletonRing).toBeTruthy();
+		expect(skeletonRing?.getAttribute('stroke')).toBe('#E0E0E0');
+		expect(skeletonRing?.getAttribute('stroke-width')).toBe('88');
+		expect(skeletonRing?.classList.contains('skeleton-ring--loading')).toBe(true);
+		expect(skeletonRing?.classList.contains('tw-opacity-0')).toBe(false);
 	});
 
 	it('does not show legend when loading', () => {


### PR DESCRIPTION
Just something basic to show the incoming shape. It "pulses" via an opacity transition.
<img width="346" height="321" alt="image" src="https://github.com/user-attachments/assets/efba7190-831b-4dce-9813-6fa704f0596c" />
