### PR TITLE
feat: mp-2831 fix datepicker stays loading

### DIFF
--- a/@kiva/kv-components/jest.config.cjs
+++ b/@kiva/kv-components/jest.config.cjs
@@ -30,6 +30,7 @@ module.exports = {
 	moduleNameMapper: {
 		'^#components/(.*)$': '<rootDir>/src/vue/$1',
 		'^#utils/(.*)$': '<rootDir>/src/utils/$1',
+		'\\.css$': '<rootDir>/tests/unit/styleMock.js',
 	},
 
 	// The test environment that will be used for testing

--- a/@kiva/kv-components/src/vue/KvDatePicker.vue
+++ b/@kiva/kv-components/src/vue/KvDatePicker.vue
@@ -4,31 +4,22 @@
 			class="kv-datepicker"
 			:class="theme"
 		>
-			<div
-				v-if="datepickerComponent"
-				class="kv-datepicker__content"
-			>
-				<component
-					:is="datepickerComponent"
-					:key="componentKey"
+			<div class="kv-datepicker__content">
+				<vue-date-picker
 					v-model="selectedDate"
 					v-bind="$attrs"
 					:auto-apply="true"
 					@update:model-value="handleDateChange"
 				/>
 			</div>
-			<div
-				v-else
-				class="kv-datepicker__loading"
-			>
-				Loading...
-			</div>
 		</div>
 	</kv-theme-provider>
 </template>
 
 <script lang="ts">
-import { markRaw, computed } from 'vue';
+import { computed } from 'vue';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
 
 import {
 	defaultTheme,
@@ -44,6 +35,7 @@ export default {
 	name: 'KvDatePicker',
 	components: {
 		KvThemeProvider,
+		VueDatePicker,
 	},
 	inheritAttrs: false,
 	props: {
@@ -86,10 +78,7 @@ export default {
 	},
 	data() {
 		return {
-			datepickerComponent: null,
-			datepickerPromise: null,
 			selectedDate: null,
-			componentKey: 0,
 		};
 	},
 	watch: {
@@ -100,24 +89,7 @@ export default {
 			immediate: true,
 		},
 	},
-	mounted() {
-		this.loadDatepicker();
-	},
 	methods: {
-		async loadDatepicker() {
-			if (this.datepickerComponent) return;
-			if (this.datepickerPromise) return this.datepickerPromise;
-
-			this.datepickerPromise = Promise.all([
-				import('@vuepic/vue-datepicker'),
-				import('@vuepic/vue-datepicker/dist/main.css')])
-				.then(async ([module]) => {
-					this.datepickerComponent = markRaw(module.default);
-					await this.$nextTick();
-				});
-
-			return this.datepickerPromise;
-		},
 		handleDateChange(value) {
 			this.selectedDate = value;
 			this.$emit('update:model-value', value);
@@ -128,12 +100,6 @@ export default {
 </script>
 
 <style>
-.kv-datepicker__loading {
-	padding: 20px;
-	text-align: center;
-	color: var(--text-secondary);
-}
-
 .kv-datepicker .dp__input {
 	font-family: inherit;
 	font-weight: inherit;

--- a/@kiva/kv-components/tests/unit/specs/components/KvDatePicker.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvDatePicker.spec.js
@@ -1,0 +1,39 @@
+import { render, fireEvent } from '@testing-library/vue';
+import { axe } from 'jest-axe';
+import KvDatePicker from '#components/KvDatePicker.vue';
+
+jest.mock('@vuepic/vue-datepicker', () => ({
+	template: `
+		<input
+			aria-label="Gift date"
+			:value="modelValue"
+			@input="$emit('update:model-value', $event.target.value)"
+		>
+	`,
+	props: {
+		modelValue: {
+			type: [Date, String, Number, Array],
+			default: null,
+		},
+	},
+}), { virtual: true });
+
+describe('KvDatePicker', () => {
+	it('renders the datepicker component with no automated accessibility violations', async () => {
+		const { container, getByRole } = render(KvDatePicker);
+
+		getByRole('textbox', { name: 'Gift date' });
+		const results = await axe(container);
+
+		expect(results).toHaveNoViolations();
+	});
+
+	it('passes datepicker value changes through component events', async () => {
+		const { emitted, getByRole } = render(KvDatePicker);
+
+		await fireEvent.update(getByRole('textbox', { name: 'Gift date' }), '2026-06-15');
+
+		expect(emitted()['update:model-value'][0]).toEqual(['2026-06-15']);
+		expect(emitted().change[0]).toEqual(['2026-06-15']);
+	});
+});

--- a/@kiva/kv-components/tests/unit/styleMock.js
+++ b/@kiva/kv-components/tests/unit/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2831

This issue affects KvDatePicker, which is used in the gift card scheduling flow. The component previously loaded @vuepic/vue-datepicker and its CSS through a dynamic import after mount. That works under normal conditions, but on very slow or unstable connections the async chunk can fail or stall, leaving the component stuck on Loading... with no recovery path.

The fix changes the date picker dependency to a static import. This makes the dependency part of the normal bundle path instead of a separate runtime chunk request, removing the failure mode where the date picker component mounts but its async dependency never finishes loading. The tradeoff is a small increase in bundle weight for consumers that include KvDatePicker, but for this flow the reliability improvement is worth it because a stuck date picker blocks the user from scheduling the gift card.

I also added a focused KvDatePicker test to verify that the wrapper renders the date picker and continues to pass value changes through via update:model-value and change. Since the component now statically imports the third-party CSS file, Jest needs a standard CSS mock. The styleMock.js mapping lets Jest ignore CSS imports during unit tests, which is a common pattern because Jest does not process CSS the same way the app bundler does.
