### PR TITLE
fix: improve centering during and after animation to focus on active …

### DIFF
--- a/@kiva/kv-components/src/vue/KvSimpleMap.vue
+++ b/@kiva/kv-components/src/vue/KvSimpleMap.vue
@@ -507,7 +507,7 @@ const fitTransform = computed<Transform | null>(() => {
 const initialManualTransform = computed<Transform>(() => fitTransform.value ?? overviewTransform.value);
 
 const displayTransform = computed<Transform>(() => {
-	if (isTourRunning.value) return focusedTransform.value ?? overviewTransform.value;
+	if (isTourRunning.value) return focusedTransform.value ?? fitTransform.value ?? overviewTransform.value;
 	return manualTransform.value;
 });
 


### PR DESCRIPTION
…countries.

Current behavior is re-centering on the US after completing the animation. New behavior centers on all active countries after the animation so they remain in view.