### PR TITLE
feat: public kv design skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "kv-ui-elements",
+  "interface": {
+    "displayName": "Kiva UI Elements"
+  },
+  "plugins": [
+    {
+      "name": "kiva-design-system",
+      "source": {
+        "source": "local",
+        "path": "./@kiva/kv-skills/design-system"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "name": "kv-ui-elements",
+  "owner": { "name": "Kiva" },
+  "plugins": [
+    {
+      "name": "kiva-design-system",
+      "source": "./@kiva/kv-skills/design-system"
+    }
+  ]
+}

--- a/@kiva/kv-skills/README.md
+++ b/@kiva/kv-skills/README.md
@@ -1,0 +1,49 @@
+# @kiva/kv-skills
+
+Kiva's public [Agent Skills](https://agentskills.io) for Claude Code, Codex, and
+other agents that follow the open skill standard. This package is the
+**canonical source** for Kiva skills.
+
+## How it's organized (multi-plugin container)
+
+Each subfolder is an independently-installable **plugin category**:
+
+```
+@kiva/kv-skills/
+└── design-system/        ← plugin "kiva-design-system"
+    ├── .claude-plugin/plugin.json
+    ├── .codex-plugin/plugin.json
+    ├── README.md
+    └── skills/<skill-name>/SKILL.md
+```
+
+The repo-root marketplace files (`.claude-plugin/marketplace.json`,
+`.agents/plugins/marketplace.json`) expose each category as a plugin. Install
+instructions for every audience live in the repo-root
+[`SKILLS.md`](../../SKILLS.md).
+
+## Categories
+
+| Category (folder) | Plugin name | Description |
+|---|---|---|
+| `design-system` | `kiva-design-system` | Design tokens, the Kiva Tailwind preset, typography/color/spacing/radius/layout, header audits, and Figma-to-skill extraction. |
+
+## Adding a skill (to an existing category)
+
+1. Add a folder under `<category>/skills/<skill-name>/` with a `SKILL.md` that has
+   valid YAML frontmatter (`name`, `description`).
+2. Bump the `version` in **both** `<category>/.claude-plugin/plugin.json` and
+   `<category>/.codex-plugin/plugin.json`.
+3. Open a PR.
+
+## Adding a plugin (a new category)
+
+1. Create `@kiva/kv-skills/<category>/` with `.claude-plugin/plugin.json`,
+   `.codex-plugin/plugin.json`, `README.md`, and a `skills/` folder.
+2. Register it: add one entry to `.claude-plugin/marketplace.json` and one to
+   `.agents/plugins/marketplace.json` at the repo root, each pointing `source`
+   at `./@kiva/kv-skills/<category>`.
+3. Open a PR.
+
+See the repo-root [`SKILLS.md`](../../SKILLS.md) for full details and the
+install matrix.

--- a/@kiva/kv-skills/design-system/.claude-plugin/plugin.json
+++ b/@kiva/kv-skills/design-system/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "kiva-design-system",
+  "description": "Kiva design-system skills: design tokens, Tailwind preset, typography, color, spacing, radius, layout, header audits, and Figma-to-skill extraction.",
+  "version": "0.1.0",
+  "keywords": ["kiva", "design-system", "design-tokens", "tailwind", "figma"]
+}

--- a/@kiva/kv-skills/design-system/.codex-plugin/plugin.json
+++ b/@kiva/kv-skills/design-system/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "kiva-design-system",
+  "version": "0.1.0",
+  "description": "Kiva design-system skills: design tokens, Tailwind preset, typography, color, spacing, radius, layout, header audits, and Figma-to-skill extraction.",
+  "author": {
+    "name": "Kiva"
+  },
+  "keywords": ["kiva", "design-system", "design-tokens", "tailwind", "figma"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Kiva Design System",
+    "shortDescription": "Kiva design-system skills for tokens, Tailwind, and Figma",
+    "longDescription": "Kiva design-system conventions and workflows: design tokens, the Kiva Tailwind preset, typography/color/spacing/radius/layout guidance, header-element audits, and Figma-to-skill extraction.",
+    "developerName": "Kiva",
+    "category": "Development",
+    "capabilities": ["Read", "Write"]
+  }
+}

--- a/@kiva/kv-skills/design-system/README.md
+++ b/@kiva/kv-skills/design-system/README.md
@@ -1,0 +1,27 @@
+# kiva-design-system
+
+The design-system plugin category of [`@kiva/kv-skills`](../README.md).
+
+## Skills
+
+| Skill | What it does |
+|-------|--------------|
+| `kiva-design-system` | Router/index for the design system, with token sub-skills: color, typography, spacing, radius, layout, color-themes. |
+| `kiva-tailwind-css` | How the `@kiva/kv-tokens` Tailwind preset changes stock Tailwind. |
+| `kiva-header-element-audit` | Audit/cleanup of `<h1>`–`<h6>` usage ahead of the semantic typography remap. |
+| `figma-design-system-to-skill` | Process for extracting a design-system section from Figma into a skill. |
+
+## Install
+
+```bash
+# Claude Code
+/plugin marketplace add kiva/kv-ui-elements
+/plugin install kiva-design-system@kv-ui-elements
+
+# Codex
+codex plugin marketplace add kiva/kv-ui-elements
+# then: codex → /plugins → install "Kiva Design System"
+```
+
+See the repo-root [`SKILLS.md`](../../../SKILLS.md) for the full per-audience
+install matrix (including claude.ai / web).

--- a/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: figma-design-system-to-skill
+description: Process skill for extracting a section of the Kiva design system from Figma into a portable agent skill file in @kiva/kv-tokens/docs/skills. Codifies the artifact-gathering, code-verification, structure, voice, and index-update steps proven out across typography, layout, spacing, and radius.
+when_to_use: Whenever starting a new skill that extracts a Figma design-system section (e.g., color, elevation, motion, iconography, components). Trigger phrases — "extract the X section of our design system into a skill", "create a new skill from these Figma panels", "let's build a skill for X".
+---
+
+# Figma Design-System → Skill
+
+## What this skill produces
+
+A single self-contained Markdown skill file in `@kiva/kv-tokens/docs/skills/<name>.md`, plus a one-line entry in `@kiva/kv-tokens/SKILLS.md`. The skill captures *design intent* from Figma (canonical), then ends with two code-facing sections: **Using with Tailwind** (how to express that intent with the Kiva Tailwind preset, hybrid so it works with or without the preset) and **Outstanding discrepancies** (the real Figma-vs-code sync gaps consumers should verify before depending on a token name).
+
+Existing exemplars in this repo:
+
+- `typography.md` — the original template, content-style skill
+- `layout.md` — multi-panel extraction with cross-skill linkage
+- `spacing.md` — the most complex (semantic categories + raw ramp + responsive values)
+- `radius.md` — small, tight scale with a per-component lookup table
+- `color.md` + `color-themes.md` — the umbrella + reference-companion split
+
+Read at least one before starting a new extraction; mirror voice, headings, and table conventions.
+
+A different kind of skill also lives here: [`tailwind`](tailwind.md) documents the **shipped mechanics** of the Kiva Tailwind preset and is *code-canonical* (not Figma-canonical). You don't author skills like it with this process, but every design-intent skill's "Using with Tailwind" section links into it — treat it as the canonical reference for preset mechanics rather than re-explaining them.
+
+## Inputs to gather from the user
+
+Always ask for, or confirm you have, all three:
+
+1. **Figma node links** for each panel in the section. Typical sections have:
+   - An **Overview** panel (the "why" + design principles + anatomy)
+   - A **Scales / Tokens** panel (the canonical values)
+   - A **Guidelines** panel (Do/Don't, usage rules, implementation in Figma)
+   Some sections have additional or merged panels — adapt accordingly.
+2. **Screenshots** of each panel (one each, plus any zoomed/annotated supplementals).
+3. **Section name** — confirm the file name (kebab-case) before writing.
+
+### When to start with screenshots vs. the Figma MCP
+
+Screenshots are sufficient for **conceptual panels** — overviews, principles, do/don't grids, anatomy diagrams, small scales. Lift content directly from them.
+
+**For dense token tables, start with `get_design_context` from the first pass — don't try to read them from a screenshot.** A panel qualifies as a "dense token table" if it has any of:
+
+- More than ~10 rows of tokens *with* a description column
+- Multiple sub-tables (e.g., one per theme, tier, or component)
+- Per-row metadata you'd otherwise transcribe (primitive source, opacity, state)
+
+The color skill round of this process missed ~5 tokens per theme and invented incorrect shadow names by reading screenshots of tables that were too dense to be legible. The Figma MCP returns the underlying React export, which lets a parser pull every row reliably (see *Extracting table data with a parser*, below). For everything else — Overview, Guidelines, Accessibility framework text — screenshots remain faster.
+
+## File and index locations
+
+- **New skill:** `@kiva/kv-tokens/docs/skills/<kebab-name>.md`
+- **Index to update:** `@kiva/kv-tokens/SKILLS.md` (add one line under `## Skills`, format: `- [name](docs/skills/name.md) — one-line hook`)
+
+## Code verification — before writing the code-facing sections
+
+Every skill ends with two code-facing sections (see *Standard skill structure* below): **Using with Tailwind** — how to express the section's intent in code via the Kiva Tailwind preset, written hybrid so it's useful with or without the preset — and **Outstanding discrepancies** — the genuine Figma-vs-code sync gaps. Both are *code-canonical* (unlike the Figma-canonical body above them), so don't write them from memory or the Figma side alone — read the source.
+
+Standard verification path (start narrow, widen only as needed):
+
+1. **`@kiva/kv-tokens/tokens/core/*.json`** — canonical token source. Files: `size.json` (space, breakpoint, radius, border-width), `color.json`, `typography.json`, `misc.json`. Open the one relevant to your section.
+2. **`@kiva/kv-tokens/configs/tailwind.config.js`** — how tokens get exposed as Tailwind utilities. Find the relevant `theme.*` block. Note any hardcoded values *not* sourced from the JSON (those are sync gaps worth flagging).
+3. **`@kiva/kv-tokens/configs/kiva*.js`** — utility modules (`kivaColors.js`, `kivaTypography.js`) for sections with programmatic helpers.
+4. **`@kiva/kv-tokens/dist/js/tokens.js`** — built output. Useful as a fallback if the source JSON doesn't yet contain everything you expect (e.g., the spacing ramp is fully expanded here even when the source isn't).
+5. **Component-side wrappers** in `@kiva/kv-components/src/vue/` — only if the section has a thin component abstraction (e.g., `KvGrid.vue` for layout). Grep for likely names; don't open the whole tree.
+
+Use `grep -rn` for targeted lookups; use `Read` for whole files. Both are fast — there's no reason to defer to a subagent for code verification at this size.
+
+### Distinguish real sync gaps from intentional differences
+
+Not every Figma-vs-code mismatch is a gap to close. Some are deliberate:
+
+- **`default` vs `base`** (radius): in code the token is `default` (Tailwind's `DEFAULT` key generates the unsuffixed utility class); in Figma it's `base` (renamed for consistency with the `xs/sm/md/lg/xl` scale, with `default` marked *legacy*). Same token, two surface-native names — document both, but don't assert which name "wins" long-term unless the team has said so. The only mechanically-fixed piece is the Tailwind `DEFAULT` key.
+- **Naming-convention separators** for the same token across surfaces: source JSON uses `_` (e.g., `2_5`), Tailwind utilities use `.` (`tw-p-2.5`), Figma variables use `-` (`2-5`). Not a gap — just three idioms for the same value.
+- **Theme / variant identifiers**: Figma names a theme "Marigold"; code names it `marigold-light`. Both are correct in their own surface. Document both side-by-side so designers and engineers can each type the name native to their tool.
+
+When you find a divergence, **ask the user or check context** before framing it as "to be closed." Errantly calling an intentional difference a sync gap is a small but recurring failure mode — and so is the inverse: declaring a difference "permanent / intentional" when the Figma source actually marks the old value *legacy* (the radius `default` vs `base` case did exactly this on its first pass). State what each surface says today and let the team decide permanence.
+
+### List concrete missing tokens — don't summarize gaps in prose
+
+When you find real sync gaps (Figma defines tokens or values that code doesn't ship), enumerate them as a bullet list inside the "Outstanding discrepancies" section. A list of names — `text/action-disabled`, `background/action-secondary`, `border/secondary-disabled` — is actionable; "several tokens are missing" is not. Group by theme or category if there are more than ~5 missing entries.
+
+### Extracting table data — prefer `get_metadata` for dense tables
+
+For any dense token/spec table, **`get_metadata` is the most reliable extractor** — more so than parsing the `get_design_context` React export. `get_metadata` returns each text node's `name` (the literal rendered string) plus its `x`/`y` coordinates and the containing cell's geometry. Reconstruct the table by sorting cells into columns by `x` and rows by `y`. This sidesteps two problems with the React export: (a) dense panels often exceed the output limit and get truncated or persisted to a file, and (b) the export is laid out column-major with ~100KB of image-asset constants, so a naive text scrape drops or scrambles cells. The metadata coordinates reconstruct even a two-sub-table ramp exactly.
+
+The QA pass that verified the spacing ramp relied on this: the `get_design_context` text scrape stopped mid-table and missed the bottom rows, while `get_metadata` returned every `(token, REM, value)` cell with coordinates — which is how the `15-5` / `16` mislabel at the bottom of the Figma ramp was confirmed. As a bonus, text-node `name`s give you clean copy for conceptual panels too (anatomy definitions, guideline paragraphs) without dumping the React export.
+
+**Fallback — parse the React export.** When metadata isn't enough (you need styling, or text lives in nested instances), write a small parser (~25 lines of Python) over the `get_design_context` export: each cell has a `data-name="<cell-type>"` attribute (e.g. `"semantic name"`, `"hex code"`, `"primitive token"`, `"description"`) and a `row-N` class — group by row and emit a Markdown row per group. Note that text inside component *instances* (Do/Don't example cards, anatomy-label components) is often exposed by neither tool — capture that from a screenshot.
+
+## Standard skill structure
+
+Mirror this order. Sections marked *(optional)* can be omitted if the source content doesn't support them.
+
+```
+---
+name: <kebab-name>
+description: <one sentence — specific enough that an agent can decide relevance>
+when_to_use: <concrete triggers — when designing/implementing X, picking between Y and Z, etc.>
+---
+
+# Kiva <Section Title>
+
+## Source of truth
+<Figma is canonical. Code may lag. Verify before depending. Link to "Outstanding discrepancies" at bottom.>
+
+## Why <section> matters / About
+<2-4 sentences on the why. Lift from the Overview panel. Include "Common alternative names" line if Figma has one.>
+
+## Design principles
+<Numbered list, usually 2-4 items from the Overview panel. One sentence each.>
+
+## <Main spec tables>
+<The canonical content. Use tables for token data. Lead with semantic intent, raw values second.>
+
+## Best practices / Usage rules
+<Do / Don't pairs. Group related rules.>
+
+## (optional) <Worked examples, lookup tables, gotchas>
+<Anything that's component-level or implementation-level worth pulling out.>
+
+## How to use in Figma
+<Variable picker tips, library hover descriptions, before-handoff check (re-bind any raw values).>
+
+## Using with Tailwind
+<How to express this section's intent with the Kiva Tailwind preset; hybrid. Cross-link into tailwind.md for mechanics; link to in-body tables for values. Include a "### Without the preset" subsection. See "Writing the code-facing sections" below.>
+
+## Outstanding discrepancies
+<Only the critical, unresolved Figma-vs-code sync gaps. Concrete token names. Omit if there are none. Keep the "flag it — it's a data point" closer.>
+
+## Figma source references
+- <Panel name>: node `XXXXX:XXXX`
+- ...
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)
+```
+
+## Writing the code-facing sections
+
+These two sections are where an otherwise Figma-canonical skill becomes **code-canonical**. They sit where the old single "Current code state" section used to — right before "Figma source references" — and they defer to the [`tailwind`](tailwind.md) skill, the canonical shipped-mechanics guide to the Kiva preset. Don't regenerate `tailwind`'s content here; link into it.
+
+### `## Using with Tailwind`
+
+Teach how to express *this section's* intent in code. It must be **hybrid**: encourage setting up and using the Kiva Tailwind preset, but still help a reader whose project doesn't have it. Use this four-part backbone:
+
+1. **Hybrid setup line.** State that the utilities come from the `@kiva/kv-tokens` preset, link to [tailwind → Consuming the preset](tailwind.md#consuming-the-preset) for projects not yet wired up, and point to the "Without the preset" subsection for projects that won't adopt it.
+2. **Authoring guidance (topic-specific).** How to pick/apply the class for this concern, plus the one key gotcha (e.g. `tw-rounded` = 16px, no `tw-text-lg`, the 8px spacing scale). **Link to the matching `tailwind.md` subsection** for the mechanics rationale instead of re-explaining it, and **point to any in-body mapping table** already in the skill instead of reprinting it.
+3. **Shipped-state details.** What actually ships today, with the authoritative source pointer (`tokens/core/*.json`, the relevant `configs/tailwind.config.js → theme.*` block). Put the "verify against the current config before depending" caveat on these lines — it replaces the old hedged section header.
+4. **`### Without the preset`.** Two clearly-separated fallbacks:
+   - *Kiva (or Kiva-adjacent) repo, preset not registered yet* → install + register (link to tailwind.md); arbitrary values are a stopgap until then.
+   - *Stock-Tailwind / non-Kiva project* → replicate the intent from the documented values, or pull CSS custom properties from `@kiva/kv-tokens/css` (`dist/css/tokens.css`); note that copied values are point-in-time and the static/hex route loses runtime theming.
+
+**Cross-link discipline:** never re-explain `tailwind.md` mechanics, and never copy a mapping table that already exists in the skill body — link to both. This keeps the section a thin bridge that won't drift as tokens change.
+
+### `## Outstanding discrepancies`
+
+Only the **critical, unresolved** Figma-vs-code divergences worth future work — the things a consumer would otherwise trip on. List concrete token names (see "List concrete missing tokens" above), and keep the closing line: "When you find a divergence … flag it — each is a data point for the design-system team." **Omit this section entirely** when a skill has no genuine gaps (a purely additive skill may not need it). Don't park stable, intentional facts here — code naming you type (`marigold-light`, the `default`/`base` split) belongs in "Using with Tailwind"; known Figma-label typos belong beside the value they describe or in a companion's source-caveats. Reserve "Outstanding discrepancies" for things that *should* change.
+
+## Voice and formatting conventions
+
+- Lead with **semantic intent**, then concrete values. "Pick a token by what the component *is*, not by eyeballing a curve" comes before the value table.
+- **Tables** for any structured data — tokens, scales, tier values, component→token lookups.
+- **Do / Don't** as boldface inline labels in a paragraph or as bullet pairs. Match how `typography.md` does it.
+- **Cross-link** related skills with relative markdown links: `[spacing](spacing.md)`, `[layout](layout.md)`.
+- Use **fenced quote blocks** (`>`) for callouts the user needs to *see* (formulas, gotchas, caveats about Figma typos). Use them sparingly — every callout dilutes the next.
+- Keep tone direct. Avoid hedge words ("typically", "generally", "may"). When something *is* true, say so; when it's a recommendation, name the recommender (design system team, the Figma spec, the engineering convention).
+
+## When to split into a companion reference file
+
+Some sections have more *reference data* than *conceptual content*. For those, split into two files: an umbrella skill that captures the framework, and a reference companion that holds the bulk data.
+
+Use the umbrella + companion pattern when **any** of these is true:
+
+- The section has multiple structured tables and the total row count exceeds ~50.
+- The data is organized **per-X** (per-theme, per-tier, per-component) and each X's table is independently useful — an agent typically needs one X's worth at a time, not all of them.
+- The Figma source itself organizes the data into discrete sub-sections that mirror well to per-file split.
+
+Naming: `<topic>.md` (umbrella) + `<topic>-<axis>.md` (companion). Examples: `color.md` + `color-themes.md`. The companion's frontmatter `description` should explicitly call out that it's a reference for the umbrella — e.g., "Reference companion to `color` …".
+
+What lives where:
+
+- **Umbrella** (`<topic>.md`): source-of-truth caveat, why, principles, token grammar, accessibility framework, best practices / usage rules, Figma usage, Using with Tailwind, Outstanding discrepancies.
+- **Companion** (`<topic>-<axis>.md`): the full structured tables, with whatever columns the Figma source has (name, hex, primitive, description, etc.). Light intro pointing back to the umbrella; per-X "source caveats" sections for Figma typos specific to that table.
+
+Add **both** files to `SKILLS.md`. The companion's index entry should explicitly mark it as a reference: e.g., *"Reference companion to `color`: the full per-theme token tables …"*
+
+## Watch-outs
+
+- **Figma source typos.** Multiple panels have small errors — `rem` column wrapping in the spacing scale, "Atonomy" / "Principals" headings on the radius overview. **Silently correct** these in the skill; don't transcribe the typo.
+- **Internally inconsistent Figma claims.** Panels — and even cells *within one panel* — contradict each other. Spacing Overview says "every value is a 4px multiple" while the Ramp says "8px base unit"; the Layout Grids panel's SM spec row says 4 columns while the SM breakpoint *diagram* is tagged `col: 8` (the drawn diagram and the Building Layouts example both confirm 4). Favor the value the canonical spec table and shipped code agree on, and add a brief caveat so a reader cross-referencing Figma isn't tripped by the stale label.
+- **Quote vs. paraphrase.** If you wrap text in quotation marks and attribute it to Figma, it must be the *literal* string from the panel. The spacing skill's first pass quoted an "8px base unit with half-steps" phrasing Figma never wrote; the real sentence ("Every space token is a multiple of this base unit") is both quotable *and* more useful, because quoting it accurately exposes why it's wrong. Paraphrase freely — just don't dress paraphrase up as a quote.
+- **Don't lift the panel's subtitle as your introduction.** Figma panel subtitles are often boilerplate ("Use these [Component name] examples in your design"). Write a real "why this matters" intro instead.
+- **Don't include the "Any questions? Let us know!" / Slack avatars** that appear in Overview panels — those are panel chrome, not content.
+- **Headings are H2.** The skill title is the only H1. All other sections are H2 / H3. Don't slip into H4+ unless you genuinely have four levels of hierarchy.
+- **No emojis** unless the user explicitly asks. The existing skills don't use them.
+
+## Process — step by step
+
+1. **Confirm inputs.** Re-state the section name, the Figma node links, and that you have the screenshots. Ask for anything missing.
+2. **(Optional) Skim one or two existing skills** if you haven't recently — pattern-match voice and structure.
+3. **Decide on the data source per panel.** Screenshots for conceptual panels; `get_design_context` (and a parser) for dense token tables. See "When to start with screenshots vs. the Figma MCP" above.
+4. **Decide whether to split** into an umbrella + reference companion before drafting. The split shape is hard to retrofit after the fact. See "When to split into a companion reference file."
+5. **Verify code state.** Open the relevant token JSON, the Tailwind config block, and any wrapper components. Note the shipped utilities (for "Using with Tailwind"), the real gaps (for "Outstanding discrepancies"), and intentional differences; list concrete missing tokens by name.
+6. **Draft the skill(s)** using the standard structure. Write into `@kiva/kv-tokens/docs/skills/<name>.md`. Use the `Write` tool for new files; use `Edit` if revising.
+7. **Update the index.** Add one entry per file to `@kiva/kv-tokens/SKILLS.md` under `## Skills`.
+8. **Self-verify against canonical Figma data.** Before declaring done, pull every panel you summarized from screenshots and spot-check at least: (a) primitive / token values that drive other claims, (b) every callout in the accessibility or "do not use" sections, (c) every Do/Don't headline. Stale Figma labels and copy-paste errors are common enough that this step regularly catches real factual mistakes — treat it as required, not optional.
+9. **Brief the user.** End with a short summary listing what's in the new skill and any divergences from Figma you flagged. Don't re-list the full table of contents — call out structural choices and surprises only.
+
+## Iteration
+
+The user will frequently correct facts after the first draft — naming conventions, scale framing, intentional-vs-accidental gaps. Treat the first pass as an outline they'll refine. When a correction lands, audit *related* skills for the same mistake — the spacing/layout 4px-vs-8px correction propagated to both files because the same misleading framing was in both.
+
+The self-verification step (step 8 above) should catch most of these before the user has to. Don't skip it to save tokens.
+
+## Kickoff prompt template
+
+Hand the user this template they (or you) can drop into a fresh session to start the next extraction:
+
+```
+Time to extract the <SECTION> section of our design system into a new skill. Please load the `figma-design-system-to-skill` skill and walk through it.
+
+Figma node links:
+- <Panel 1>: <URL>
+- <Panel 2>: <URL>
+- <Panel 3>: <URL>
+
+Screenshots attached: <count or list>
+```

--- a/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
@@ -20,7 +20,7 @@ Existing exemplars in this repo:
 
 Read at least one before starting a new extraction; mirror voice, headings, and table conventions.
 
-A different kind of skill also lives here: [`tailwind`](tailwind.md) documents the **shipped mechanics** of the Kiva Tailwind preset and is *code-canonical* (not Figma-canonical). You don't author skills like it with this process, but every design-intent skill's "Using with Tailwind" section links into it — treat it as the canonical reference for preset mechanics rather than re-explaining them.
+A different kind of skill also lives here: [`tailwind`](../kiva-tailwind-css/SKILL.md) documents the **shipped mechanics** of the Kiva Tailwind preset and is *code-canonical* (not Figma-canonical). You don't author skills like it with this process, but every design-intent skill's "Using with Tailwind" section links into it — treat it as the canonical reference for preset mechanics rather than re-explaining them.
 
 ## Inputs to gather from the user
 
@@ -135,13 +135,13 @@ File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)
 
 ## Writing the code-facing sections
 
-These two sections are where an otherwise Figma-canonical skill becomes **code-canonical**. They sit where the old single "Current code state" section used to — right before "Figma source references" — and they defer to the [`tailwind`](tailwind.md) skill, the canonical shipped-mechanics guide to the Kiva preset. Don't regenerate `tailwind`'s content here; link into it.
+These two sections are where an otherwise Figma-canonical skill becomes **code-canonical**. They sit where the old single "Current code state" section used to — right before "Figma source references" — and they defer to the [`tailwind`](../kiva-tailwind-css/SKILL.md) skill, the canonical shipped-mechanics guide to the Kiva preset. Don't regenerate `tailwind`'s content here; link into it.
 
 ### `## Using with Tailwind`
 
 Teach how to express *this section's* intent in code. It must be **hybrid**: encourage setting up and using the Kiva Tailwind preset, but still help a reader whose project doesn't have it. Use this four-part backbone:
 
-1. **Hybrid setup line.** State that the utilities come from the `@kiva/kv-tokens` preset, link to [tailwind → Consuming the preset](tailwind.md#consuming-the-preset) for projects not yet wired up, and point to the "Without the preset" subsection for projects that won't adopt it.
+1. **Hybrid setup line.** State that the utilities come from the `@kiva/kv-tokens` preset, link to [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset) for projects not yet wired up, and point to the "Without the preset" subsection for projects that won't adopt it.
 2. **Authoring guidance (topic-specific).** How to pick/apply the class for this concern, plus the one key gotcha (e.g. `tw-rounded` = 16px, no `tw-text-lg`, the 8px spacing scale). **Link to the matching `tailwind.md` subsection** for the mechanics rationale instead of re-explaining it, and **point to any in-body mapping table** already in the skill instead of reprinting it.
 3. **Shipped-state details.** What actually ships today, with the authoritative source pointer (`tokens/core/*.json`, the relevant `configs/tailwind.config.js → theme.*` block). Put the "verify against the current config before depending" caveat on these lines — it replaces the old hedged section header.
 4. **`### Without the preset`.** Two clearly-separated fallbacks:

--- a/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/figma-design-system-to-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-design-system-to-skill
-description: Process skill for extracting a section of the Kiva design system from Figma into a portable agent skill file in @kiva/kv-tokens/docs/skills. Codifies the artifact-gathering, code-verification, structure, voice, and index-update steps proven out across typography, layout, spacing, and radius.
+description: Process skill for extracting a section of the Kiva design system from Figma into a portable agent skill file in @kiva/kv-skills/design-system/skills/kiva-design-system. Codifies the artifact-gathering, code-verification, structure, voice, and index-update steps proven out across typography, layout, spacing, and radius.
 when_to_use: Whenever starting a new skill that extracts a Figma design-system section (e.g., color, elevation, motion, iconography, components). Trigger phrases — "extract the X section of our design system into a skill", "create a new skill from these Figma panels", "let's build a skill for X".
 ---
 
@@ -8,7 +8,7 @@ when_to_use: Whenever starting a new skill that extracts a Figma design-system s
 
 ## What this skill produces
 
-A single self-contained Markdown skill file in `@kiva/kv-tokens/docs/skills/<name>.md`, plus a one-line entry in `@kiva/kv-tokens/SKILLS.md`. The skill captures *design intent* from Figma (canonical), then ends with two code-facing sections: **Using with Tailwind** (how to express that intent with the Kiva Tailwind preset, hybrid so it works with or without the preset) and **Outstanding discrepancies** (the real Figma-vs-code sync gaps consumers should verify before depending on a token name).
+A single self-contained Markdown skill file in `@kiva/kv-skills/design-system/skills/kiva-design-system/<name>.md`, plus a one-line entry in `@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md`. The skill captures *design intent* from Figma (canonical), then ends with two code-facing sections: **Using with Tailwind** (how to express that intent with the Kiva Tailwind preset, hybrid so it works with or without the preset) and **Outstanding discrepancies** (the real Figma-vs-code sync gaps consumers should verify before depending on a token name).
 
 Existing exemplars in this repo:
 
@@ -48,8 +48,8 @@ The color skill round of this process missed ~5 tokens per theme and invented in
 
 ## File and index locations
 
-- **New skill:** `@kiva/kv-tokens/docs/skills/<kebab-name>.md`
-- **Index to update:** `@kiva/kv-tokens/SKILLS.md` (add one line under `## Skills`, format: `- [name](docs/skills/name.md) — one-line hook`)
+- **New skill:** `@kiva/kv-skills/design-system/skills/kiva-design-system/<kebab-name>.md`
+- **Index to update:** `@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md` (add one line under `## Skills`, format: `- [name](docs/skills/name.md) — one-line hook`)
 
 ## Code verification — before writing the code-facing sections
 
@@ -199,8 +199,8 @@ Add **both** files to `SKILLS.md`. The companion's index entry should explicitly
 3. **Decide on the data source per panel.** Screenshots for conceptual panels; `get_design_context` (and a parser) for dense token tables. See "When to start with screenshots vs. the Figma MCP" above.
 4. **Decide whether to split** into an umbrella + reference companion before drafting. The split shape is hard to retrofit after the fact. See "When to split into a companion reference file."
 5. **Verify code state.** Open the relevant token JSON, the Tailwind config block, and any wrapper components. Note the shipped utilities (for "Using with Tailwind"), the real gaps (for "Outstanding discrepancies"), and intentional differences; list concrete missing tokens by name.
-6. **Draft the skill(s)** using the standard structure. Write into `@kiva/kv-tokens/docs/skills/<name>.md`. Use the `Write` tool for new files; use `Edit` if revising.
-7. **Update the index.** Add one entry per file to `@kiva/kv-tokens/SKILLS.md` under `## Skills`.
+6. **Draft the skill(s)** using the standard structure. Write into `@kiva/kv-skills/design-system/skills/kiva-design-system/<name>.md`. Use the `Write` tool for new files; use `Edit` if revising.
+7. **Update the index.** Add one entry per file to `@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md` under `## Skills`.
 8. **Self-verify against canonical Figma data.** Before declaring done, pull every panel you summarized from screenshots and spot-check at least: (a) primitive / token values that drive other claims, (b) every callout in the accessibility or "do not use" sections, (c) every Do/Don't headline. Stale Figma labels and copy-paste errors are common enough that this step regularly catches real factual mistakes — treat it as required, not optional.
 9. **Brief the user.** End with a short summary listing what's in the new skill and any divergences from Figma you flagged. Don't re-list the full table of contents — call out structural choices and surprises only.
 

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
@@ -1,0 +1,148 @@
+
+---
+name: kiva-design-system
+description: >
+  Index and router for the Kiva design system skills — typography, layout,
+  spacing, radius, color, and color-themes. Use this as the entry point for any
+  task that touches Kiva's visual language: auditing existing code for
+  design-system compliance, generating new UI that uses correct tokens and
+  Tailwind utilities, answering design token questions, or performing a
+  Figma-to-code handoff. This skill routes to the relevant sub-skill(s); do
+  not load all sub-skills at once — load only what the task requires.
+when_to_use: >
+  Invoke when any of the following apply:
+  — Auditing a component, page, or PR for design-system compliance (wrong token,
+    missing class, incorrect radius, hardcoded color, etc.).
+  — Generating new Vue/HTML/Tailwind code and need to know the correct token
+    name, utility class, or component pattern for color, type, spacing, radius,
+    or layout.
+  — Answering a question about which design token to use for a given purpose
+    (e.g. "what's the right text color for a disabled button in the Marigold
+    theme?").
+  — Handing off a Figma design to code (mapping Figma token names and theme
+    values to `@kiva/kv-tokens` utilities).
+  Trigger phrases: "design system", "kiva token", "tw- class", "which token",
+  "audit", "design compliance", "Figma handoff", "color theme", "type style",
+  "spacing token", "border radius", "layout grid", "breakpoint".
+---
+
+# Kiva Design System — Index Skill
+
+## What this skill is
+
+This file is the **entry point and router** for the Kiva design system knowledge base. It does not contain token values itself — those live in the sub-skills below, sourced directly from the Figma Kiva Ecosystem 2026 file. Each sub-skill is **Figma-canonical**: the values, token names, and utility classes recorded there reflect design intent, and the shipped code in `@kiva/kv-tokens` may temporarily lag those specs while the token sync is in progress.
+
+**Always read the relevant sub-skill before advising on or generating design-system code.** Do not rely on memory for token names, class names, or hex values — load the sub-skill and quote from it.
+
+---
+
+## Sub-skills
+
+Load only the sub-skill(s) relevant to the current task. Do not load all six unless the task genuinely spans all categories.
+
+| Sub-skill | File | What it covers |
+|---|---|---|
+| **color** | [color.md](color.md) | Primitive palettes, the five themes (Default, Green Light, Green Dark, Marigold, Stone Light), the role/slot/state token grammar, accessibility levels per pairing, and decision rules for picking a token by purpose. |
+| **color-themes** | [color-themes.md](color-themes.md) | Full per-theme token tables (name → hex → primitive source → description) for every text, background, border, underline, and shadow slot. Load alongside `color` when you need canonical token data for a specific theme. |
+| **typography** | [typography.md](typography.md) | Type scale (Display → Caption), heading hierarchy, font families (Dovetail MVB / Kiva Post Grotesk), pairing rules, and Tailwind utility class mappings (`tw-text-*`). |
+| **layout** | [layout.md](layout.md) | Breakpoint tiers (XS/SM/MD/LG/XL), column/gutter/margin specs, content max-width rules, nested grids, and rules for aligning content on the grid. |
+| **spacing** | [spacing.md](spacing.md) | Semantic spacing categories (Structure, Component Gap, Component Inset, Micro), the 4px-grain ramp, responsive per-tier values, and the "between vs. inside" decision for picking a token. |
+| **radius** | [radius.md](radius.md) | Border-radius token scale (`none` → `full`), per-component use cases, the `inner = outer − gap` concentric formula, and the `tw-rounded` = 16px gotcha. |
+
+---
+
+## Routing rules — which sub-skill(s) to load
+
+### By task type
+
+| Task | Load these sub-skills |
+|---|---|
+| Audit component for design compliance | color + typography + spacing + radius (the four most commonly violated) |
+| Audit layout / responsive breakpoints | layout |
+| Generate a new component | Load the sub-skills that match the component's visual categories (color + typography is almost always needed; add spacing, radius, layout as the component requires) |
+| Answer a token question about color | color (+ color-themes if a specific theme's values are needed) |
+| Answer a token question about type | typography |
+| Answer a token question about space | spacing |
+| Answer a token question about corners | radius |
+| Answer a question about the grid / breakpoints | layout |
+| Figma-to-code handoff involving color | color + color-themes |
+| Figma-to-code handoff involving a full component | All sub-skills that the component's design touches |
+
+### By keyword in the task
+
+- **"color", "background", "text color", "border color", "theme"** → color (+ color-themes for specific values)
+- **"font", "heading", "type style", "text size", "tw-text-"** → typography
+- **"spacing", "padding", "gap", "margin between"** → spacing
+- **"radius", "rounded", "corner"** → radius
+- **"grid", "column", "breakpoint", "responsive", "layout"** → layout
+
+---
+
+## Use-case playbooks
+
+### 1 — Auditing code for design-system compliance
+
+**Goal:** Identify violations — hardcoded values, wrong tokens, missing classes — and recommend the correct replacement.
+
+**Steps:**
+
+1. Load the sub-skills that cover the component's visual categories (see routing rules above).
+2. Scan the target code for:
+   - Hardcoded hex values, raw `px` sizes, or `font-*` properties instead of token-backed utilities.
+   - Tailwind classes from stock Tailwind that the Kiva preset overrides or disables (e.g. `text-lg`, `font-bold` without the `tw-` prefix).
+   - Incorrect token usage — right category, wrong semantic role (e.g. using `text/secondary` for an interactive link instead of `text/action`).
+   - Radius values applied as raw `px` instead of `tw-rounded-*` utilities.
+   - Color primitives (e.g. `eco-green/3`) used directly in a component instead of the semantic layer.
+3. For each violation, cite the sub-skill rule that applies and give the specific corrected class or token name.
+4. Flag any divergence between the Figma-canonical spec (sub-skill) and the current shipped code — note it as a known sync gap, not a compliance failure.
+
+### 2 — Generating new UI code
+
+**Goal:** Produce HTML/Vue/Tailwind code that uses the correct Kiva tokens and utility classes from the first line.
+
+**Steps:**
+
+1. Before writing any markup, load the sub-skills that correspond to the component's visual areas.
+2. Apply type styles exclusively via `tw-text-*` utilities (e.g. `tw-text-headline`, `tw-text-body`); never set `font-family`, `font-size`, `font-weight`, `line-height`, or `letter-spacing` by hand.
+3. Use semantic color tokens via the `tw-bg-*` / `tw-text-*` / `tw-border-*` utilities backed by `@kiva/kv-tokens`; never use a hex value or a primitive token name in a component.
+4. Apply spacing via token-backed utilities — reach for the spacing sub-skill to pick the right semantic category before picking a size.
+5. Apply border radius via `tw-rounded-*` utilities — reach for the radius sub-skill to match the component family to the correct token.
+6. Verify that any utility class you write exists in the Kiva preset, not just in stock Tailwind. Note the sync-gap caveat from each sub-skill for any class you are unsure about.
+
+### 3 — Answering design token questions
+
+**Goal:** Give a specific, correct answer about which token to use and why — no guessing from memory.
+
+**Steps:**
+
+1. Load the targeted sub-skill (see routing rules).
+2. Find the token or rule that directly answers the question.
+3. Quote the token name, its utility class, and the decision rule from the sub-skill.
+4. If the question involves two similar tokens, use the sub-skill's decision guidance (e.g. the "between vs. inside" rule in spacing, or the role/slot grammar in color) to explain the difference.
+5. Flag any case where the Figma-canonical value in the sub-skill may differ from what is currently shipped in code (every sub-skill has an "Outstanding discrepancies" section).
+
+### 4 — Figma-to-code handoff
+
+**Goal:** Map Figma token names and theme values to the `@kiva/kv-tokens` Tailwind utilities a developer will actually write.
+
+**Steps:**
+
+1. Load **color + color-themes** for any color decision (nearly always needed).
+2. Load the additional sub-skills matching the design's visual categories.
+3. For each Figma token name, locate its row in the relevant sub-skill table and provide:
+   - The semantic token name (e.g. `text/action`)
+   - The Tailwind utility class (e.g. `tw-text-action`)
+   - The hex value for the active theme (from color-themes)
+4. For layout, map Figma's frame width and auto-layout gap values to the breakpoint tier and spacing token using the layout + spacing sub-skills.
+5. For typography, map Figma's text style name to the correct `tw-text-*` utility.
+6. Call out any Figma token that does not yet have a shipped code equivalent — use the "Outstanding discrepancies" section of the relevant sub-skill.
+
+---
+
+## Important standing rules
+
+1. **Figma is the source of truth for design intent.** The sub-skills capture that intent. Shipped code may lag; always note divergence rather than silently adopting the code value as correct.
+2. **Never reach past the semantic layer.** Components use semantic tokens (e.g. `text/action`). Primitives (e.g. `eco-green/3`) are only for defining semantics — never in component code.
+3. **No bespoke styles.** Do not write inline `style` attributes or custom CSS to set color, typography, spacing, or radius values. Always use the token-backed utility class. If no class fits, that is a signal for the design system team.
+4. **Token names are surface-specific.** In Figma: `base` (radius). In code: `default` → generates `tw-rounded`. Both refer to the same token. When bridging surfaces, use the name native to each surface.
+5. **Verify before committing.** The sub-skills note which token names or class names may not yet be shipped. Check `@kiva/kv-tokens/configs/tailwind.config.js` or the dist output before depending on a class name in production code.

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/color-themes.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/color-themes.md
@@ -1,0 +1,325 @@
+---
+name: color-themes
+description: Per-theme semantic color token tables from the Kiva design system — every token in Default, Green Light, Green Dark, Marigold, and Stone Light, with hex value, primitive source, and Figma-authored description. Plus the shadow color tokens. The reference companion to the conceptual `color` skill.
+when_to_use: When implementing or designing in a specific theme and you need the full token list for that theme — every text, background, border, and underline slot with its hex, primitive token, and intended usage description. Load this alongside the `color` skill whenever you need the canonical data, not just the framework. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+make_kit:
+  include: true
+  category: foundations
+  order: 25
+---
+
+# Kiva Color — Theme Token Tables
+
+This is the data companion to [color](color.md). Load that first for the *why* (principles, token grammar, accessibility framework, best practices, code-state caveats); load this when you need the full per-theme token list.
+
+Five themes are documented below in the order they appear in Figma, followed by the shadow color tokens. Each table is reproduced from the Figma "Color Themes and Usage" panel and uses the format:
+
+| Token | Hex | Primitive | Description |
+
+The **Token** column is the semantic name a designer or engineer references. The **Primitive** column shows which raw value powers it — useful when tracing how the system composes, and the only place opacity-based disabled tokens (e.g., `color/gray/800-1` = `#212121 (30%)`) are visible.
+
+**Wiring colors without the Tailwind preset?** These hex and primitive values are your fallback. See [color → Using with Tailwind](color.md#using-with-tailwind): when the `@kiva/kv-tokens` preset isn't registered, the themable `tw-bg-*` / `tw-text-*` utilities don't exist, so you either pull the CSS custom properties from `@kiva/kv-tokens/css` or apply the hex values in the tables below directly (losing runtime theming).
+
+## Source-of-truth caveats
+
+Several rows in the Figma source have obvious copy-paste or transcription errors. These are surfaced in **Figma source caveats** at the bottom of each theme rather than transcribed verbatim. When in doubt, treat the **Primitive** column as the canonical answer — primitive token names rarely have typos, and the hex/description should match the primitive.
+
+---
+
+## Default theme
+
+**White base · Used across all standard page layouts.**
+
+The fully populated theme. Every other theme inherits from this one and only redefines the tokens that differ. Forms and text fields render in this theme regardless of the surrounding section.
+
+### Text
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `text/primary` | `#223829` | `color/eco-green/4` | Primary text for all body copy, headlines, and icons. The darkest eco-green value. Use it for all high-importance content. |
+| `text/primary-inverse` | `#EDF4F1` | `color/eco-green/1` | Inverted text color for dark buttons and dark backgrounds. Used on dark surfaces (like `background/primary-inverse`) to maintain contrast. |
+| `text/secondary` | `#505050` | `color/gray/600` | Medium-contrast supportive text. Used for secondary labels, subtitles, metadata, and placeholder text. |
+| `text/tertiary` | `#757575` | `color/gray/500` | Low-contrast text for subtle information. Used for hints or non-essential decorative text. |
+| `text/action` | `#276A43` | `color/eco-green/3` | Brand-colored interactive text. Used for links, clickable labels, and active navigation items. |
+| `text/action-highlight` | `#223829` | `color/eco-green/4` | Darker brand text for active/pressed states. Used when the mouse hovers over links, secondary buttons, or clickable labels. |
+| `text/action-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled text within Default sections. Opacity-based — the intentionally low contrast communicates unavailability. |
+
+### Text — Alerts
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `text/caution` | `#593207` | `color/marigold/4` | Dark text for warning context. Used for warning messages or status labels that require user attention. |
+| `text/caution-highlight` | `#996210` | `color/marigold/3` | Hover state for warning-related text. Enhances visibility for interactive warning elements during hover. |
+| `text/danger` | `#5C2A22` | `color/desert-rose/4` | Dark text for error context. Used for error messages, critical alerts, and destructive action labels. |
+| `text/danger-highlight` | `#A24536` | `color/desert-rose/3` | Hover state for error-related text. Visual feedback for interactive destructive or error-prone elements. |
+
+### Background
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/primary` | `#FFFFFF` | `color/neutral/white` | Main application surface. The base color for the entire page or main content areas. |
+| `background/primary-inverse` | `#223829` | `color/eco-green/4` | High-contrast dark surface. Use for high-emphasis containers like dark headers, sidebars, or hero cards. |
+| `background/secondary` | `#EDF4F1` | `color/eco-green/1` | Subtle secondary surface. Use for section backgrounds, form inputs, or to differentiate cards from the main page. |
+| `background/tertiary` | `#C4C4C4` | `color/gray/300` | Low-priority decorative surface. Use inside a component (e.g., the track behind a progress bar) or for a disabled button surface. Not for page or section backgrounds. |
+| `background/action` | `#276A43` | `color/eco-green/3` | Brand-colored action surface. The base color for primary buttons, active toggles, and brand-heavy elements. Pair text with `text/primary-inverse`. |
+| `background/action-highlight` | `#223829` | `color/eco-green/4` | Hover state for action surfaces. Specifically for primary button hover and interactive brand surfaces. |
+| `background/action-secondary` | `#FFFFFF` | `color/neutral/white` | Surface color for secondary button default state within Default sections. |
+| `background/action-secondary-highlight` | `#EDF4F1` | `color/eco-green/1` | Hover state for secondary surfaces. Feedback color for interactive cards or buttons on hover. |
+| `background/primary-disabled` | `#276A43` (30%) | `color/eco-green/3-1` | Disabled or inactive state for primary button (30% opacity). |
+
+### Background — Alerts
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/caution` | `#F8CD69` | `color/marigold/2` | Subtle amber background. Background color for warning banners, toast notifications, and alert callouts. |
+| `background/caution-highlight` | `#F8F2E6` | `color/marigold/1` | Hover state for warning surfaces. Feedback color for interactive warning cards or actionable alerts on hover. |
+| `background/danger` | `#E0988D` | `color/desert-rose/2` | Subtle red background. Background color for error banners, destructive action dialogs, or invalid states. |
+| `background/danger-highlight` | `#F9F0EF` | `color/desert-rose/1` | Soft red background. The standard error alert surface — paired with `text/danger` for the body copy of an error message. |
+
+### Border
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `border/primary` | `#505050` | `color/gray/600` | High-contrast border. Use for component outlines, input field borders, and strong layout dividers. |
+| `border/primary-inverse` | `#FFFFFF` | `color/neutral/white` | Inverted border for dark surfaces. Contrast border for elements placed on dark-themed containers. |
+| `border/secondary` | `#757575` | `color/gray/500` | Medium-contrast border. Use for card borders, internal table dividers, and secondary component outlines. |
+| `border/secondary-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled or inactive state for secondary button (30% opacity). |
+| `border/tertiary` | `#C4C4C4` | `color/gray/300` | Low-contrast subtle border. Use for low-emphasis decorative lines or subtle element separation. |
+| `border/action` | `#276A43` | `color/eco-green/3` | Brand-colored border. Use for active focus states, selection rings, and brand-themed outlines. |
+| `border/action-highlight` | `#223829` | `color/eco-green/4` | Hover state for Default action borders. Darker green that darkens the outline on interaction. Apply on `:hover` and `:active` only. |
+
+### Border — Alerts
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `border/caution` | `#F8CD69` | `color/marigold/2` | Dark border for warning-related components. Borders on warning banners, alert cards, or validation states. |
+| `border/caution-highlight` | `#F8F2E6` | `color/marigold/1` | Hover state for warning-related borders. Visual feedback for interactive warning components on hover. |
+| `border/danger` | `#E0988D` | `color/desert-rose/2` | Dark border for error-related components. Borders on invalid input fields, error banners, or critical alert containers. |
+| `border/danger-highlight` | `#F9F0EF` | `color/desert-rose/1` | Hover state for error-related borders. Visual feedback for interactive destructive or error components on hover. |
+
+### Underline
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `heading-underline-primary` | `#2AA967` | `color/eco-green/default` | Brand-colored heading accent. A decorative variable used for brand underlines beneath main titles. |
+
+### Figma source caveats — Default
+
+- `background/danger-highlight` in the Figma table copies `background/danger`'s description verbatim. The corrected description above reflects how the token is actually used (soft error alert surface).
+
+---
+
+## Green Light theme
+
+**Light tint surface · Secondary sections, soft brand presence.**
+
+Green Light has only two unique tokens. Everything else — text, action, alerts, borders — is inherited from Default. Use Green Light for sections that need a subtle brand tint without owning the page atmosphere.
+
+### Background
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/primary` | `#EDF4F1` | `color/eco-green/1` | Light green section background. The base surface for all Green Light theme sections. |
+| `background/primary-inverse` | `#FFFFFF` | `color/neutral/white` | Theme-specific secondary surface. Provides contrast against `background/primary` for cards and inputs. |
+
+> **Why Green Light has only two unique tokens.** Green Light inherits all text, border, and alert tokens from the Default theme — they are identical in value and usage. Only `background/primary` and `background/primary-inverse` differ, because they define the section's surface color. The shared tokens are not duplicated here to avoid confusion — refer to the Default theme tables above for everything else.
+
+---
+
+## Green Dark theme
+
+**Dark green base · For high-emphasis sections, hero areas · Never full page.**
+
+Green Dark inverts the text/background relationship and brightens the action color so it remains legible against the dark surface. Reserved for section-level emphasis; never apply to a full page. Forms still render in Default — re-wrap form children in a Default-themed container.
+
+### Text
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `text/primary` | `#EDF4F1` | `color/eco-green/1` | Primary text on dark green surfaces. Use for body copy, headlines, and icons in Green Dark sections. |
+| `text/primary-inverse` | `#223829` | `color/eco-green/4` | Dark text color. Used for contrast when text is placed on rare light-colored components within a Green Dark section. |
+| `text/secondary` | `#C4C4C4` | `color/gray/300` | Subtle light gray text. Used for secondary labels, metadata, and supporting information. |
+| `text/tertiary` | `#E0E0E0` | `color/gray/200` | Low-contrast muted text. Used for hints or non-essential decorative text. |
+| `text/action` | `#78C79F` | `color/eco-green/2` | Bright accent green. High-visibility interactive color for links and active navigation tabs against dark surfaces. |
+| `text/action-highlight` | `#EDF4F1` | `color/eco-green/1` | Hover state for action text. Strong feedback color when hovering over interactive links in Green Dark sections. |
+| `text/action-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled text within Green Dark sections. Opacity-based — the low contrast communicates unavailability. |
+
+### Background
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/primary` | `#223829` | `color/eco-green/4` | Dark green base surface. The main background for Green Dark section content areas. |
+| `background/primary-inverse` | `#FFFFFF` | `color/neutral/white` | Pure white surface. High-contrast callouts or special containers needing maximum attention within a dark section. |
+| `background/secondary` | `#276A43` | `color/eco-green/3` | Subtle secondary surface. Use for nested cards, form inputs, or to differentiate sub-regions from the main dark surface. |
+| `background/tertiary` | `#C4C4C4` | `color/gray/300` | Low-priority decorative surface. Use inside a component (e.g., progress bar track) or for a disabled button surface. |
+| `background/action` | `#78C79F` | `color/eco-green/2` | Bright action surface. High-visibility background for primary buttons to stand out against dark environments. |
+| `background/action-highlight` | `#EDF4F1` | `color/eco-green/1` | Hover state for action surfaces. Specifically for primary button hover and active brand surfaces. |
+| `background/action-secondary` | `#223829` | `color/eco-green/4` | Surface color for secondary button default state within Green Dark sections. |
+| `background/action-secondary-highlight` | `#276A43` | `color/eco-green/3` | Hover state for secondary surfaces. Feedback color for interactive cards or buttons on hover. |
+| `background/primary-disabled` | `#276A43` (30%) | `color/eco-green/3-1` | Disabled or inactive state for primary button (30% opacity). |
+
+### Border
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `border/primary` | `#EDF4F1` | `color/eco-green/1` | Light green border. Primary component boundaries and strong dividers for Green Dark layouts. |
+| `border/primary-inverse` | `#223829` | `color/eco-green/4` | Dark border color. Inverted border for elements placed on rare light-colored containers within a Green Dark section. |
+| `border/secondary` | `#276A43` | `color/eco-green/3` | Muted brand green border. Subtle separation for secondary UI elements or nested sections. |
+| `border/secondary-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled or inactive state for secondary button (30% opacity). |
+| `border/tertiary` | `#78C79F` | `color/eco-green/2` | Low-contrast subtle border. Use for low-emphasis decorative lines or subtle element separation. |
+| `border/action` | `#78C79F` | `color/eco-green/2` | Bright interactive border. Used for active selection borders and focus rings in Green Dark sections. |
+| `border/action-highlight` | `#EDF4F1` | `color/eco-green/1` | Hover state for Green Dark action borders. Lighter green that lightens the outline on interaction. Apply on `:hover` and `:active` only. |
+
+### Underline
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `heading-underline-primary` | `#2AA967` | `color/eco-green/default` | Brand-colored heading accent. A decorative variable used for brand underlines beneath main titles. |
+
+### Figma source caveats — Green Dark
+
+- The Figma table renders `text/action`, `background/action`, `border/tertiary`, and `border/action` with hex `#276A43` (an `#` typo also appears as `##276A43`), but their primitive is `color/eco-green/2`. The shipped code resolves `eco-green/2` to `#78C79F`, which matches the visual in the Figma chips. The hex column above has been corrected to `#78C79F`; if you are reading the Figma table, ignore the textual hex and trust the primitive + chip.
+- `background/primary-disabled`'s Figma description ("Hover state for error surfaces…") was copy-pasted from another row. The corrected description above reflects how the token is actually used.
+
+---
+
+## Marigold theme
+
+**Warm amber surface for marketing, decoration, warning purposes.**
+
+Warm amber atmosphere for marketing pages, donation flows, and storytelling. Note that **the code names this theme `marigold-light`** even though Figma drops the `-light` suffix.
+
+### Text
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `text/primary` | `#593207` | `color/marigold/4` | Primary text for body copy, headlines, and icons within Marigold sections. The darkest marigold value. |
+| `text/primary-inverse` | `#F8F2E6` | `color/marigold/1` | Light marigold text for content placed on dark marigold surfaces (`background/primary-inverse`). Use exclusively on dark amber backgrounds — never on light surfaces where it becomes unreadable. |
+| `text/secondary` | `#505050` | `color/gray/600` | Mid-contrast supporting text within Marigold sections — labels, subtitles, metadata. |
+| `text/tertiary` | `#757575` | `color/gray/500` | Low-contrast muted text. Used for hints or non-essential decorative text. |
+| `text/action` | `#996210` | `color/marigold/3` | Deep gold interactive text. Used for interactive links and active navigation labels. |
+| `text/action-highlight` | `#593207` | `color/marigold/4` | Hover and pressed state for `text/action` within Marigold sections. Darker value ensures increased contrast on interaction. Apply on `:hover` and `:active` only — not for static emphasis. |
+| `text/action-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled text within Marigold sections. Opacity-based — the low contrast communicates unavailability. |
+
+### Background
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/primary` | `#F8F2E6` | `color/marigold/1` | Light amber section background. The base surface for Marigold sections. Use for warning-context sections, standout CTAs, or promotional sections. |
+| `background/primary-inverse` | `#593207` | `color/marigold/4` | Dark amber surface for high-emphasis containers within a Marigold section — banners, callout cards, or feature highlights. |
+| `background/secondary` | `#FFFFFF` | `color/neutral/white` | Subtle secondary surface. Use for nested cards, form inputs, or to differentiate sub-regions from the main amber surface. |
+| `background/tertiary` | `#C4C4C4` | `color/gray/300` | Low-priority decorative surface. Use inside a component (e.g., progress bar track) or for a disabled button surface. |
+| `background/action` | `#996210` | `color/marigold/3` | Golden action surface. Base color for primary buttons and active UI elements. |
+| `background/action-highlight` | `#593207` | `color/marigold/4` | Hover state for action surfaces. Feedback color for interactive surfaces and buttons on hover. |
+| `background/action-secondary` | `#F8F2E6` | `color/marigold/1` | Surface color for secondary button default state within Marigold sections. |
+| `background/action-secondary-highlight` | `#FFFFFF` | `color/neutral/white` | Hover state for secondary buttons within Marigold sections. Visual feedback that the outlined button is interactive. Apply on `:hover` and `:active` only. |
+| `background/primary-disabled` | `#996210` (30%) | `color/marigold/3-1` | Disabled state surface for Marigold primary buttons. Low opacity signals unavailability. |
+
+### Border
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `border/primary` | `#996210` | `color/marigold/3` | Deep gold border. Main border color for defining component boundaries within Marigold sections. |
+| `border/primary-inverse` | `#F8F2E6` | `color/marigold/1` | Light marigold inverted border. Used for elements placed on dark amber surfaces. |
+| `border/secondary` | `#F8CD69` | `color/marigold/2` | Medium-contrast border. Use for card borders, internal table dividers, and secondary component outlines. |
+| `border/secondary-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled or inactive state for secondary button (30% opacity). |
+| `border/tertiary` | `#FFFFFF` | `color/neutral/white` | Low-contrast subtle border for this theme. Use for low-emphasis decorative lines or subtle element separation. |
+| `border/action` | `#996210` | `color/marigold/3` | Brand-colored border for this theme. Use for active focus states, selection rings, and brand-themed outlines. |
+| `border/action-highlight` | `#593207` | `color/marigold/4` | Hover state for Marigold action borders. Darker amber that darkens the outline on interaction. Apply on `:hover` and `:active` only. |
+
+### Underline
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `heading-underline-primary` | `#F8CD69` | `color/marigold/2` | Brand-colored heading accent. A decorative variable used for brand underlines beneath main titles. |
+
+### Figma source caveats — Marigold
+
+- The Figma table renders `border/primary-inverse` with hex `#223829` (an eco-green value) and description "Brand gold accent. Specific decorative underline for headings." Both fields appear pasted from another token; the primitive `color/marigold/1` and the surrounding Marigold palette make `#F8F2E6` the correct value. Corrected above.
+
+---
+
+## Stone Light theme
+
+**Neutral warm stone · Earth-toned content.**
+
+Editorial and story atmosphere where green would compete with imagery. Note that **the code names this theme `stone-light`** which matches Figma's naming (unlike Marigold).
+
+### Text
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `text/primary` | `#2E271E` | `color/stone/4` | Primary text for body copy, headlines, and icons within Stone Light sections. The darkest stone value. |
+| `text/primary-inverse` | `#F3F1EF` | `color/stone/1` | Light stone text. Used for contrast when text is placed on dark stone surfaces (`background/primary-inverse`). |
+| `text/secondary` | `#505050` | `color/gray/600` | Subtle gray text. Used for secondary labels, metadata, and supporting information. |
+| `text/tertiary` | `#757575` | `color/gray/500` | Low-contrast muted text. Used for hints or non-essential decorative text. |
+| `text/action` | `#635544` | `color/stone/3` | Interactive text for links and clickable labels. Passes AA on `background/primary` and `background/secondary`. Do not use on `background/tertiary` (`#C4C4C4`) — contrast fails there. |
+| `text/action-highlight` | `#2E271E` | `color/stone/4` | Hover and pressed state for `text/action` within Stone sections. Apply on `:hover` and `:active` only. |
+| `text/action-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled text within Stone sections. Opacity-based — the low contrast communicates unavailability. |
+
+### Background
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `background/primary` | `#F3F1EF` | `color/stone/1` | Warm stone section background. Base surface for Stone Light sections — testimonials, partner areas, neutral content bands. |
+| `background/primary-inverse` | `#2E271E` | `color/stone/4` | Dark stone surface for high-emphasis containers within Stone sections. Creates strong contrast — use only when genuine emphasis is needed. |
+| `background/secondary` | `#FFFFFF` | `color/neutral/white` | Subtle secondary surface. Use for nested cards, form inputs, or to differentiate sub-regions from the main stone surface. |
+| `background/tertiary` | `#C4C4C4` | `color/gray/300` | Low-priority decorative surface. Use inside a component (e.g., progress bar track) or for a disabled button surface. |
+| `background/action` | `#635544` | `color/stone/3` | Muted stone action surface. Primary button fill for Stone theme buttons. |
+| `background/action-highlight` | `#2E271E` | `color/stone/4` | Hover state for action surfaces. Visual feedback for interactive buttons or cards on hover. |
+| `background/action-secondary` | `#F3F1EF` | `color/stone/1` | Surface color for secondary button default state within Stone sections. |
+| `background/action-secondary-highlight` | `#FFFFFF` | `color/neutral/white` | Hover state for secondary surfaces. Visual feedback for interactive cards or outlined buttons on hover. |
+| `background/primary-disabled` | `#635544` (30%) | `color/stone/3-1` | Disabled or inactive state for primary button (30% opacity). |
+
+### Border
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `border/primary` | `#635544` | `color/stone/3` | Muted stone border. Used for component outlines and layout dividers within Stone sections. |
+| `border/primary-inverse` | `#2E271E` | `color/stone/4` | Dark stone border. Inverted border for elements placed on light stone containers. |
+| `border/secondary` | `#AA9E8D` | `color/stone/2` | Muted stone border. Subtle separation for secondary UI elements or nested sections. |
+| `border/secondary-disabled` | `#212121` (30%) | `color/gray/800-1` | Disabled or inactive state for secondary button (30% opacity). |
+| `border/tertiary` | `#FFFFFF` | `color/neutral/white` | Low-contrast subtle border. Use for low-emphasis decorative lines or subtle element separation. |
+| `border/action` | `#635544` | `color/stone/3` | Muted stone interactive border. Base color for action selection borders and primary button outlines. |
+| `border/action-highlight` | `#2E271E` | `color/stone/4` | Hover state for Stone action borders. Visual feedback when hovering over interactive brand elements (e.g., secondary buttons). |
+
+### Underline
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `heading-underline-primary` | `#AA9E8D` | `color/stone/2` | Brand-colored heading accent. A decorative variable used for brand underlines beneath main titles. |
+
+### Figma source caveats — Stone Light
+
+- `background/action-secondary-highlight` and `background/primary-disabled` descriptions in Figma are copy-pasted from other rows ("Hover state for warning surfaces…" and "Hover state for error surfaces…"). The corrected descriptions above reflect actual use.
+- `border/secondary`'s Figma description refers to "muted brand green border" — left-over text from the Green Dark table. Corrected to "muted stone border."
+
+---
+
+## Shadow colors
+
+Three color tokens drive elevation. Apply the shadow token via the relevant component or utility rather than hand-rolling an `rgba()` — that way dark-theme shadows can be retuned without component rewrites.
+
+| Token | Hex | Primitive | Description |
+|---|---|---|---|
+| `shadow/default` | `#000000` (8%) | `color/shadow/default` | Default elevation shadow. Apply to cards, sticky elements, and any surface that should read as "lifted off the page." |
+| `shadow/hover` | `#000000` (16%) | `color/shadow/hover` | Stronger shadow for hover and interactive emphasis. Adds visible lift on `:hover` for cards and buttons. |
+| `shadow/click-active` | `#000000` (8%) | `color/shadow/click-active` | Pressed-state shadow. Used on `:active` to communicate the surface has been pushed back toward the page. |
+
+### Figma source caveats — Shadow
+
+- The Figma shadow table has the description and primitive-token columns swapped between the `shadow/hover` and `shadow/click-active` rows. The (semantic name, hex) pairings by row position are canonical and have been used above; the `:hover`-typically-stronger-than-`:active` convention confirms the assignment.
+
+---
+
+## Figma source reference
+
+- Color Themes and Usage: node `17950:8787`
+  - Default theme table: `18644:1206`
+  - Green Dark theme table: `18703:11854`
+  - Green Light theme table: `18712:12784`
+  - Marigold theme table: `18703:12254`
+  - Stone Light theme table: `18703:12497`
+  - Shadow token table: `18712:12793`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/color.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/color.md
@@ -1,0 +1,243 @@
+---
+name: color
+description: Semantic color system from the Kiva design system — primitive palettes (eco-green, marigold, desert-rose, stone, gray, neutral), the five themes (Default, Green Light, Green Dark, Marigold, Stone Light), the role/slot/state token grammar, accessibility levels per pairing, and rules for picking a token by purpose rather than hex value. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing anything that has color — backgrounds, text, borders, button surfaces, alert states, themed sections — or when picking between two tokens that look similar. Use it before reaching for a hex value, before applying a theme to a section, and any time a color decision crosses a semantic line (action vs. caution, primary vs. secondary, default vs. inverse). Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 20
+---
+
+# Kiva Color
+
+## Source of truth
+
+This skill captures the **semantic color system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which primitives exist, which themes are supported, what each semantic token means, when to use it, and how tokens compose into accessible pairings.
+
+Hex values and token names in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any token reference against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps, and "Using with Tailwind" for code naming and the shipped utility surface.
+
+## Why color matters
+
+Color does work on Kiva that the rest of the system can't: it tells a lender which button advances the lending flow, signals to a borrower that a field is in error, and separates a marigold "story" section from a default "form" section without needing a single word of copy. The semantic color system encodes that work in token names — `background/action` is *the* button color in whatever theme is active, not "green" — so the same component behaves correctly under any of the five themes.
+
+Common alternative names you may see used interchangeably: **color palette**, **color variables**, **design tokens**, **swatches**, **semantic colors**.
+
+## Design principles
+
+1. **Name the purpose, not the hue.** Use `text/action` for an interactive link, not "green" — the token resolves to the right color per theme. If you ever find yourself picking a token because it "looks right," step back and pick by intent.
+2. **Themes scope intent.** A theme is a coordinated set of role/slot tokens tuned for one page atmosphere. The token name stays the same across themes; the value changes. Compose pages from themed *sections*, don't repaint individual components.
+3. **Semantic meanings don't theme.** Error stays red, warning stays amber. Caution and danger token values are stable across themes precisely because the meaning is stable.
+4. **Always reference semantic tokens, not primitives.** Primitives exist to *build* semantic tokens. Components should never reach past the semantic layer into a raw `eco-green/3` or `gray/500`.
+
+## Primitives
+
+Primitive tokens are the raw values that power every semantic token. Use these only when defining new semantic tokens — components should always consume the semantic layer.
+
+| Family | Step | Hex | | Family | Step | Hex |
+|---|---|---|---|---|---|---|
+| **eco-green** | 1 | `#EDF4F1` | | **stone** | 1 | `#F3F1EF` |
+| | 2 | `#78C79F` | | | default | `#DFD0BC` |
+| | default | `#2AA967` | | | 2 | `#AA9E8D` |
+| | 3 | `#276A43` | | | 3 | `#635544` |
+| | 4 | `#223829` | | | 4 | `#2E271E` |
+| **marigold** | 1 | `#F8F2E6` | | **gray** | 50 | `#FAFAFA` |
+| | 2 | `#F8CD69` | | | 100 | `#F5F5F5` |
+| | default | `#F4B539` | | | 200 | `#E0E0E0` |
+| | 3 | `#996210` | | | 300 | `#C4C4C4` |
+| | 4 | `#593207` | | | 400 | `#9E9E9E` |
+| **desert-rose** | 1 | `#F9F0EF` | | | 500 | `#757575` |
+| | 2 | `#E0988D` | | | 600 | `#505050` |
+| | default | `#C45F4F` | | | 700 | `#454545` |
+| | 3 | `#A24536` | | | 800 | `#212121` |
+| | 4 | `#5C2A22` | | **neutral** | white | `#FFFFFF` |
+| | | | | | black | `#000000` |
+
+The stone family uses an out-of-order step naming (`1`, `default`, `2`, `3`, `4`) so the lighter swatch keeps the visual position designers expect. Don't try to "fix" it.
+
+> **Figma label typo for `eco-green/2`.** The Color Overview panel renders the text label `#C7EDD7` on top of the `eco-green/2` swatch, but the swatch's *actual fill* is `#78C79F` (the value above). The label is stale; the chip color, the Figma `color/eco-green/2` variable, and the shipped code (`tokens/core/color.json`) all agree on `#78C79F`. Use `#78C79F`.
+
+## Themes
+
+Five themes are supported. Each is suited to a specific page atmosphere; choose one as the section's base and let the semantic tokens do the rest.
+
+| Theme | Atmosphere | Use for |
+|---|---|---|
+| **Default** | White background, neutral and trustworthy | Forms, dashboards, primary content surfaces. The required theme for any form or text field. |
+| **Green Light** | Light green tinted surfaces | Secondary sections that lean on brand color without dominating. Inherits Default's text, action, and caution tokens. |
+| **Green Dark** | Dark green sections | High-emphasis brand moments (impact stats, partner CTAs). Section-level only — never the whole page. |
+| **Marigold** | Warm amber accents | Marketing, donation, warmth-forward stories. |
+| **Stone Light** | Neutral warm stone | Editorial / story content where green would compete with imagery. |
+
+## Token grammar
+
+Every semantic token reads as **role / slot / state-modifier**:
+
+| Part | Meaning | Examples |
+|---|---|---|
+| **Role** | What kind of property the token paints. | `text`, `background`, `border`, `heading-underline`, `shadow` |
+| **Slot** | What the color communicates. | `primary`, `secondary`, `tertiary`, `action`, `caution`, `danger` |
+| **State modifier** *(optional)* | Interaction or context variant. | `highlight` (hover / pressed), `inverse` (on opposite-tone surface), `disabled`, `secondary` (alternate emphasis within a state) |
+
+A few practical reads:
+
+- `text/primary` — the standard body copy color for the current theme.
+- `background/action-highlight` — the button surface under a hover or pressed state.
+- `border/primary-inverse` — the border color used when the component sits on a dark surface in the current theme.
+- `text/danger` — the foreground for an error message; pair with `background/danger-highlight` for the standard alert surface.
+
+## Per-theme token tables
+
+Every theme's full token list — name, hex, primitive source, and Figma-authored description for every text / background / border / underline token — lives in the companion reference file [color-themes.md](color-themes.md). That file is the data layer; this file is the framework.
+
+A quick orientation before you load it:
+
+- **Default** is the base. Every other theme inherits Default and only redefines the tokens that differ.
+- **Green Light** is the smallest theme — only two unique tokens (`background/primary`, `background/primary-inverse`). Everything else falls back to Default.
+- **Green Dark**, **Marigold**, and **Stone Light** each define their own full set of text / background / border tokens plus `heading-underline-primary`.
+- **Alert tokens** (`text/caution(+-highlight)`, `text/danger(+-highlight)`, `background/caution(+-highlight)`, `background/danger(+-highlight)`, `border/caution(+-highlight)`, `border/danger(+-highlight)`) are defined on Default only and used unchanged across themes — caution stays amber, danger stays desert-rose. See "Preserve semantic color meaning" below.
+
+The companion file also documents `shadow/default`, `shadow/hover`, and `shadow/click-active` and calls out the (several) Figma copy-paste errors in the source table.
+
+## The disabled-state pattern
+
+Disabled tokens (`text/action-disabled`, `background/primary-disabled`, `border/secondary-disabled`) are not full new color values — they are an **existing primitive at reduced opacity**. The Figma table renders this as a primitive name with a `-1` suffix (e.g., `color/gray/800-1` = `#212121` at 30%; `color/eco-green/3-1` = `#276A43` at 30%).
+
+The takeaway: a disabled state is the active-state color washed down — not a separately tuned gray. If you find yourself reaching for a custom disabled color, use the matching `*-disabled` token instead.
+
+## Shadow tokens (interaction-driven)
+
+Three color tokens drive elevation: `shadow/default` (resting), `shadow/hover` (lifted on hover), `shadow/click-active` (pressed). The naming is **interaction-state-based**, not severity-based. Full descriptions in [color-themes.md](color-themes.md#shadow-colors).
+
+## Accessibility
+
+Every meaningful foreground/background pairing in the Figma "Color Accessibility" panel is rated against **WCAG 2.1 AA (4.5:1)** and **AAA (7:1)** for normal body text.
+
+| Badge | Meaning | Safe for |
+|---|---|---|
+| **Pass** | Ratio ≥ 7:1 (passes AA and AAA) | All text, all sizes. |
+| **AA only** | 4.5:1 ≤ ratio < 7:1 | Normal body text; not for extended reading at small sizes or thin weights. |
+| **Large only** | 3:1 ≤ ratio < 4.5:1 | Large text (≥ 18pt or ≥ 14pt bold), icons, decorative type — never small body copy. |
+| **Fail** | Ratio < 4.5:1 (below AA) | Non-text decorative use only, or intentionally low-emphasis states (e.g., disabled). |
+
+A "Fail" is not automatically a bug. Some pairings fail on purpose — disabled controls, decorative panels — but a few are dangerous and should never be used for readable content. The Figma panel calls those out individually; treat its annotations as authoritative for which "Fail" pairings are acceptable.
+
+Notable real-world callouts from the Figma rating tables:
+
+- **Default theme:** `text/tertiary` on `background/secondary` is `4.1:1` and on `background/tertiary` is `2.6:1` — both flagged **Fail** in Figma with the note "Does not pass AA at any text size." Don't use `text/tertiary` for readable copy on those surfaces; use `text/primary` or `text/secondary` instead. (The 4.1:1 ratio technically clears 3:1 for large text, but the design system team is explicit that this pairing should not be used for readable text — heed the explicit guidance.)
+- **Green Light:** inherits Default's text/action/caution ratings — refer to Default for those, not duplicated in the Green Light table.
+- **Green Dark:** has a critically low pairing (`text/primary` on `background/tertiary` at `1.5:1`) explicitly flagged "must never be used." Treat the warning as load-bearing.
+- **Marigold:** `text/tertiary` pairings drop into Large-only or Fail; keep tertiary text off Marigold body surfaces.
+- **Stone Light:** similar caution around `text/tertiary` — Large-only on `background/primary`, Fail on `background/tertiary`.
+- **Alerts:** the alert tokens (`text/caution(+-highlight)`, `text/danger(+-highlight)`) are defined on Default and used across themes. They pass AA on their paired alert backgrounds.
+
+When in doubt, look the pairing up in the Figma table before approving it for body copy.
+
+## Best practices
+
+### Limit 1–2 primary themes per page
+
+- **Do** keep a page visually cohesive by anchoring it in one to two primary themes, with an optional tertiary theme for emphasis if needed.
+- **Don't** stack multiple themed sections (Default → Green Dark → Stone Light → Marigold) in a single page — the page reads as a swatchbook.
+
+### Buttons adapt to their theme context
+
+- **Do** use the theme's `background/action` and `text/action` tokens — the button reads as "primary" in whatever theme it sits in.
+- **Don't** hard-pin a button to a specific brand color or override `background/action` to enforce a global "primary green." Doing so breaks contrast guarantees in dark themes and defeats the point of theming.
+
+### Don't mix theme content within a single section
+
+- **Do** keep all content inside one section on the same theme. Theme switches should align with section boundaries.
+- **Don't** drop a Green Dark card into a Default section just to call attention to it — use spacing, hierarchy, or a sectioning component instead.
+
+### All forms and text fields follow the Default theme
+
+- **Do** render forms and inputs in Default theme, even when the surrounding section uses another theme.
+- **Don't** apply alternate themes to inputs, selects, or controls. Input contrast and focus states are tuned only against Default; off-theme inputs fail accessibility and read as broken.
+
+### Dark theme is for sections, not pages
+
+- **Do** use Green Dark to highlight specific sections.
+- **Don't** stack multiple Green Dark sections back to back without a visual break — the page loses rhythm and the dark sections stop reading as emphasized.
+
+### Preserve semantic color meaning
+
+- **Do** keep alert colors stable — caution is amber, danger is desert-rose, success is eco-green. Use `text/danger` and the danger backgrounds only for error states.
+- **Don't** redefine what a color represents per context (e.g., using desert-rose as a brand accent in a marketing band). The same color must mean the same thing everywhere or the system stops communicating.
+
+## How to use in Figma
+
+### Picking the right token
+
+Tokens are namespaced in the Figma variable picker by role. Search keywords:
+
+- `text` for foregrounds, `background` (or `bg`) for surfaces, `border` for outlines.
+- Add the slot to narrow further: `text/action`, `background/primary-inverse`, `border/danger-highlight`.
+
+If the variable picker shows two tokens with the same hex value, pick by *role*, not by value — `border/secondary` and `text/secondary` resolve to the same gray today but will diverge if the secondary text ramp shifts.
+
+### Theming a section
+
+1. Wrap the section frame in a component or auto-layout container themed via Figma variable modes.
+2. Switch the mode to the target theme (`default`, `green-light`, `green-dark`, `marigold`, `stone-light`).
+3. Every variable-bound color in that subtree updates automatically.
+4. Forms inside the section still use Default — re-wrap form children in a Default-themed container.
+
+### Before handoff
+
+Walk the file and check fills, strokes, and text colors for raw hex values. **Re-bind any raw value to a variable** — a raw hex is a detached color decision that won't follow updates and gives engineering nothing to map to. The Figma panel calls this out explicitly; treat it as a hard gate on hand-off.
+
+## Using with Tailwind
+
+The color utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+
+**Themable colors** are exposed as `tw-text-{slot}`, `tw-bg-{slot}`, `tw-border-{slot}`, `tw-divide-{slot}`, and `tw-ring-{slot}` — e.g. `tw-bg-primary`, `tw-text-action`, `tw-border-danger-highlight`. The slot names match the semantic token names in [color-themes.md](color-themes.md) (with `background/` → `bg-`). They compile to `rgb(var(--token))` and resolve at runtime from CSS custom properties, so they follow the active theme — reach for them by default. See [tailwind → Color is semantic, themable, and runtime-resolved](tailwind.md#color-is-semantic-themable-and-runtime-resolved), and [tailwind → Make themable colors resolve](tailwind.md#3-make-themable-colors-resolve-required-for-color-to-render) for how the custom properties get onto the page (`KvThemeProvider` does this in components).
+
+**Primitive (non-themed) utilities** — `tw-bg-eco-green-3`, `tw-text-marigold-DEFAULT`, `tw-bg-gray-100`, etc. — resolve directly to primitive values and do **not** change with theme. Use sparingly; components should consume semantic tokens, not primitives.
+
+**Theme names: type the code name, not the Figma name.** When importing themes from `@kiva/kv-tokens` (e.g. `marigoldLightTheme`) or referencing one in code:
+
+| Figma (design intent) | Code (what to type) |
+|---|---|
+| Default | `DEFAULT` |
+| Green Light | `green-light` |
+| Green Dark | `green-dark` |
+| Marigold | `marigold-light` *(code suffixes `-light`)* |
+| Stone Light | `stone-light` |
+
+Legacy themes still exported in code (`dark`, `dark-green`, `dark-mint`, `dark-stone`, `mint`, `stone-dark`) predate the five-theme system and are kept for backwards compatibility — **don't pick them for new work.**
+
+**Authoritative sources** (verify before depending):
+
+- `@kiva/kv-tokens/tokens/core/color.json` — primitive palette declarations.
+- `@kiva/kv-tokens/dist/js/tokens.js` (`colors.theme.*`) — the built, per-theme semantic token tree.
+- `@kiva/kv-tokens/configs/kivaColors.js` — turns each theme into CSS custom properties and exposes the Tailwind color choices.
+- `@kiva/kv-tokens/configs/tailwind.config.js` — wires the custom properties into the `tw-text-*` / `tw-bg-*` / `tw-border-*` / `tw-divide-*` / `tw-ring-*` utilities.
+- [`KvThemeProvider.vue`](../../../kv-components/src/vue/KvThemeProvider.vue) — sets the theme custom properties on a subtree.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Stock-Tailwind / non-Kiva project:** the themable utilities won't exist. Either import the shipped custom properties from `@kiva/kv-tokens/css` ([`dist/css/tokens.css`](../../dist/css/tokens.css), which ships a `:root` block plus `[data-theme="…"]` blocks) and reference `var(--token)` yourself, or use the static hex values from [color-themes.md](color-themes.md). The hex route loses runtime theming and the values are point-in-time.
+
+## Outstanding discrepancies
+
+- **`heading-underline/primary` is the only `heading-underline` token shipped,** and only Default, Marigold, and Stone Light (plus legacy `stone-dark`) define it; other themes fall back to whatever the parent provides.
+- **Semantic tokens defined in Figma but not yet in the shipped `colors.theme.*` tree:**
+  - `text/action-disabled` (all themes)
+  - `background/action-secondary`, `background/action-secondary-highlight`, `background/primary-disabled` (all themes except Green Light)
+  - `border/secondary-disabled`, `border/tertiary` (Green Dark, Marigold, Stone Light)
+  - `text/secondary`, `text/tertiary`, `background/tertiary`, `border/tertiary` (Green Dark, Marigold, Stone Light)
+
+  These can be added without breaking changes since they're new entries.
+- **Shadow tokens are not yet color-tokenized.** `boxShadow.DEFAULT` and `boxShadow.lg` in `tailwind.config.js` are hardcoded `rgb(0 0 0 / 0.08)`; the `shadow/default`, `shadow/hover`, `shadow/click-active` semantic tokens described in Figma have no code entry yet.
+
+When you find a divergence between this skill and the shipped tokens/components, flag it — closing those gaps is part of the long-running token sync work, and each instance is a data point.
+
+## Figma source references
+
+- Color Overview: node `18445:832`
+- Color Themes and Usage: node `17950:8787`
+- Color Accessibility: node `18829:465`
+- Color Guidelines: node `18296:7293`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/color.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/color.md
@@ -188,9 +188,9 @@ Walk the file and check fills, strokes, and text colors for raw hex values. **Re
 
 ## Using with Tailwind
 
-The color utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+The color utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
 
-**Themable colors** are exposed as `tw-text-{slot}`, `tw-bg-{slot}`, `tw-border-{slot}`, `tw-divide-{slot}`, and `tw-ring-{slot}` — e.g. `tw-bg-primary`, `tw-text-action`, `tw-border-danger-highlight`. The slot names match the semantic token names in [color-themes.md](color-themes.md) (with `background/` → `bg-`). They compile to `rgb(var(--token))` and resolve at runtime from CSS custom properties, so they follow the active theme — reach for them by default. See [tailwind → Color is semantic, themable, and runtime-resolved](tailwind.md#color-is-semantic-themable-and-runtime-resolved), and [tailwind → Make themable colors resolve](tailwind.md#3-make-themable-colors-resolve-required-for-color-to-render) for how the custom properties get onto the page (`KvThemeProvider` does this in components).
+**Themable colors** are exposed as `tw-text-{slot}`, `tw-bg-{slot}`, `tw-border-{slot}`, `tw-divide-{slot}`, and `tw-ring-{slot}` — e.g. `tw-bg-primary`, `tw-text-action`, `tw-border-danger-highlight`. The slot names match the semantic token names in [color-themes.md](color-themes.md) (with `background/` → `bg-`). They compile to `rgb(var(--token))` and resolve at runtime from CSS custom properties, so they follow the active theme — reach for them by default. See [tailwind → Color is semantic, themable, and runtime-resolved](../kiva-tailwind-css/SKILL.md#color-is-semantic-themable-and-runtime-resolved), and [tailwind → Make themable colors resolve](../kiva-tailwind-css/SKILL.md#3-make-themable-colors-resolve-required-for-color-to-render) for how the custom properties get onto the page (`KvThemeProvider` does this in components).
 
 **Primitive (non-themed) utilities** — `tw-bg-eco-green-3`, `tw-text-marigold-DEFAULT`, `tw-bg-gray-100`, etc. — resolve directly to primitive values and do **not** change with theme. Use sparingly; components should consume semantic tokens, not primitives.
 
@@ -216,7 +216,7 @@ Legacy themes still exported in code (`dark`, `dark-green`, `dark-mint`, `dark-s
 
 ### Without the preset
 
-- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset).
 - **Stock-Tailwind / non-Kiva project:** the themable utilities won't exist. Either import the shipped custom properties from `@kiva/kv-tokens/css` ([`dist/css/tokens.css`](../../dist/css/tokens.css), which ships a `:root` block plus `[data-theme="…"]` blocks) and reference `var(--token)` yourself, or use the static hex values from [color-themes.md](color-themes.md). The hex route loses runtime theming and the values are point-in-time.
 
 ## Outstanding discrepancies

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
@@ -1,0 +1,202 @@
+---
+name: layout
+description: Layout grid system from the Kiva design system — breakpoint tiers (XS/SM/MD/LG/XL), columns, gutters, margins, nested grids, and rules for aligning content within the grid. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing any page layout, responsive composition, or component that places content into columns — choosing a breakpoint, deciding a column span, reasoning about gutter vs. margin, nesting a grid inside a component, or handing off a multi-tier design to development. Reference design intent first; verify breakpoint and gap values against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 50
+---
+
+# Kiva Layout
+
+## Source of truth
+
+This skill captures the **layout grid system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which tiers exist, what their column/gutter/margin values are, and how content is meant to sit on the grid.
+
+Numeric values, tier names, and any class references in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` and `@kiva/kv-components` may temporarily lag behind these specs while the layout token sync work is in progress. **Verify any breakpoint value, gap class, or grid utility against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps.
+
+## Why a grid
+
+Kiva uses layout grids so that content aligns consistently across all screen sizes. The grid provides a shared structure that makes layout decisions predictable and repeatable — designers and developers reach the same answer without re-deriving it per screen.
+
+Common alternative names you may see used interchangeably: **columns**, **rows**, **guides**, **layout guides**, **grid system**.
+
+## Anatomy
+
+A page grid has three parts.
+
+| Part | What it is |
+|---|---|
+| **Column** | The vertical divisions that content aligns to. Column count and width change based on the size of the screen or container. |
+| **Gutter** | The empty space between columns, separating elements and preventing content from merging. Gutter stays the same size as the container resizes within a tier. |
+| **Margin** | The space between the outermost columns and the container edge. This value stays constant across the full range of each tier. |
+
+The mental model: margins frame the page; columns hold content; gutters keep content blocks from touching.
+
+## Breakpoint tiers — page grid specs
+
+The canonical reference for all five breakpoint tiers:
+
+| Tier | Range | Columns | Gutter | Margin |
+|---|---|---|---|---|
+| **XS** | 0 – 319px | 4 | 16px | 20px |
+| **SM** | 320px – 733px | 4 | 16px | 20px |
+| **MD** | 734px – 1023px | 8 | 24px | 32px |
+| **LG** | 1024px – 1439px | 12 | 32px | 64px |
+| **XL** | 1440px – up | 12 | 32px | 120px |
+
+> **Figma label note (SM columns):** the SM *breakpoint diagram* in Figma is tagged `col: 8`, but that label is stale — the spec table above, the diagram's own drawn columns, and the "Building Layouts" SM example all show **4** columns for SM. Use **4**; the `col: 8` tag is a Figma typo flagged to the design system team.
+
+### What XS is for
+
+XS exists as a **boundary tier only**. There is no XS Figma frame to design in — SM at 390px is the practical mobile design frame. XS guarantees the grid still resolves below 320px if a viewport ever lands there.
+
+### Content max width
+
+Even in LG and XL, content is constrained within a **1200px container**. Actual grid content caps at **~1152px** after accounting for padding and margins. Wider viewports show additional negative space at the edges; the grid does not keep growing.
+
+### Relationship to the spacing scale
+
+Every gutter and margin value above is a multiple of 4 — they sit on the same **4px-grained ramp** that powers the spacing system (see the [spacing](spacing.md) skill). Gutters map cleanly to spacing tokens (16 = `2`, 24 = `3`, 32 = `4`); the larger margin values (64 = `8`, 120 = `15`) also resolve on the ramp. Designers and developers can reason about both systems against one shared scale.
+
+## Nested grids
+
+A nested grid is a grid placed **inside a column of an existing page grid**. Use nested grids to organize the internal layout of a component (e.g., stats inside a loan card) without affecting the overall page structure.
+
+| Tier | Columns | Gutter | Margin |
+|---|---|---|---|
+| **XS** | 4 | 16px | — |
+| **SM** | 4 | 16px | — |
+| **MD** | 8 | 24px | — |
+| **LG** | 12 | 32px | — |
+| **XL** | 12 | 32px | — |
+
+**There is no margin on a nested grid** — that is the only structural difference from the page grid. Columns and gutters match the parent tier.
+
+### When to nest vs. span the parent
+
+The decision comes down to whether a section needs to align with the rest of the page or only with itself.
+
+| Use case | Approach | Example | Gutter |
+|---|---|---|---|
+| Main page sections | Span the parent grid | Nav, hero, content rows | Parent tier gutter |
+| Internal component layout | Use a nested grid | Stats inside a loan card | Parent tier gutter |
+| Spacing between items | Always use the tier gutter | Gap between cards, columns | Parent tier gutter |
+
+## Aligning content on the grid
+
+### Place content at the column edge, not the gutter
+
+Content starts at the **column edge**. Gutters are breathing room between content blocks — they are not a starting point for content.
+
+### Span
+
+Content can span one or more columns. Use `span` to control how wide a content block is within the grid.
+
+- If a span value **exceeds** the available columns, the content shrinks to fill what's available.
+- If there is not enough room left in a row, the content **wraps to the next row**.
+
+### Intrinsic-width content
+
+Not all content needs to span the full column width. Tags, badges, and pill buttons have a fixed natural size and should remain at their default width.
+
+- **Do** keep the intrinsic-width content at its natural size.
+- **Don't** stretch or shrink an intrinsic-width component to fill the grid.
+
+### Fixed-width content
+
+Some elements — most often a side navigation panel — have a fixed width that does not align with the column grid. When placed next to other content:
+
+- The gap between the fixed-width element and the adjacent content uses the **parent grid's gutter value**.
+- The remaining content continues to align with the outer grid.
+
+- **Do** follow the parent screen's layout gutter for the gap.
+- **Don't** abut adjacent content directly to the fixed-width edge with no gutter, and don't push the adjacent content past the next column edge.
+
+## Building layouts across tiers
+
+The same composition is expressed differently per tier because column counts change. Use spans that make sense for the tier:
+
+- **LG (12 columns):** Full-width sections use `span 12`. A three-up row of cards uses three `span 4` items.
+- **MD (8 columns):** Full-width sections use `span 8`. A two-up row uses two `span 4` items.
+- **SM (4 columns):** Almost everything stacks into single `span 4` blocks.
+
+When a design needs to shift from a multi-up row to a stack on a smaller tier, redo the span — don't try to preserve the same span value across tiers with different column counts.
+
+## Implementation in Figma
+
+### The grid is a guide, not a cage
+
+Use the grid as a guide, not a constraint. It exists to create alignment and rhythm, but:
+
+- Full-bleed elements (e.g., a hero background, a section banner) may extend beyond the grid.
+- Intrinsic elements like tags, badges, and buttons do not need to align to column edges.
+
+### Switching tiers mid-design
+
+Set your Figma frame to the **official width for the tier you're designing for**. Designing at an arbitrary width and approximating the grid causes inconsistencies during handoff. The tier ranges are absolute: anything 1024–1439px should use LG; anything 734–1023px should use MD; etc.
+
+### Handoff clarity
+
+When sharing specs with developers, **always note which tier the design is built at** and **whether any nested grids are in use**. Developers working mobile-first need to know which breakpoint token a component's internal layout maps to.
+
+### Applying layout grids in Figma
+
+Layout grid styles are published in the Kiva Ecosystem library. Apply the matching style to a frame:
+
+- `XS 0 - 319` — page grid for XS
+- `SM 320 - 733` — page grid for SM
+- `MD 734 - 1023` — page grid for MD
+- `LG 1024 - 1439` — page grid for LG
+- `XL 1440 - up` — page grid for XL
+- `XS-Nested 0 - 319`, `SM-Nested 320 - 733`, … — nested grid variants
+
+Match the style to the frame width and to whether the frame represents a page or a nested context.
+
+## Usage rules
+
+### Do
+
+- Pick the tier by viewport width using the absolute ranges above.
+- Align content to **column edges**, not gutters.
+- Use the **tier's** gutter for spacing between grid items (don't substitute an arbitrary gap).
+- Use a **nested grid** for component-internal layout that shouldn't be coupled to the page grid.
+- Note tier and nested-grid usage when handing a design to developers.
+
+### Don't
+
+- Don't approximate the grid by designing at non-tier widths.
+- Don't start content in the gutter or treat the gutter as a content well.
+- Don't stretch intrinsic-width components (tags, badges, pills) to fill columns.
+- Don't add a margin to a nested grid — nested grids have no margin by design.
+- Don't reuse the same span number across tiers without re-checking against the tier's column count.
+
+## Using with Tailwind
+
+The layout primitives come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+
+Breakpoints are **mobile-first min-width screens: `md`, `lg`, `xl`** (plus a `print` screen) — there is **no `sm` and no `2xl`**. Unprefixed utilities are the base tier, so the design system's XS and SM tiers both fall under "no prefix" in Tailwind; layer `md:` / `lg:` / `xl:` on top. See [tailwind → Breakpoints are `md` / `lg` / `xl`](tailwind.md#breakpoints-are-md--lg--xl-mobile-first-no-sm). Build grids with `tw-grid` and the column/gap utilities, or use `KvGrid` (with the gutter caveat below).
+
+**Shipped breakpoint values** (verify against `@kiva/kv-tokens/configs/tailwind.config.js` / `tokens/core/size.json`): `md: 734`, `lg: 1024`, `xl: 1440`.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Stock-Tailwind / non-Kiva project:** define `md` / `lg` / `xl` screens at the values above in your own config (or use arbitrary min-width media), and set gutters/margins explicitly from the [grid specs](#breakpoint-tiers--page-grid-specs). Copied values are point-in-time.
+
+## Outstanding discrepancies
+
+- **XS and SM tiers are not named breakpoints in code** — mobile is the unprefixed default; the XS/SM values in this skill are design-side targets only.
+- **`KvGrid`** ([`@kiva/kv-components/src/vue/KvGrid.vue`](../../../kv-components/src/vue/KvGrid.vue)) hard-codes its gap as `tw-gap-2 md:tw-gap-3 lg:tw-gap-3.5`, which **does not match** the Figma tier gutters (16 / 16 / 24 / 32 / 32). For spec-accurate gutters, set them explicitly with gap utilities rather than relying on `KvGrid`'s defaults.
+- **Margins** (20 / 20 / 32 / 64 / 120) and the **1200px content max-width** are not shipped as named tokens; page-container behavior lives per-consumer today.
+
+When you find a divergence between this skill and the shipped tokens/components, flag it — each is a data point for the design-system team.
+
+## Figma source references
+
+- Layout Overview: node `17968:7844`
+- Layout Grid: node `17968:7170`
+- Layout Guidelines: node `17968:7175`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
@@ -174,15 +174,15 @@ Match the style to the frame width and to whether the frame represents a page or
 
 ## Using with Tailwind
 
-The layout primitives come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+The layout primitives come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
 
-Breakpoints are **mobile-first min-width screens: `md`, `lg`, `xl`** (plus a `print` screen) — there is **no `sm` and no `2xl`**. Unprefixed utilities are the base tier, so the design system's XS and SM tiers both fall under "no prefix" in Tailwind; layer `md:` / `lg:` / `xl:` on top. See [tailwind → Breakpoints are `md` / `lg` / `xl`](tailwind.md#breakpoints-are-md--lg--xl-mobile-first-no-sm). Build grids with `tw-grid` and the column/gap utilities, or use `KvGrid` (with the gutter caveat below).
+Breakpoints are **mobile-first min-width screens: `md`, `lg`, `xl`** (plus a `print` screen) — there is **no `sm` and no `2xl`**. Unprefixed utilities are the base tier, so the design system's XS and SM tiers both fall under "no prefix" in Tailwind; layer `md:` / `lg:` / `xl:` on top. See [tailwind → Breakpoints are `md` / `lg` / `xl`](../kiva-tailwind-css/SKILL.md#breakpoints-are-md--lg--xl-mobile-first-no-sm). Build grids with `tw-grid` and the column/gap utilities, or use `KvGrid` (with the gutter caveat below).
 
 **Shipped breakpoint values** (verify against `@kiva/kv-tokens/configs/tailwind.config.js` / `tokens/core/size.json`): `md: 734`, `lg: 1024`, `xl: 1440`.
 
 ### Without the preset
 
-- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset).
 - **Stock-Tailwind / non-Kiva project:** define `md` / `lg` / `xl` screens at the values above in your own config (or use arbitrary min-width media), and set gutters/margins explicitly from the [grid specs](#breakpoint-tiers--page-grid-specs). Copied values are point-in-time.
 
 ## Outstanding discrepancies

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/radius.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/radius.md
@@ -1,0 +1,184 @@
+---
+name: radius
+description: Border-radius token system from the Kiva design system — the 8-step scale from none (0px) to full (9999px), per-component use cases, the inner-radius formula for nested elements, and rules for keeping corners consistent. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing any UI that has corners — buttons, cards, modals, inputs, chips, tags, avatars, images, section frames. Use it whenever someone reaches for a raw px corner-radius value, when nesting one rounded element inside another, or when picking a Tailwind `tw-rounded-*` utility. Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 60
+---
+
+# Kiva Radius
+
+## Source of truth
+
+This skill captures the **border-radius system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which tokens exist, what each represents, and how to choose between them for any given component.
+
+Numeric values, token names, and class references in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any token reference against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps.
+
+## Why radius matters
+
+Radius shapes the corners of UI elements — and corner shape communicates **warmth, hierarchy, and interactivity**. Kiva's system defines 8 tokens running from square (`none`) to fully rounded (`full`), each mapped to a specific component family.
+
+Using defined tokens instead of arbitrary values gets us three things:
+
+1. Visual consistency across screens and components.
+2. **Concentric corners** — proportional relationships between nested elements so corner curves look intentional.
+3. Cleaner design-to-engineering handoff with no surprise pixel values to translate.
+
+Common alternative names you may see used interchangeably: **border radius**, **rounding**, **corner radius**.
+
+## Design principles
+
+1. **Contextual hierarchy.** Radius signals element importance. Larger tokens (`base`, `lg`, `xl`) mark prominent interactive surfaces — buttons, cards, section frames. Smaller tokens (`xs`, `sm`) serve utility-first components like inputs and chips.
+2. **Concentric consistency.** When elements are nested, the inner radius equals the outer radius minus the gap (see the [inner-radius formula](#inner-radius-the-concentric-formula)). A flat inner corner inside a rounded outer corner reads as unintentional.
+3. **Scale discipline.** Always reach for a token — in design and in code. Never introduce arbitrary radius values. This keeps the system predictable, token-auditable, and clean for engineering handoff.
+
+## The scale
+
+Each token pairs a value with a component family. Pick by what the component *is*, not by eyeballing a curve.
+
+| Token | Value | Tailwind class | Use cases |
+|---|---|---|---|
+| **none** | 0px | `tw-rounded-none` | Table cells; marketing photos as needed |
+| **xs** | 4px | `tw-rounded-xs` | Form inputs, dropdowns, text areas, combo boxes |
+| **sm** | 8px | `tw-rounded-sm` | Chips, table frame, large rectangular achievement badges |
+| **md** | 12px | `tw-rounded-md` | Tooltips, stats tiles, selection tiles, sticky banners/footers, images, photos |
+| **base** | 16px | `tw-rounded` | Buttons, modal, lightbox, toast, bottom sheet, mini cards |
+| **lg** | 20px | `tw-rounded-lg` | All standard card outer corners, loan cards, slider cards, desktop images (except branding/marketing) |
+| **xl** | 24px | `tw-rounded-xl` | Section frame |
+| **full** | 9999px | `tw-rounded-full` | Icon buttons, tags / small badges, avatars, toggles |
+
+### Anatomy of a token
+
+Every radius token is defined by three properties:
+
+- **Token name** — the identifier used in Figma and code. The 16px token is named **`base`** in Figma (renamed for visual consistency with the `xs / sm / md / lg / xl` scale; Figma treats the older **`default`** as the legacy name). In code it is still **`default`**, because Tailwind's `DEFAULT` key convention is what generates the unsuffixed `tw-rounded` utility. The two names refer to the same token — each is the one to type in its own surface.
+- **Pixel value** — the corner radius. The scale runs `0, 4, 8, 12, 16, 20, 24, 9999`.
+- **Tailwind class** — the utility generated from the token. Because the 16px token maps to the **`DEFAULT`** key in Tailwind, the utility is just `tw-rounded` (no suffix).
+
+### The `tw-rounded` gotcha
+
+In stock Tailwind, `rounded` (no suffix) is a small radius — pill-shaped corners come from `rounded-full`. In **Kiva's Tailwind preset** that's not true: `tw-rounded` resolves to **16px** (the `base` token), not to a pill. Use **`tw-rounded-full`** when you want a pill or circle.
+
+If you're porting code from a standard Tailwind project, audit every bare `rounded` — what was a subtle curve there is a noticeably rounded 16px corner here.
+
+## Inner radius — the concentric formula
+
+When a component is nested flush inside a container, calculate its corner radius:
+
+> **inner radius = outer radius − gap**
+
+This prevents *visual inversion* — the failure mode where inner corners look larger than outer corners, which breaks the spatial hierarchy.
+
+Worked examples (outer / gap → content):
+
+| Outer | Gap | Content (inner) |
+|---|---|---|
+| 16px | 8px | 8px |
+| 20px | 8px | 12px |
+| 20px | 16px | 4px |
+| 24px | 16px | 8px |
+
+### When math suggests something awkward
+
+For some cases, lean into an **8px radius** for a more effortless look, even if the formula suggests 4px. Treat the formula as a baseline, not a tyrant — the goal is optical consistency, not strict arithmetic.
+
+### Independent content — when not to use the formula
+
+When inner elements are **clearly independent** of the container (e.g., mini cards laid out inside a wide banner, where the cards have their own visual identity), the inner element should use its **own component token radius** rather than the container's formula.
+
+The one constraint that still holds: **inner radius must always be ≤ outer radius**. Even with independent content, never let a child have a more rounded corner than its parent — that's visual inversion in the other direction.
+
+## Best practices
+
+### Use the formula inside a card
+
+- **Do** compute the inner radius from the outer + gap when content sits flush inside a rounded container.
+- **Don't** use a flat `0px` corner radius inside a rounded container. Always calculate the inner radius.
+
+### Keep corners symmetric unless there's a structural reason
+
+- **Do** apply the same radius to all four corners of a component.
+- **Don't** apply different radius values to different corners arbitrarily. Asymmetric rounding reads as inconsistency unless it has a structural justification — for example, a card visually attached to the bottom of a tab bar where the top corners are flat to indicate continuity.
+
+## Component → token quick reference
+
+For fast lookup at design or build time, here's the inverse of the table above — common component types and the token they map to:
+
+| Component | Token | Class |
+|---|---|---|
+| Dropdown, text input, text area, combo box | `xs` | `tw-rounded-xs` |
+| Chip, table frame, achievement badge | `sm` | `tw-rounded-sm` |
+| Tooltip, mobile image, stats tile, selection tile, sticky banner/footer | `md` | `tw-rounded-md` |
+| Button, toast, lightbox, modal, bottom sheet, mini card | `base` | `tw-rounded` |
+| Card (standard), loan card, slider card, desktop image | `lg` | `tw-rounded-lg` |
+| Section frame | `xl` | `tw-rounded-xl` |
+| Icon button, tag, small badge, avatar, toggle | `full` | `tw-rounded-full` |
+| Table cell, raw marketing photo | `none` | `tw-rounded-none` |
+
+## Usage rules
+
+### Do
+
+- Pick a token by **component type** using the scale table above.
+- Use the inner-radius formula whenever content is nested flush inside a rounded container.
+- Apply the same radius to all four corners by default.
+- Use `tw-rounded-full` (not bare `tw-rounded`) when you want a pill or circle.
+
+### Don't
+
+- Don't write arbitrary radius values (`border-radius: 10px`, `tw-rounded-[10px]`). If no token fits, that's a design-system conversation, not a one-off.
+- Don't leave a flat (`0px`) corner against a rounded container.
+- Don't let an inner radius exceed its container's radius — visual inversion in either direction breaks the spatial hierarchy.
+- Don't asymmetrically round corners without a structural reason.
+
+### Need something not covered here?
+
+Open a request with the design system team. Include the use case, the component, and why the existing tokens don't fit.
+
+## How to use in Figma
+
+All radius tokens are published as variables in the Kiva Ecosystem library. When applying a radius:
+
+- Bind the corner-radius property to the radius variable instead of typing a number.
+- Hover a variable to see its value and intended use cases.
+- Before handoff, inspect the frame: if the corner-radius field shows a raw number instead of a variable name, **re-bind it from the library**. A raw value is a detached decision that won't follow updates and leaves developers without a token to map to.
+
+## Using with Tailwind
+
+The radius utilities below come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered the preset yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset at all? See [Without the preset](#without-the-preset) below.
+
+Pick the class straight from the [scale table](#the-scale) above — each token's `tw-rounded-*` utility is listed there. The one trap carried over from stock Tailwind: **`tw-rounded` (no suffix) is 16px here**, not a small radius; use `tw-rounded-full` for a pill or circle. See [The `tw-rounded` gotcha](#the-tw-rounded-gotcha) above, and [tailwind](tailwind.md#border-radius-is-token-driven-and-tw-rounded--pill) for why.
+
+**Shipped today** (verify against `@kiva/kv-tokens/configs/tailwind.config.js → theme.borderRadius` before depending):
+
+- `tw-rounded-none` → `0px` (hardcoded in the preset)
+- `tw-rounded-xs` → `4px` (from `radii.xs`)
+- `tw-rounded-sm` → `8px` (from `radii.sm`)
+- `tw-rounded-md` → `12px` (from `radii.md`)
+- `tw-rounded` → `16px` (the `DEFAULT` key, from `radii.default`)
+- `tw-rounded-lg` → `20px` (from `radii.lg`)
+- `tw-rounded-xl` → `24px` (from `radii.xl`)
+- `tw-rounded-full` → `500rem` (hardcoded in the preset; functionally a pill at any real width)
+
+The 16px token is **`default` in code** and **`base` in Figma** — Tailwind's `DEFAULT` key generates the unsuffixed `tw-rounded` utility, so the mapping resolves through `DEFAULT` regardless of the source name. In code use `default` / `DEFAULT`; in Figma use `base`.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Until then, arbitrary values (`rounded-[16px]`) are a stopgap.
+- **Stock-Tailwind / non-Kiva project:** use arbitrary values from the [scale table](#the-scale) (`rounded-[16px]`, `rounded-[20px]`). These are point-in-time copies of the token values, so re-check them if the scale changes.
+
+## Outstanding discrepancies
+
+- **`none` (0px) and `full` (500rem) are hardcoded in the preset** rather than flowing from `tokens/core/size.json` like the rest of the scale. A sync gap worth closing.
+
+When you find a divergence from the shipped tokens, flag it — each is a data point for the design-system team.
+
+## Figma source references
+
+- Radius Overview: node `18929:1295`
+- Radius Scale: node `18931:1295`
+- Radius Guidelines: node `18932:1295`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/radius.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/radius.md
@@ -147,9 +147,9 @@ All radius tokens are published as variables in the Kiva Ecosystem library. When
 
 ## Using with Tailwind
 
-The radius utilities below come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered the preset yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset at all? See [Without the preset](#without-the-preset) below.
+The radius utilities below come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered the preset yet? See [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Not using the preset at all? See [Without the preset](#without-the-preset) below.
 
-Pick the class straight from the [scale table](#the-scale) above — each token's `tw-rounded-*` utility is listed there. The one trap carried over from stock Tailwind: **`tw-rounded` (no suffix) is 16px here**, not a small radius; use `tw-rounded-full` for a pill or circle. See [The `tw-rounded` gotcha](#the-tw-rounded-gotcha) above, and [tailwind](tailwind.md#border-radius-is-token-driven-and-tw-rounded--pill) for why.
+Pick the class straight from the [scale table](#the-scale) above — each token's `tw-rounded-*` utility is listed there. The one trap carried over from stock Tailwind: **`tw-rounded` (no suffix) is 16px here**, not a small radius; use `tw-rounded-full` for a pill or circle. See [The `tw-rounded` gotcha](#the-tw-rounded-gotcha) above, and [tailwind](../kiva-tailwind-css/SKILL.md#border-radius-is-token-driven-and-tw-rounded--pill) for why.
 
 **Shipped today** (verify against `@kiva/kv-tokens/configs/tailwind.config.js → theme.borderRadius` before depending):
 
@@ -166,7 +166,7 @@ The 16px token is **`default` in code** and **`base` in Figma** — Tailwind's `
 
 ### Without the preset
 
-- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Until then, arbitrary values (`rounded-[16px]`) are a stopgap.
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Until then, arbitrary values (`rounded-[16px]`) are a stopgap.
 - **Stock-Tailwind / non-Kiva project:** use arbitrary values from the [scale table](#the-scale) (`rounded-[16px]`, `rounded-[20px]`). These are point-in-time copies of the token values, so re-check them if the scale changes.
 
 ## Outstanding discrepancies

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
@@ -185,9 +185,9 @@ Open a request with the design system team. Include the use case, the component,
 
 ## Using with Tailwind
 
-The spacing utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+The spacing utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
 
-The preset wires every value on [the raw spacing ramp](#the-raw-spacing-ramp) into the standard spacing utilities — `tw-p-*`, `tw-m-*`, `tw-gap-*`, `tw-space-*`, etc. all flow from the `space` scale. The thing to internalize: this is an **8px scale with 4px half-steps**, so the same number means a different size than stock Tailwind — `tw-p-4` is **32px** here, not 16px. See [tailwind → Spacing is an 8px scale](tailwind.md#spacing-is-an-8px-scale-with-4px-half-steps).
+The preset wires every value on [the raw spacing ramp](#the-raw-spacing-ramp) into the standard spacing utilities — `tw-p-*`, `tw-m-*`, `tw-gap-*`, `tw-space-*`, etc. all flow from the `space` scale. The thing to internalize: this is an **8px scale with 4px half-steps**, so the same number means a different size than stock Tailwind — `tw-p-4` is **32px** here, not 16px. See [tailwind → Spacing is an 8px scale](../kiva-tailwind-css/SKILL.md#spacing-is-an-8px-scale-with-4px-half-steps).
 
 Three key-naming conventions describe the same tokens — don't get tripped up:
 
@@ -199,7 +199,7 @@ The shipped code exposes this **raw numeric ramp**, not the semantic categories 
 
 ### Without the preset
 
-- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset).
 - **Stock-Tailwind / non-Kiva project:** the ramp is plain px, so the values in [the raw spacing ramp](#the-raw-spacing-ramp) table can be applied as arbitrary values (`p-[20px]`) or used to define your own scale. These are point-in-time copies.
 
 ## Outstanding discrepancies

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
@@ -1,0 +1,218 @@
+---
+name: spacing
+description: Semantic spacing system from the Kiva design system — token categories (Structure, Component Gap, Component Inset, Micro), the 4px-grain ramp, responsive per-tier values, and rules for picking a token by spatial relationship rather than pixel value. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing any UI that involves space — section gaps, component padding, gaps inside a component, padding inside a card or modal, or any auto-layout gap/padding decision in Figma. Use it whenever someone reaches for a raw pixel value, or when picking between two tokens that happen to share the same number. Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 40
+---
+
+# Kiva Spacing
+
+## Source of truth
+
+This skill captures the **semantic spacing system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which categories exist, what each token means, when to use it, and how spacing values are expected to scale across breakpoints.
+
+Numeric values and token names in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any token reference against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps.
+
+## Why spacing matters
+
+Spacing is the invisible structure that holds an interface together. It creates relationships: grouping elements that belong together, separating elements that don't, and guiding a user's eye from one piece of content to the next. On Kiva, spacing shapes how borrowers read loan details, how lenders scan the stories, and how partners navigate their dashboards.
+
+Common alternative names you may see used interchangeably: **padding**, **gap**, **layout**.
+
+## Design principles
+
+1. **Name the relationships.** Each spacing value should represent a clear intent — group related elements, separate distinct sections, indicate hierarchy, improve readability and scanning. *If you can't explain why a space exists, reconsider it.*
+2. **Stay on the grid.** Every value is a 4px multiple. The spacing system shares its grid with typography and layout — reusing tokens across screens creates rhythm and reduces visual noise.
+3. **Spacing signals hierarchy.** A larger space implies separation; a medium space implies "related but distinct"; a smaller space implies grouping. Hierarchy should be readable even with color and typography stripped away.
+
+## The "between or inside" decision
+
+When picking a token, start with the spatial relationship — not with a pixel value:
+
+> **Am I spacing *between* things, or *inside* something?**
+
+- **Between** → reach for **Structure** (page-scale) or **Component / Gap** (inside-a-component scale).
+- **Inside** → reach for **Component / Inset** (padding within a bordered container).
+
+The same number can mean two different things (16px as a card gap is not the same intent as 16px of internal card padding). Picking by category first keeps that distinction explicit.
+
+## Semantic token categories
+
+Token values are responsive: most tokens hold a single value across tiers, but a few shrink on mobile. Always apply the token, not a raw px — the responsiveness is the point.
+
+### Structure
+
+The large-scale spaces that shape a page's overall layout and breathing room. Use *between* sections and large compositions on a page.
+
+| Token | Desktop | Tablet | Mobile | Example use |
+|---|---|---|---|---|
+| **XL** | 32px | 32px | 24px | Between major page sections (hero → content, content → footer) |
+| **L** | 24px | 24px | 16px | Between large components |
+| **M** | 16px | 16px | 16px | Between components |
+| **S** | 8px | 8px | 8px | Between header and subheader |
+
+### Component / Gap
+
+Space between sibling elements *inside* a component. The internal breathing room of a component.
+
+| Token | Desktop | Tablet | Mobile | Example use |
+|---|---|---|---|---|
+| **L** | 16px | 16px | 16px | Between cards in a grid |
+| **M** | 8px | 8px | 8px | Between content and button inside a card; list-item internal spacing |
+| **S** | 4px | 4px | 4px | Between tags or text elements in compact contexts |
+
+### Component / Inset
+
+Padding *inside* containers. Anything with a visible boundary — modals, cards, sidesheets, chips — gets inset padding.
+
+| Token | Desktop | Tablet | Mobile | Example use |
+|---|---|---|---|---|
+| **XL** | 32px | 24px | 20px | Padding for modals, lightboxes, sidesheets, popups |
+| **L** | 24px | 24px | 20px | Padding for large widgets, expanded panels, feature sections |
+| **M** | 16px | 16px | 16px | Padding for medium cards, standard content containers |
+| **S** | 8px | 8px | 8px | Padding for small cards, compact containers |
+| **XS** | 4px | 4px | 4px | Padding for location chips, tags, badges |
+
+### Micro
+
+A single 4px value reserved for the **tightest inline coupling** — gaps that exist only to keep adjacent elements visually attached, not to imply hierarchy.
+
+| Token | Desktop | Tablet | Mobile | Example use |
+|---|---|---|---|---|
+| **Micro** | 4px | 4px | 4px | Gap between icon + text pairs, small inline elements, gaps inside compact UI patterns |
+
+## The raw spacing ramp
+
+Underneath the semantic categories is a numeric ramp that is **4px-grained** — every token is a 4px multiple, and adjacent steps on the ramp are 4px apart. Every semantic token resolves to a value on this ramp, and the same ramp underpins layout values (gutters, margins) and any other dimension token in the system.
+
+Token naming uses two kinds of step:
+
+- **Whole-number tokens** (`1`, `2`, `3`…) land on the 8px multiples of the scale — `1` = 8px, `2` = 16px, `3` = 24px, etc. These are the most commonly reached-for values.
+- **Half-step tokens** (`0-5`, `1-5`, `2-5`…) fill in the 4px steps between — `0-5` = 4px, `1-5` = 12px, `2-5` = 20px, etc.
+
+Despite the `-5` naming, the half-steps are not "less canonical." They're first-class values on the same 4px scale. The Figma Spacing Ramp panel frames the system around an 8px base unit: *"The 8px base unit … forms the basis of our space token system, as the base unit `spacing 1`. Every space token is a multiple of this base unit."* That last claim is misleading — the half-step tokens (`0-5` = 4px, `1-5` = 12px, `2-5` = 20px) are **not** multiples of 8px. Treat the scale as **4px-grained** throughout, which matches both the Spacing Overview panel's "Every value is a 4px multiple" principle and the shipped code.
+
+Quick formula: `N` = `N × 8px`, and `N-5` = `N × 8px + 4px` — both of which simplify to "the Nth and (N + ½)th rung of a 4px ramp."
+
+| Token | px | rem | | Token | px | rem |
+|---|---|---|---|---|---|---|
+| 0 | 0 | 0 | | 8-5 | 68 | 4.25 |
+| 0-5 | 4 | 0.25 | | 9 | 72 | 4.5 |
+| 1 | 8 | 0.5 | | 9-5 | 76 | 4.75 |
+| 1-5 | 12 | 0.75 | | 10 | 80 | 5 |
+| 2 | 16 | 1 | | 10-5 | 84 | 5.25 |
+| 2-5 | 20 | 1.25 | | 11 | 88 | 5.5 |
+| 3 | 24 | 1.5 | | 11-5 | 92 | 5.75 |
+| 3-5 | 28 | 1.75 | | 12 | 96 | 6 |
+| 4 | 32 | 2 | | 12-5 | 100 | 6.25 |
+| 4-5 | 36 | 2.25 | | 13 | 104 | 6.5 |
+| 5 | 40 | 2.5 | | 13-5 | 108 | 6.75 |
+| 5-5 | 44 | 2.75 | | 14 | 112 | 7 |
+| 6 | 48 | 3 | | 14-5 | 116 | 7.25 |
+| 6-5 | 52 | 3.25 | | 15 | 120 | 7.5 |
+| 7 | 56 | 3.5 | | 15-5 | 124 | 7.75 |
+| 7-5 | 60 | 3.75 | | 16 | 128 | 8 |
+| 8 | 64 | 4 | | | | |
+
+The raw ramp is the layer the **Tailwind config** ships today (e.g., `tw-p-2.5` = 20px). The semantic categories above are not yet exposed in code — see "Outstanding discrepancies."
+
+> **Caveat about the Figma table:** the Spacing Scales & Tokens panel in Figma has typos in the `rem` column from row `10-5` onward (the values appear to have wrapped), and the panel labels the bottom two rows as `16 = 124px` and `16-5 = 128px` when they are actually `15-5` and `16` on the ramp. The shipped `tokens/core/size.json` is authoritative — trust it (and the formula above) over the rendered Figma table.
+
+## Best practices
+
+### Apply spacing by *meaning*, not values
+
+- **Do** select spacing tokens based on their intended semantic purpose. Use **Component / Gap** for spacing between elements *inside* a component, and **Component / Inset** for the container's padding. Semantic consistency keeps layouts predictable, scalable, and easier to refactor.
+- **Don't** substitute tokens across categories just because the pixel values happen to match. Picking by number alone breaks system logic and makes the system harder to evolve — when the value behind `Inset M` shifts later, you don't want stray `Gap M`s following along.
+
+### A worked example (single card on a page)
+
+Reading from outside in on a typical loan-style card:
+
+1. **Structure XL** — space between the card section and the next page section.
+2. **Component Inset XL** — padding inside the card.
+3. **Component Inset L** — padding inside a sub-region of the card.
+4. **Component Gap L** — vertical space between stacked content blocks inside the card (e.g., body → CTAs).
+5. **Component Gap S** — tight space between a small heading and its supporting paragraph.
+
+The mobile variant of the same card shifts insets down a tier (XL → 20px, L → 20px) and replaces Structure XL's 32 with 24 — all driven by the same tokens, automatically.
+
+## Implementation in Figma
+
+### Responsive spacing
+
+Apply spacing tokens using Figma's **variable modes**. The token holds responsive values; switching modes refreshes everything bound to it.
+
+1. Find **Appearance** in the right panel.
+2. Click the component and select the variable mode (`lg` for desktop, `md` for tablet, `sm` for mobile).
+3. When switching a frame's tier, change the mode to match the breakpoint.
+4. Responsive tokens then update automatically.
+
+### Finding the right token
+
+Spacing tokens are organized by category in Figma's variable picker. Use the category to narrow results quickly.
+
+- Search keywords: `gap`, `inset`, `structure`.
+- Tokens are namespaced like `spacing/component/gap`, `spacing/component/inset`, `spacing/structure`.
+- If you're unsure which category fits, ask the "between or inside" question first.
+
+### Before handoff
+
+Check auto-layout properties on key frames. If you see a raw number instead of a variable name, **re-bind it from the library** — a raw value is a detached spacing decision that won't follow updates and gives developers nothing to map to.
+
+## Usage rules
+
+### Do
+
+- Pick the token by **category first**, then size.
+- Apply tokens via Figma variables (or, in code, via the Tailwind utility) — never as raw px in an inline style.
+- Let responsive tokens do the per-tier work; don't author one-off mobile values when an existing token already encodes the shift.
+- Re-use the same token for spaces that mean the same thing across screens, even when the surrounding components differ.
+
+### Don't
+
+- Don't substitute tokens across categories because the pixel value happens to match (`Inset M` ≠ `Gap M` even if both are 16px today).
+- Don't reach for a raw `tw-p-[18px]` or `gap: 18px` — if no token fits, that's a design-system conversation, not a one-off override.
+- Don't mix `Micro` with the other categories for hierarchy. Micro is for *coupling*, not separation.
+- Don't leave detached spacing values in Figma at handoff.
+
+### Need something not covered here?
+
+Open a request with the design system team. Include the use case, the component, and why the existing categories or tokens don't fit.
+
+## Using with Tailwind
+
+The spacing utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+
+The preset wires every value on [the raw spacing ramp](#the-raw-spacing-ramp) into the standard spacing utilities — `tw-p-*`, `tw-m-*`, `tw-gap-*`, `tw-space-*`, etc. all flow from the `space` scale. The thing to internalize: this is an **8px scale with 4px half-steps**, so the same number means a different size than stock Tailwind — `tw-p-4` is **32px** here, not 16px. See [tailwind → Spacing is an 8px scale](tailwind.md#spacing-is-an-8px-scale-with-4px-half-steps).
+
+Three key-naming conventions describe the same tokens — don't get tripped up:
+
+- **Tailwind classes** use dots: `tw-p-0.5`, `tw-p-1`, `tw-p-1.5`, `tw-p-2.5` (4px, 8px, 12px, 20px).
+- **`tokens/core/size.json`** (the authoritative source) uses underscores: `0_5`, `1`, `1_5`, `2_5`.
+- **Figma's variable picker** uses hyphens: `0-5`, `1`, `1-5`, `2-5`.
+
+The shipped code exposes this **raw numeric ramp**, not the semantic categories above — verify a value against `@kiva/kv-tokens/tokens/core/size.json` before depending on it. Express responsive shifts with breakpoint prefixes (`tw-p-2.5 md:tw-p-3 lg:tw-p-4`); note there is **no `sm` screen** — mobile is the unprefixed default.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Stock-Tailwind / non-Kiva project:** the ramp is plain px, so the values in [the raw spacing ramp](#the-raw-spacing-ramp) table can be applied as arbitrary values (`p-[20px]`) or used to define your own scale. These are point-in-time copies.
+
+## Outstanding discrepancies
+
+- **No shipped semantic spacing tokens.** `structure-xl`, `component-gap-l`, `component-inset-xl`, `micro`, etc. do not exist in code — the semantic layer lives only in Figma variables today. In code, express the intent by picking the matching ramp value (optionally with a comment or a thin component wrapper).
+- **No responsive spacing tokens.** Figma encodes per-tier shifts (e.g. `Inset XL` is `32 / 24 / 20`); the code does not. Today, responsive shifts must be done with Tailwind responsive prefixes.
+
+When you find a divergence between this skill and the shipped tokens, flag it — each is a data point for the design-system team.
+
+## Figma source references
+
+- Spacing Overview: node `17285:6968`
+- Spacing Scales & Tokens: node `17285:6976`
+- Spacing Guidelines: node `17285:6981`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/typography.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/typography.md
@@ -237,20 +237,20 @@ All tokens are published as text styles in the Kiva Ecosystem library.
 
 ## Using with Tailwind
 
-The typography utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+The typography utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
 
 Type styles ship as **semantic, whole-style utilities** (e.g. `tw-text-base`, `tw-text-headline`, `tw-text-caption`) — each bundles font-family, size, line-height, and letter-spacing together. Pick one from [How to apply type styles](#how-to-apply-type-styles) or the [HTML + Tailwind mapping](#heading-hierarchy--semantic-html-mapping) tables above; don't assemble a style from individual utilities.
 
 Two stock-Tailwind habits won't work here, by design:
 
-- **No `tw-text-lg` / `tw-text-2xl` / `tw-leading-*` / `tw-tracking-*`.** The preset disables the `fontSize`, `lineHeight`, and `letterSpacing` core plugins, so those utilities aren't generated — use a semantic text style instead. (`tw-text-{color}` like `tw-text-primary` still works; that's color, a separate concern.) See [tailwind → Text sizing utilities don't exist](tailwind.md#text-sizing-utilities-dont-exist--use-semantic-text-styles).
-- **No `tw-font-bold` / `tw-font-semibold`.** The heaviest weight is `medium` (500), and the base layer resets `strong` / `b` to normal (400). See [tailwind → Font weight tops out at `medium`](tailwind.md#font-weight-tops-out-at-medium-500).
+- **No `tw-text-lg` / `tw-text-2xl` / `tw-leading-*` / `tw-tracking-*`.** The preset disables the `fontSize`, `lineHeight`, and `letterSpacing` core plugins, so those utilities aren't generated — use a semantic text style instead. (`tw-text-{color}` like `tw-text-primary` still works; that's color, a separate concern.) See [tailwind → Text sizing utilities don't exist](../kiva-tailwind-css/SKILL.md#text-sizing-utilities-dont-exist--use-semantic-text-styles).
+- **No `tw-font-bold` / `tw-font-semibold`.** The heaviest weight is `medium` (500), and the base layer resets `strong` / `b` to normal (400). See [tailwind → Font weight tops out at `medium`](../kiva-tailwind-css/SKILL.md#font-weight-tops-out-at-medium-500).
 
 These utilities are defined in `@kiva/kv-tokens/configs/tailwind.config.js` (via `kivaTypography.js`) — verify a class name against the current config before depending on it.
 
 ### Without the preset
 
-- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](../kiva-tailwind-css/SKILL.md#consuming-the-preset).
 - **Stock-Tailwind / non-Kiva project:** the semantic `tw-text-*` styles won't exist. Replicate a style by reading its font-family, size, and line-height from the [type scale](#type-scale) and the mapping tables, and load the web fonts with the `@font-face` rules the package ships. Copied values are point-in-time.
 
 > The in-progress `<h1>`–`<h6>` / `tw-text-h1`–`tw-text-h6` semantic remap is tracked separately — see the `header-element-audit` skill before doing heading cleanup.

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/typography.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/typography.md
@@ -1,0 +1,265 @@
+---
+name: typography
+description: Semantic typography guidelines from the Kiva design system — type scale, heading hierarchy, font families, pairing rules, and HTML/Tailwind mappings. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing UI that involves text styling — choosing a heading level, applying a type token, picking a font family, building a section that pairs multiple type styles, or reasoning about typographic hierarchy. Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 30
+---
+
+# Kiva Typography
+
+## Source of truth
+
+This skill captures the **semantic typography system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which token exists, what it means, when to use it, and how styles pair together.
+
+Numeric values, token names, and Tailwind utility class names in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any class name or token reference against the current code before depending on it.**
+
+## How to apply type styles
+
+Always apply type styles by using the right **semantic HTML element** or by adding a **provided typography utility class**. Do not write custom CSS to set font family, size, weight, line height, or letter spacing for text. If no existing element default or class fits the use case, that is a signal to talk to the design system team — not to author bespoke styles.
+
+The typography utility classes shipped today (defined in `configs/tailwind.config.js`, served with the `tw-` prefix the project's Tailwind config applies to all classes):
+
+- `tw-text-base`
+- `tw-text-display`
+- `tw-text-headline`
+- `tw-text-headline-two`
+- `tw-text-subheadline`
+- `tw-text-title`
+- `tw-text-button-link`
+- `tw-text-upper`
+- `tw-text-caption`
+- `tw-text-label`
+- `tw-text-small`
+- `tw-text-link`
+- `tw-text-blockquote`
+
+## Design principles
+
+1. **Hierarchy first.** Kiva serves borrowers, lenders, and partners on the same page. Stick to the predefined scale to maintain visual balance and communicate an immediate reading order.
+2. **Simple semantics.** Semantic groupings tell teams how a style is *intended* to be used, while leaving room for context-specific decisions.
+
+A typography token is a complete unit — it bundles font family, size, weight, line height, and letter spacing. Apply tokens whole; do not override individual attributes.
+
+## Typefaces
+
+| Role | Family | Used for |
+|---|---|---|
+| Serif (brand) | **Dovetail MVB** | Display, Headline 1, Headline 2 — structural hierarchy that anchors a page |
+| Sans (product) | **Kiva Post Grotesk** | Subheadline, Title, Base, all utility styles — content, UI, long-form reading |
+
+**Fallbacks**
+
+| Primary | Fallback |
+|---|---|
+| Dovetail MVB | Georgia |
+| Kiva Post Grotesk | Arial |
+
+Fallbacks are tuned to closely match the metrics of the primary typefaces to minimize layout shift if brand fonts fail to load.
+
+## Type scale
+
+Each style is responsive across three device tiers: **Large** (desktop), **Medium** (tablet), **Small** (mobile). `Base` and the small-tier utility styles (Button, Label, Caption, Upper) are universal across all devices.
+
+### Display — `Dovetail MVB Medium`
+
+Expressive, large-scale text reserved for the single most important headline on a marketing page (homepage hero, campaign title). Limit to one per page; marketing pages only.
+
+| Tier | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Large (desktop) | 44px | 57px (1.3) | -0.88px (-0.02em) | Homepage hero, campaign hero |
+| Medium (tablet) | 40px | 52px (1.3) | -0.80px (-0.02em) | Same content, tablet |
+| Small (mobile) | 36px | 52px (1.3) | -0.72px (-0.02em) | Same content, mobile |
+
+### Headline 1 — `Dovetail MVB Medium`
+
+Primary section headers that establish top-level hierarchy within a page below the hero.
+
+| Tier | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Large | 26px | 36px (1.4) | -0.52px (-0.02em) | Section headers |
+| Medium | 22px | 31px (1.4) | -0.22px (-0.01em) | Section headers, tablet |
+| Small | 22px | 31px (1.4) | -0.22px (-0.01em) | Section headers, mobile |
+
+> **Why are Medium and Small identical?** At this level of hierarchy, further size reduction from tablet to mobile interferes with rather than improves readability.
+
+### Headline 2 — `Dovetail MVB Medium`
+
+Secondary headers that organize and support content within a section.
+
+| Tier | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Large | 22px | 31px (1.4) | -0.22px (-0.01em) | Category labels, subsection titles |
+| Medium | 20px | 26px (1.3) | -0.20px (-0.01em) | Same content, tablet |
+| Small | 20px | 26px (1.3) | -0.20px (-0.01em) | Same content, mobile |
+
+### Subheadline — `Kiva Post Grotesk Book`
+
+Supporting text that sits below a Headline to expand on it.
+
+| Tier | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Large | 20px | 26px (1.3) | 0 | Subheading below the headline |
+| Medium | 18px | 23px (1.3) | 0 | Same content, tablet |
+| Small | 18px | 23px (1.3) | 0 | Same content, mobile |
+
+### Title — `Kiva Post Grotesk Medium`
+
+Component-level headings used to label cards, modules, or distinct content blocks. Same size/line-height as Subheadline but **Medium weight** instead of Book — this is what distinguishes a component title from a supporting subheadline.
+
+| Tier | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Large | 20px | 26px (1.3) | 0 | Card headers, modal titles, list titles |
+| Medium | 18px | 23px (1.3) | 0 | Same content, tablet |
+| Small | 18px | 23px (1.3) | 0 | Same content, mobile |
+
+### Base — `Kiva Post Grotesk Book`
+
+Default body text for paragraphs and most reading content. **Universal across all devices.**
+
+| Token | Size | Line height | Letter spacing | Example use |
+|---|---|---|---|---|
+| Base | 16px | 22px (1.4) | 0 | Borrower stories, loan descriptions |
+
+### Utility / Small styles — `Kiva Post Grotesk`
+
+Functional UI text. Universal across all devices.
+
+| Token | Size | Weight | Line height | Letter spacing | Example use |
+|---|---|---|---|---|---|
+| Button | 16px | Medium | 21px (1.25) | 0 | CTA labels |
+| Label | 14px | Medium | 18px (1.25) | 0 | Form labels, filter names |
+| Caption | 14px | Book | 18px (1.25) | 0 | Disclaimers, captions |
+| Upper | 14px | Medium | 18px (1.25) | 0 | Tags, status badges (always UPPERCASE) |
+
+## Heading hierarchy & semantic HTML mapping
+
+The design system defines semantic type tokens for heading levels **h1 through h4 only**. Do not use `<h5>` or `<h6>`. For deeper content hierarchy, use a paragraph element with the appropriate type token (see "Going deeper than h4" below).
+
+### Default mapping (most contexts)
+
+| Style token | HTML element | Tailwind class | Mobile | Tablet | Desktop | Notes |
+|---|---|---|---|---|---|---|
+| Headline 1 | `<h1>` | `tw-text-headline` | 22px | 22px | 26px | Global h1 default via base CSS |
+| Headline 2 | `<h2>` | `tw-text-headline-two` | 20px | 20px | 22px | Global h2 default via base CSS |
+| Subheadline | `<h3>` | `tw-text-subheadline` | 18px | 18px | 20px | Global h3 default via base CSS |
+| Title | `<h4>` | `tw-text-title` | 18px | 18px | 20px | Global h4 default via base CSS |
+| Base / Body | `<p>`, `<body>` | `tw-text-base` | 16px | 16px | 16px | Global paragraph and body default |
+| Button | `<button>` | `tw-text-button-link` | 16px | 16px | 16px | Global button default; primary CTA labels |
+| Label | `<label>` | `tw-text-label` | 14px | 14px | 14px | Global label default |
+| Caption | `<figcaption>` | `tw-text-caption` | 14px | 14px | 14px | Use for disclaimers and captions |
+| Upper | — (utility only) | `tw-text-upper` | 14px | 14px | 14px | No element default; always UPPERCASE |
+| Small | `<small>` | `tw-text-small` | 14px | 14px | 14px | Supportive UI text |
+| Blockquote | `<blockquote>` | `tw-text-blockquote` | 20px | 20px | 22px | Italic Dovetail serif |
+| Link | `<a>` | `tw-text-link` | 16px | 16px | 16px | Underline + action color; inherits size from parent |
+
+### Going deeper than h4
+
+For content that needs sub-h4 hierarchy, do not reach for `<h5>`. Use a semantic text element with a type token instead:
+
+- "Small heading" feel → `<p>` + `tw-text-title` or `tw-text-label`
+- Supportive / metadata text → `<p>` or `<span>` + `tw-text-caption` or `tw-text-small`
+- Form field labels → `<label>` + `tw-text-label`
+
+### Contentful-specific shifted header mapping
+
+Marketing pages rendered through Contentful shift each heading element down one level so that `<h1>` can be reserved for the Display style on hero modules. Use this mapping only in the Contentful context; a CSS override is needed for it.
+
+| Style token | HTML element | Tailwind class | Mobile | Tablet | Desktop | Notes |
+|---|---|---|---|---|---|---|
+| Display | `<h1>` | `tw-text-display` | 36px | 40px | 44px | Marketing hero only; CSS override required |
+| Headline 1 | `<h2>` | `tw-text-headline` | 22px | 22px | 26px | |
+| Headline 2 | `<h3>` | `tw-text-headline-two` | 20px | 20px | 22px | |
+| Subheadline | `<h4>` | `tw-text-subheadline` | 18px | 18px | 20px | |
+| Title | `<h5>` | `tw-text-title` | 18px | 18px | 20px | Permitted only inside the Contentful shift |
+
+## Pairing guidelines
+
+The full marketing pairing pattern stacks five elements in this order:
+
+1. **Upper** — short eyebrow / category label above the headline
+2. **Display** — hero headline (one per page, marketing only)
+3. **Subheadline** — supporting paragraph that expands the headline
+4. **Button** — primary CTA
+5. **Caption** — supportive metadata, e.g., a contact prompt
+
+The standard in-page (non-hero) pairing pattern stacks:
+
+1. **Headline 1** — section header (with a paragraph of Subheadline beneath it)
+2. **Subheadline** — supporting paragraph
+3. **Headline 2** — subsection header (with a paragraph of Base beneath it)
+4. **Base** — body content
+5. **Title** — card/module heading (with a paragraph of Base beneath it)
+
+The semantic distinction worth remembering: **Subheadline** and **Title** share the same size at every tier — Subheadline (Book weight) describes/expands the thing above it, Title (Medium weight) names the thing it sits inside (a card, a modal, a module).
+
+## Best practices
+
+### Hierarchy and legibility
+
+- **Do** clearly differentiate heading sizes to create hierarchy. Use Base for long-form body paragraphs.
+- **Don't** make headings and body text look too similar. Don't use Caption or Label for long paragraphs.
+
+### All caps
+
+- **Do** use the Upper style for short, 1–3 word labels (tags, eyebrows, status badges).
+- **Don't** use all caps for full sentences or long paragraphs.
+
+## Usage rules
+
+### Do
+
+- Use the correct size tier (Large / Medium / Small) for the target device.
+- Respect the Dovetail MVB / Kiva Post Grotesk family boundary — serif for Display and Headlines, sans for everything else.
+- Limit Display to one per page, and only on marketing pages.
+- Default to Base for any paragraph content.
+
+### Don't
+
+- Override individual attributes of a token (size, weight, line height, letter spacing). Apply the token whole, or pick a different token.
+- Write custom CSS (or one-off Tailwind utility combinations like `tw-text-[18px] tw-font-medium tw-leading-[23px]`) to set type styles. Use a semantic HTML element or one of the provided typography utility classes.
+- Create new styles outside this system without design system team review.
+
+### Need something not covered here?
+
+Open a request with the design system team. Include the use case, the component, and why existing tokens don't work.
+
+## How to use in Figma
+
+All tokens are published as text styles in the Kiva Ecosystem library.
+
+- Match the size tier to your frame: Desktop frames get Large variants, Tablet frames get Medium, Mobile frames get Small. Utility styles and Base are universal.
+- A detached style breaks the connection to the library — the element stops receiving updates and becomes an undocumented variant.
+- Hover over a text style to see a description of where it's used.
+- Before handing off, inspect every text layer. If a layer shows raw values (e.g. "Dovetail / 26px / Medium") instead of a style name (e.g. "Headline 1 Large"), it's detached — reapply the matching style from the library.
+
+## Using with Tailwind
+
+The typography utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered it yet? See [tailwind → Consuming the preset](tailwind.md#consuming-the-preset). Not using the preset? See [Without the preset](#without-the-preset) below.
+
+Type styles ship as **semantic, whole-style utilities** (e.g. `tw-text-base`, `tw-text-headline`, `tw-text-caption`) — each bundles font-family, size, line-height, and letter-spacing together. Pick one from [How to apply type styles](#how-to-apply-type-styles) or the [HTML + Tailwind mapping](#heading-hierarchy--semantic-html-mapping) tables above; don't assemble a style from individual utilities.
+
+Two stock-Tailwind habits won't work here, by design:
+
+- **No `tw-text-lg` / `tw-text-2xl` / `tw-leading-*` / `tw-tracking-*`.** The preset disables the `fontSize`, `lineHeight`, and `letterSpacing` core plugins, so those utilities aren't generated — use a semantic text style instead. (`tw-text-{color}` like `tw-text-primary` still works; that's color, a separate concern.) See [tailwind → Text sizing utilities don't exist](tailwind.md#text-sizing-utilities-dont-exist--use-semantic-text-styles).
+- **No `tw-font-bold` / `tw-font-semibold`.** The heaviest weight is `medium` (500), and the base layer resets `strong` / `b` to normal (400). See [tailwind → Font weight tops out at `medium`](tailwind.md#font-weight-tops-out-at-medium-500).
+
+These utilities are defined in `@kiva/kv-tokens/configs/tailwind.config.js` (via `kivaTypography.js`) — verify a class name against the current config before depending on it.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — [tailwind → Consuming the preset](tailwind.md#consuming-the-preset).
+- **Stock-Tailwind / non-Kiva project:** the semantic `tw-text-*` styles won't exist. Replicate a style by reading its font-family, size, and line-height from the [type scale](#type-scale) and the mapping tables, and load the web fonts with the `@font-face` rules the package ships. Copied values are point-in-time.
+
+> The in-progress `<h1>`–`<h6>` / `tw-text-h1`–`tw-text-h6` semantic remap is tracked separately — see the `header-element-audit` skill before doing heading cleanup.
+
+## Figma source references
+
+- Typography Overview: node `17279:6062`
+- Type Scales & Tokens: node `17443:6589`
+- Typography Guidelines: node `17279:6478`
+- HTML + Tailwind Reference: node `19446:186`
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-header-element-audit/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-header-element-audit/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: header-element-audit
+description: Pre-emptive audit and cleanup of <h1>-<h6> elements and tw-text-h1-h6 utility classes in repos that consume @kiva/kv-tokens, ahead of the semantic typography remap. Produces an audit inventory and applies per-usage fixes one heading level at a time.
+when_to_use: When a Kiva repo (kv-ui-elements or any consumer) needs to be prepared for the upcoming kv-tokens semantic typography mapping and you want to minimize visual churn. Trigger phrases - "header audit", "header cleanup", "typography header migration", "pre-empt the type style update".
+---
+
+# Typography Header Cleanup
+
+## Purpose
+
+`@kiva/kv-tokens` is moving toward a new semantic typography system. The `<h1>`–`<h6>` element defaults and `tw-text-h1`–`tw-text-h6` utility classes will eventually be remapped onto the new semantic styles. The classes and elements stay in use; their visual output shifts.
+
+This skill audits every header usage in the target repo and applies pre-emptive per-usage fixes (element swap, class swap, both, or no-op) so the remap produces minimal visible churn.
+
+## Prerequisites
+
+- Confirm the consuming repo uses `@kiva/kv-tokens` and the `tw-` prefix.
+- Read the current `typography.md` skill in `kv-tokens` (`@kiva/kv-tokens/docs/skills/typography.md`) — it's the source of truth for the new mapping.
+- Identify which packages / source roots contain `.vue` (or `.tsx`/`.jsx` if extended later) component files in scope.
+- Have ripgrep installed.
+
+## Decision vocabulary
+
+- `keep` — accept the new mapped style, no change
+- `swap-class` — replace the `tw-text-hN` class with another typography utility
+- `swap-element` — change the HTML element only
+- `swap-both` — both element and class change
+- `defer` — flag for design-team review; not fixed in this pass
+
+## Phase 1 — Audit
+
+Run a single ripgrep pass across all in-scope packages. Match four surfaces (the fourth was added during real use):
+
+1. Header elements: `<h[1-6]\b` in `<template>`
+2. Header utility classes in template attributes: `tw-text-h[1-6]`
+3. `@apply tw-text-h[1-6]` declarations inside `<style>` / `<style scoped>` blocks
+4. **CSS selectors referencing the heading classes** inside `<style>` blocks (e.g. `.tw-text-h1 u { ... }`) — flag as `source: style-selector`
+
+### Glob set
+
+```
+--glob '**/*.vue'
+--glob '!**/stories/**'
+--glob '!**/.storybook/**'
+--glob '!**/*.stories.*'
+--glob '!**/tests/**'
+--glob '!**/*.spec.*'
+--glob '!**/dist/**'
+--glob '!**/build/**'
+--glob '!**/node_modules/**'
+```
+
+### Combined pattern
+
+```
+<h[1-6]\b|tw-text-h[1-6]|@apply\s+tw-text-h[1-6]
+```
+
+The element scan and class scan are usually best as separate `rg` runs to keep output legible:
+
+```bash
+# Element matches
+rg -n --no-heading <globs> '<h[1-6]\b' <source-roots>
+
+# Class matches (template + style-apply + style-selector all caught)
+rg -n --no-heading <globs> 'tw-text-h[1-6]' <source-roots>
+```
+
+Then disambiguate `template` vs `style-apply` vs `style-selector` by inspecting whether the match line is inside `<template>`, contains `@apply`, or appears as a CSS selector inside `<style>`.
+
+### Inventory schema
+
+Write a Markdown working doc (default `docs/header-cleanup-audit.md`) with a Summary table and one section per heading level. Row columns:
+
+| Column | Description |
+|---|---|
+| `package` | Package name |
+| `file` | Path relative to repo root |
+| `line` | Line number |
+| `level` | 1–6 |
+| `element` | `<hN>` if present, else blank |
+| `class` | `tw-text-hN` if present, else blank |
+| `source` | `template`, `style-apply`, `style-selector`, or `template+style-apply` |
+| `mismatch?` | `yes` if element# ≠ class# on the same opening tag |
+| `context` | Trimmed match line (peek next line if opening tag has no inner text) |
+| `decision` | Filled in Phase 2 |
+| `replacement` | Filled in Phase 2 |
+| `verified?` | Filled in Phase 2 |
+
+When an opening tag has both `<hN>` and `tw-text-hM`, emit **one** row at level = M (the class number). The element column shows the actual element; the mismatch flag is set when M ≠ N.
+
+After populating, spot-check 3 random rows against the source files before continuing.
+
+## Phase 2 — Per-level fix loop
+
+Run this six-step loop **once per level**, in order **H4 → H1 → H2 → H3 → H5 → H6**. H4 first because its rule is known (default class swap to `tw-text-upper`), which proves the loop and surfaces toolchain/test issues early.
+
+1. **Slice** — pull rows for level *N* into focus.
+2. **Discuss patterns** — codify candidate patterns with the operator before editing. Group rows by usage shape (e.g. "all country-name overlays," "all eyebrow labels," "all section headers").
+3. **Decide** — fill `decision` and `replacement` for every row.
+4. **Apply** — edit components grouped by file (smallest diff first); commit grouped by pattern.
+5. **Verify** — Storybook eyeball for visual surfaces; run lint + tests; record `verified?`.
+6. **Close out** — confirm every row has non-blank `decision`, `replacement` (where applicable), and `verified?`.
+
+## Per-level rubric (starting hypotheses)
+
+These are starting points. Refine against actual audit data per level.
+
+| Level | Today | New mapped style | Likely visual delta | Starting hypothesis |
+|---|---|---|---|---|
+| **H1** | Serif Medium, h1 scale, letter-spacing −0.5 | `textHeadline` — Serif Medium, semantic h1 scale, letter-spacing −200/−300 | Minor | Default `keep`. Inspect tight compositions for unwanted spacing shifts. |
+| **H2** | Serif Medium, h2 scale, letter-spacing normal→−0.3 | `textHeadlineTwo` — Serif Medium, semantic h2 scale, letter-spacing −200/−300 | Minor | Default `keep`. Watch for H2s used as eyebrows / small labels. |
+| **H3** | Sans Normal, letter-spacing −1, tight | `textSubheadline` — Sans Light, letter-spacing 0 | Notable: weight Normal → Light; tightening lost | Per-usage. Section sub-heading → likely `keep`; card/module title → likely `swap-class` to `tw-text-title`. |
+| **H4** | Sans Normal, **uppercase**, h4 scale | `textTitle` — Sans Normal, **not uppercase**, h3 scale | Major: loses uppercase, size grows | Default `swap-class` to `tw-text-upper`. Element case-by-case. |
+| **H5** | Sans Normal, h4.sm size | None (deprecated) | Unknown — depends on base CSS pruning | Default `swap-element` → `<p>` + `tw-text-title` / `tw-text-label` / `tw-text-upper`. |
+| **H6** | Not defined in kv-tokens | None (deprecated) | Already off-system | Default `swap-element` → `<p>` + a utility class chosen per usage. Treat as latent bug. |
+
+## Recurring patterns observed (from kv-ui-elements H4 sweep)
+
+These showed up as repeating shapes during the proving run. Worth checking for in any consumer repo.
+
+- **Country-name overlay on loan cards** — `<p>` (or `<div>`) inside an absolutely-positioned pill on top of an image, today using `tw-text-h4` for small uppercase. **Replacement:** `swap-class` → `tw-text-upper`. Element stays.
+- **Eyebrow / status / tag labels** — `<span>` with `tw-text-h4` near other UI. **Replacement:** `swap-class` → `tw-text-upper`. Element stays.
+- **Mismatched element/class headings** — `<hN class="tw-text-hM">` where N ≠ M. The class is what the consumer relied on visually. **Replacement:** swap the class to its new equivalent; element usually stays.
+- **Lowercase-overridden H4** — `<h4 class="tw-lowercase ...">` deliberately removes the H4 uppercase. After the remap H4 isn't uppercase anymore, so `tw-lowercase` becomes noise. **Replacement:** `swap-both` → `<p>` + `tw-text-label` (Medium 14px, no transform); drop `tw-lowercase`.
+- **Date / metadata heading inside a list** — `<h4>{{ date }}</h4>`. Not really structural; visually small uppercase. **Replacement:** `swap-both` → `<p>` + `tw-text-upper`.
+- **Chart axis label as `<h4>`** — semantically not a heading. **Replacement:** `swap-both` → `<p>` + `tw-text-upper`.
+- **Text-link styled as `tw-text-h4`** — small uppercase link. **Replacement:** `swap-class` → `tw-text-upper`. Component element stays.
+- **`@apply tw-text-h4` overriding third-party iframe styles** (e.g. Braintree) — pre-empt the look-shift. **Replacement:** swap the `@apply` token to `tw-text-upper`.
+
+## Edge cases
+
+- **Mismatched element/class pair** (`<h2 class="tw-text-h4">`): decide based on the **class** — that's what the consumer was relying on visually.
+- **Class on a non-heading element** (`<span class="tw-text-h4">`): class is the source of truth; element stays unless structurally wrong.
+- **`@apply tw-text-hN` in a `<style>` block**: same per-class decision applies, but the swap is made in the style block (`@apply tw-text-upper`), not on the template element.
+- **CSS selectors referencing heading classes** (`.tw-text-h1 u { ... }`): usually safe to `keep` — the rules continue to apply to whatever the new mapped style produces. Worth a quick visual check (e.g. underline color/style) but rarely actionable.
+- **`<h6>` and `tw-text-h6`**: in `kv-tokens` today, `tw-text-h6` is not defined (silent no-op) and `<h6>` has no token-driven base style. Both are off-system — treat as latent bugs to clean up regardless of the remap.
+- **Heading inside a slot consumed by another component**: flag for slot-consumer review; may need `defer`.
+
+## Element-swap rules (apply every time)
+
+When swapping an HTML element (e.g. `<h4>` → `<p>`):
+
+1. Copy ALL attributes onto the new element verbatim — `class`, `:class`, `id`, ARIA attributes (`aria-labelledby`, `aria-describedby`, etc.), `ref`, event handlers (`@click`, etc.), `data-*`, conditional directives (`v-if`, `v-show`).
+2. If the original element had an `id` referenced elsewhere via `aria-labelledby`, the replacement element still needs that `id`.
+3. Update the matching closing tag (`</h4>` → `</p>`).
+4. Search the test suite for assertions targeting the old element selector (e.g. `querySelectorAll('h4')`) and update them — element swaps will break tests that assert on tag names.
+
+## Class-swap rules (apply every time)
+
+1. Preserve all other classes in their original order.
+2. Don't reorder unrelated classes.
+3. When the original tag had both `<hN>` and `tw-text-hN` (redundant), removing the class on element-swap to `<p>` requires picking the right replacement class — don't leave the `<p>` typography-naked unless that's intended.
+4. For `@apply` swaps in `<style>` blocks: replace only the matched `tw-text-hN` token. Do not change the selector or other declarations in the rule.
+
+## Verification
+
+- **Lint** (per-package, using the repo's eslintrc): run on every modified file.
+- **Unit tests** (per-package): run after edits. Element swaps frequently break selector-based assertions — update the test, don't accept the regression.
+- **Storybook**: eyeball for components with stories. Compare before/after for the H4 patterns where the visual delta is biggest (loss of uppercase).
+- For utility/non-visual packages, verification happens transitively when re-rendering through a consumer.
+- No-visual-surface escape hatch: mark `verified?` as `n/a — no local visual surface` with a one-line reason. Should be rare.
+
+## Definition of done
+
+- Every inventory row has a non-blank `decision`.
+- Every `swap-*` row has a non-blank `replacement`.
+- Every modified component has been visually verified or explicitly marked `n/a`.
+- All H6 rows resolved (latent bugs cleaned up regardless of remap status).
+- Re-running the master `rg` pattern shows only `decision: keep` rows remaining.
+- Code changes per heading level are committed in level-scoped chunks (or one bundled PR if the operator explicitly prefers that).
+
+## Anti-patterns
+
+- Do **not** edit `kv-tokens` (primitives, configs, classes) as part of this work.
+- Do **not** rename or remove `tw-text-hN` classes.
+- Do **not** fix non-header typography drift while in the codebase for this work.
+- Do **not** apply a uniform per-level rubric in place of per-usage discussion. Patterns emerge from the audit; impose them after seeing the slice, not before.
+- Do **not** bundle all six heading levels into a single commit — chunking by level is what makes review tractable.
+- Do **not** auto-commit. The operator decides commit boundaries; pause for confirmation.

--- a/@kiva/kv-skills/design-system/skills/kiva-header-element-audit/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-header-element-audit/SKILL.md
@@ -15,7 +15,7 @@ This skill audits every header usage in the target repo and applies pre-emptive 
 ## Prerequisites
 
 - Confirm the consuming repo uses `@kiva/kv-tokens` and the `tw-` prefix.
-- Read the current `typography.md` skill in `kv-tokens` (`@kiva/kv-tokens/docs/skills/typography.md`) — it's the source of truth for the new mapping.
+- Read the current `typography.md` skill in `kv-tokens` (`@kiva/kv-skills/design-system/skills/kiva-design-system/typography.md`) — it's the source of truth for the new mapping.
 - Identify which packages / source roots contain `.vue` (or `.tsx`/`.jsx` if extended later) component files in scope.
 - Have ripgrep installed.
 

--- a/@kiva/kv-skills/design-system/skills/kiva-tailwind-css/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-tailwind-css/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: tailwind
+description: How to use Tailwind CSS v3 when it is backed by Kiva's design tokens — what the @kiva/kv-tokens preset changes about stock Tailwind (the tw- prefix, themable colors compiled to CSS custom properties, disabled core plugins, token-driven scales, an opinionated base layer), how to wire the preset into a project, and how the preset is compiled from DTCG tokens. Mechanical and integration-focused; for which token to pick, defer to the per-topic skills (color, spacing, radius, typography, layout).
+when_to_use: When authoring or reviewing Tailwind utility classes in any repo that uses the Kiva preset (kv-components, kiva/ui, and other consumers), when setting up the preset in a new project, when a Tailwind class behaves differently than stock Tailwind would suggest (e.g. tw-text-lg or tw-font-bold "not working"), or when modifying the design-token → Tailwind pipeline inside this monorepo. Read this for how the system works and how to use it; read color/spacing/radius/typography/layout for which value to choose.
+make_kit:
+  include: true
+  category: foundations
+  order: 10
+---
+
+# Kiva Tailwind
+
+## Source of truth
+
+The canonical definition of Kiva's Tailwind setup is the **preset itself** — [`@kiva/kv-tokens/configs/tailwind.config.js`](../../configs/tailwind.config.js) — and the design tokens it compiles from. Unlike the design-intent skills (color, spacing, etc.), which describe Figma intent that code may temporarily lag, this skill describes **shipped mechanics**: how the preset reshapes Tailwind and how to author against it.
+
+This skill deliberately **does not enumerate class values**. Exact scales drift as tokens change, and listing them here would duplicate the per-topic skills and the config. For specific values, read the config or the relevant skill:
+
+- **[color](color.md)** / **[color-themes](color-themes.md)** — which color token, what the themes are.
+- **[spacing](spacing.md)** — which spacing token for a given relationship.
+- **[radius](radius.md)** — which corner radius per component.
+- **[typography](typography.md)** — which text style, the type scale.
+- **[layout](layout.md)** — the breakpoint/grid system and content placement.
+
+Verify any specific class or value against the current config before depending on it.
+
+## What the preset is (mental model)
+
+Kiva does not ship a stylesheet you import — it ships a **Tailwind preset**: a partial `tailwind.config.js` that a consuming project merges into its own config via the `presets` array. Tailwind then generates utility classes from the merged result.
+
+The preset is itself generated from design tokens. The full path a value travels:
+
+```
+tokens/*.json (DTCG)  →  Style Dictionary build  →  dist/js/tokens.js
+        │                                                   │
+        │                                                   ▼
+        │                              configs/tailwind.config.js  (the preset)
+        │                                                   │
+        └──────────────► dist/css/tokens.css                ▼
+            (themed CSS custom properties)     your project's tailwind.config.js
+                                                  (presets: [tailwindConfig])
+                                                            │
+                                                            ▼
+                                                  generated tw-* utilities
+```
+
+Two consequences worth internalizing up front:
+
+1. **You author Tailwind utilities as normal** — the preset changes *which* utilities exist and what they resolve to, not *how* Tailwind works.
+2. **Themable colors are not baked into the CSS at build time.** They compile to `var(--token)` references and are resolved at runtime from CSS custom properties (see [Color](#color-is-semantic-themable-and-runtime-resolved) below). This is the single biggest departure from stock Tailwind.
+
+## Consuming the preset
+
+This is the common case: a project that installs `@kiva/kv-tokens` and wants Kiva styling.
+
+### 1. Install
+
+```sh
+npm i --save-dev @kiva/kv-tokens
+```
+
+### 2. Register the preset
+
+```js
+// tailwind.config.js
+import { tailwindConfig } from '@kiva/kv-tokens';
+
+export default {
+	presets: [tailwindConfig],
+	content: [
+		// YOUR project's template globs — the preset does not set these for you
+		'./src/**/*.{vue,js,ts}',
+	],
+};
+```
+
+Two equivalent import paths exist:
+
+- `import { tailwindConfig } from '@kiva/kv-tokens'` — named export from the package index.
+- `import tailwindConfig from '@kiva/kv-tokens/tailwind'` — the config file directly, via the `./tailwind` export.
+
+Use either. **You own `content`** — Tailwind purges any class it can't find in your templates, so an incomplete `content` glob is the most common reason a Kiva class "doesn't show up."
+
+### 3. Make themable colors resolve (required for color to render)
+
+Themable color utilities (`tw-bg-primary`, `tw-text-primary`, …) emit `rgb(var(--bg-primary))`-style values. Those custom properties must exist on the page. The preset already injects the **default theme** onto `:root` via its base layer, so a project that registers the preset gets working colors out of the box.
+
+To switch themes, swap the custom-property values for a subtree. In `@kiva/kv-components` this is done by `KvThemeProvider`; at the token layer, `@kiva/kv-tokens/css` ([`dist/css/tokens.css`](../../dist/css/tokens.css)) ships a `:root` block plus `[data-theme="…"]` blocks you can apply directly. See [color](color.md) for the theme catalog.
+
+### 4. Safelist dynamically generated classes (only if you need it)
+
+Tailwind only emits classes it can statically find in `content`. If you generate class names at runtime (e.g. a styleguide that renders every color name), build a `safelist`. `@kiva/kv-components` does this by resolving the preset and enumerating theme keys:
+
+```js
+import resolveConfig from 'tailwindcss/resolveConfig';
+import { tailwindConfig as sharedConfig } from '@kiva/kv-tokens';
+
+const { theme } = resolveConfig(sharedConfig);
+// …walk theme.backgroundColor, theme.spacing, etc. to build a safelist array
+```
+
+Most projects do **not** need this — reach for it only when class names aren't present as literal strings in your source.
+
+## Authoring with the Kiva preset
+
+This section is the heart of the skill: how stock Tailwind v3 knowledge changes once the preset is in place. Each item is a rule, the reason, and what to do instead.
+
+### Every utility carries the `tw-` prefix
+
+The preset sets `prefix: 'tw-'`. Every generated class is prefixed: `tw-flex`, `tw-mb-2`, `tw-bg-primary`.
+
+- The prefix sits **after** any variant: `hover:tw-bg-primary`, `md:tw-flex`, `dark:tw-text-primary` — not `tw-hover:...`.
+- It sits **after** a negative sign: `-tw-mt-2`.
+- Arbitrary values keep the prefix: `tw-mt-[3px]`.
+
+If a class isn't taking effect, the missing `tw-` is the first thing to check. When porting markup from a stock-Tailwind project, every utility needs the prefix added.
+
+### Color is semantic, themable, and runtime-resolved
+
+The preset replaces Tailwind's default color palette. There are two families:
+
+- **Themable (semantic) colors** — role-based names like `primary`, `secondary`, `action`, etc., available on text, background, border, ring, divide, placeholder, and gradient-stop utilities: `tw-text-primary`, `tw-bg-secondary`, `tw-border-primary`. These compile to `rgb(var(--…))` and change with the active theme. **This is what you should reach for by default.**
+- **Static colors** — fixed palettes that do *not* change with theme: `brand`, `eco-green`, `marigold`, `desert-rose`, `stone`, `gray`, `social`, plus `black` / `white` / `transparent` / `current`. Use these only when a color must stay constant regardless of theme.
+
+Opacity modifiers work on both: `tw-bg-primary/50` resolves to `rgba(var(--bg-primary), 0.5)`. Do **not** assume stock Tailwind color names exist — `tw-bg-gray-500` works (gray is a static palette) but `tw-bg-slate-500`, `tw-text-red-600`, etc. do not. For *which* token, see **[color](color.md)**.
+
+### Spacing is an 8px scale with 4px half-steps
+
+The spacing scale is token-driven: each whole step is **8px** (`tw-p-1` = 8px, `tw-m-2` = 16px), with `.5` half-steps at **4px** granularity (`tw-p-0.5` = 4px, `tw-gap-1.5` = 12px), running up to `16` (128px). This differs from stock Tailwind's 4px-per-step scale, so the *same number means a different size* — `tw-p-4` is 32px here, not 16px. Apply a scale token, never a raw pixel value; see **[spacing](spacing.md)**.
+
+### Text sizing utilities don't exist — use semantic text styles
+
+The preset **disables the `fontSize`, `lineHeight`, and `letterSpacing` core plugins.** That means these stock utilities are **not generated**:
+
+- No `tw-text-xs` / `tw-text-lg` / `tw-text-2xl` (font-size scale)
+- No `tw-leading-*` (line-height)
+- No `tw-tracking-*` (letter-spacing)
+
+Size, line-height, and letter-spacing are bundled into **semantic text-style utilities** instead — `tw-text-h1`, `tw-text-body`, `tw-text-caption`, and the 2026 styles (`tw-text-display`, `tw-text-headline`, `tw-text-title`, …). Note `tw-text-{color}` still works (color is a separate concern); only the *sizing* `tw-text-*` utilities are gone. So `tw-text-primary` (color) is valid; `tw-text-lg` (size) is not. Reach for a semantic style; see **[typography](typography.md)**.
+
+### Font weight tops out at `medium` (500)
+
+Available weights are `light` (300), `normal` (400), and `medium` (500) — plus `book` as a legacy alias for 300. There is **no `tw-font-bold`** (700) or `tw-font-semibold`. Additionally, the base layer sets `strong` / `b` to normal weight (400), so bolding text requires an explicit weight utility and the design system's heaviest weight is `medium`.
+
+### Border-radius is token-driven and `tw-rounded` ≠ pill
+
+`tw-rounded` (the unsuffixed utility) resolves to **16px**, not a small radius, and `tw-rounded-full` is the pill/circle. This is a frequent porting bug from stock Tailwind. See **[radius](radius.md)** for the full scale and the concentric-corner rules.
+
+### Breakpoints are `md` / `lg` / `xl` (mobile-first, no `sm`)
+
+The preset defines only three min-width screens — `md`, `lg`, `xl` — plus a `print` screen. There is **no `sm:` and no `2xl:`**. Unprefixed utilities are the mobile/base tier; the design system's smaller tiers (XS, SM in the layout skill) both fall under "no prefix" in Tailwind. Use `print:` to target print styles. For the grid and tier semantics, see **[layout](layout.md)**.
+
+### Z-index, shadow, and opacity are small named scales
+
+- **z-index** uses semantic names (`tw-z-modal`, `tw-z-dropdown`, `tw-z-sticky`, `tw-z-toast`, …) rather than `tw-z-10` / `tw-z-50`. Pick by role.
+- **box-shadow** ships only `tw-shadow` (default) and `tw-shadow-lg`. There is no `tw-shadow-md` / `tw-shadow-xl` scale.
+- **opacity** utilities are limited (`tw-opacity-0`, `tw-opacity-10`, `tw-opacity-low`, `tw-opacity-full`) — the full `0–100` scale is not generated. (Color opacity *modifiers* like `tw-bg-primary/50` are unaffected and work normally.)
+
+### The base layer styles bare HTML
+
+The preset's plugin injects global element styles via `addBase`: web fonts, `body` typography and color, `h1`–`h5`, `small`, `code`, `blockquote`, links (`a`), `hr`, and input placeholders, plus a button focus reset. Two implications:
+
+- Bare semantic HTML is already styled — don't re-apply utilities to recreate what the base layer provides.
+- `h6` is **not** styled by the base layer, and `strong`/`b` are set to normal (400) weight. Don't assume browser defaults for those.
+
+The `@tailwindcss/typography` plugin is included with Kiva overrides, so `tw-prose` is available for long-form rich text.
+
+### Escape hatches
+
+When no token fits, Tailwind's arbitrary-value syntax still works with the prefix (`tw-mt-[7px]`, `tw-bg-[#123456]`). Treat this as a last resort and a signal: a recurring need for an off-scale value is a design-system conversation, not a one-off. Prefer a token every time one exists.
+
+## How the preset is compiled
+
+Read this section when working **inside this monorepo** to change a value or understand where one comes from.
+
+### Token authoring
+
+Tokens are authored as [W3C DTCG](https://design-tokens.github.io/community-group/format/) JSON under [`tokens/`](../../tokens/):
+
+- [`tokens/core/`](../../tokens/core/) — primitives (color, size/space/radius/border-width, typography, z-index, opacity).
+- [`tokens/semantic/themes/`](../../tokens/semantic/themes/) — per-theme semantic tokens that reference primitives.
+
+### Build pipeline
+
+`npm run build` (also run automatically by the `prepare` lifecycle hook on install) does three things:
+
+1. **Style Dictionary** ([`build/style-dictionary.config.js`](../../build/style-dictionary.config.js)) emits `dist/js/tokens.js` (flat named exports **and** a nested default export), `dist/css/tokens.css` (themed CSS custom properties as `R, G, B` triples so opacity composes), and `dist/scss/tokens.scss`.
+2. **`build/build-dtcg.js`** deep-merges all source files into the single manifest `dist/dtcg/tokens.json`.
+3. **`build/build.js`** copies fonts and emits the heading-underline SVG sprite.
+
+`dist/` is gitignored but regenerated by `prepare`, so a fresh `npm install` leaves it ready for workspace consumers like `@kiva/kv-components`.
+
+### How the config assembles the theme
+
+[`configs/tailwind.config.js`](../../configs/tailwind.config.js) imports the generated `dist/js/tokens.js` plus two helper modules and builds the Tailwind `theme`:
+
+- **[`configs/kivaColors.js`](../../configs/kivaColors.js)** — `buildColorChoices(category)` maps each semantic token name to a `withOpacity('--token')` function so utilities emit `rgb(var(--token))` / `rgba(var(--token), <opacity>)`. It also exports per-theme objects (`defaultTheme`, `greenLightTheme`, …) that are sets of CSS custom properties.
+- **[`configs/kivaTypography.js`](../../configs/kivaTypography.js)** — text styles, web-font `@font-face` rules, and prose overrides.
+
+The config then:
+
+- Sets `prefix`, `screens`, `spacing`, `borderRadius`, `fontFamily`, `fontWeight`, `borderWidth`, `opacity`, `zIndex`, `boxShadow`, and static `colors` directly from token values.
+- Disables `container`, `fontSize`, `letterSpacing`, and `lineHeight` core plugins.
+- In `theme.extend`, wires themable color categories (`textColor`, `backgroundColor`, `borderColor`, …) to `buildColorChoices` output.
+- Registers a custom plugin that: `addBase` for element styles and web fonts, injects `:root` = `defaultTheme` custom properties, and `addUtilities` for the semantic text styles (which inherit the `tw-` prefix → `tw-text-h1`, etc.).
+
+### Changing a value safely
+
+- **To change a token value** (a color, a spacing step, a radius), edit the relevant file under `tokens/`, then run `npm run build` to regenerate `dist/`. Do **not** hand-edit `dist/` — it is generated.
+- **To change Tailwind structure** (add a utility category, adjust a base style, enable a core plugin), edit `configs/tailwind.config.js` directly.
+- After either change, rebuild and verify against a consumer (e.g. run Storybook in `@kiva/kv-components`).
+- Package exports (which subpath resolves to what) are documented in the [README](../../README.md#package-exports).
+
+## Common mistakes
+
+- Forgetting the **`tw-` prefix** on a utility (or writing `tw-hover:` instead of `hover:tw-`).
+- Using **stock Tailwind color names** (`tw-bg-slate-500`, `tw-text-red-600`) that the preset doesn't define.
+- Reaching for **`tw-text-lg` / `tw-leading-*` / `tw-tracking-*`** — disabled; use semantic text styles.
+- Expecting **`tw-font-bold`** — the heaviest weight is `medium` (500).
+- Treating **`tw-rounded`** as a small radius — it's 16px; use `tw-rounded-full` for pills.
+- Assuming a **`sm:`** breakpoint or the full **opacity / shadow / z-index** numeric scales exist.
+- Using **raw pixel values** instead of scale tokens; or assuming a spacing number matches stock Tailwind (`tw-p-4` is 32px here).
+- An incomplete **`content`** glob (or missing `safelist` for runtime-generated classes), so Tailwind purges classes you expected.
+- Hand-editing **`dist/`** instead of editing `tokens/` and rebuilding.
+
+## Current code state (verify before depending)
+
+This skill describes shipped mechanics, but specifics still change as tokens and the config evolve. Before relying on an exact class or value:
+
+- **The preset is authoritative:** [`configs/tailwind.config.js`](../../configs/tailwind.config.js) defines exactly which utilities exist and what they resolve to. The token values feeding it live in [`tokens/`](../../tokens/) and the generated [`dist/js/tokens.js`](../../dist/js/tokens.js).
+- **Disabled core plugins** (`container`, `fontSize`, `letterSpacing`, `lineHeight`) are the source of the "missing utility" surprises above — confirm the list in the config if a utility you expect is absent.
+- **Semantic color and text-style names** are the categories most likely to gain or rename entries over time; treat [color](color.md) and [typography](typography.md) as companions and cross-check the config.
+
+When you find a divergence between this skill and the shipped preset, flag it — each instance is a data point for the design-system team.

--- a/@kiva/kv-skills/package.json
+++ b/@kiva/kv-skills/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@kiva/kv-skills",
+  "version": "0.1.0",
+  "description": "Kiva agent skills (Claude Code + Codex), organized as installable plugin categories. v1 ships the design-system category.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "*/skills/",
+    "*/README.md"
+  ],
+  "keywords": ["kiva", "design-system", "agent-skills", "claude", "codex", "tailwind", "figma"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kiva/kv-ui-elements.git",
+    "directory": "@kiva/kv-skills"
+  },
+  "license": "ISC"
+}

--- a/@kiva/kv-skills/package.json
+++ b/@kiva/kv-skills/package.json
@@ -6,8 +6,9 @@
     "access": "public"
   },
   "files": [
-    "*/skills/",
-    "*/README.md"
+    "*/skills/**",
+    "*/README.md",
+    "README.md"
   ],
   "keywords": ["kiva", "design-system", "agent-skills", "claude", "codex", "tailwind", "figma"],
   "repository": {

--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ npm unlink --no-save @kiva/kv-shop
 The Kiva UI project is bound by a [Code of Conduct](https://github.com/kiva/ui/blob/master/code_of_conduct.md).
 
 Kiva welcomes outside contributions to our UI repository. If you have any ideas for a feature or improvement, create an issue and we can discuss whether it makes sense to create a pull request. Thanks for the help!
+
+## Agent Skills
+
+This repo doubles as a public Claude Code and Codex plugin marketplace for
+Kiva's [Agent Skills](https://agentskills.io), organized as installable plugin
+categories under [`@kiva/kv-skills`](./@kiva/kv-skills). See
+[`SKILLS.md`](./SKILLS.md) for the full install matrix and contribution guide.
+
+```bash
+# Claude Code
+/plugin marketplace add kiva/kv-ui-elements
+
+# Codex
+codex plugin marketplace add kiva/kv-ui-elements
+```

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,93 @@
+# Kiva Agent Skills (public)
+
+Public [Agent Skills](https://agentskills.io) for Kiva, shipped from this repo as
+installable plugin categories. Usable in Claude Code, Codex, and — by download —
+on claude.ai / the web. No GitHub org membership required.
+
+Canonical source: [`@kiva/kv-skills/`](./@kiva/kv-skills). v1 ships one category,
+the `kiva-design-system` plugin.
+
+## Install
+
+| Audience | How |
+|----------|-----|
+| **Claude Code CLI** | `/plugin marketplace add kiva/kv-ui-elements` then `/plugin install kiva-design-system@kv-ui-elements`. No clone needed. |
+| **Codex CLI** | `codex plugin marketplace add kiva/kv-ui-elements`, then open `codex`, run `/plugins`, and install **Kiva Design System**. Restart Codex after installing. No clone needed. |
+| **claude.ai / web (no CLI)** | On GitHub, use **Code → Download ZIP** (or clone). Open `@kiva/kv-skills/design-system/skills/`, pick the skill folder you want, and upload it to a Project / Capability. |
+
+### Claude Code
+
+```bash
+# Add the marketplace directly from GitHub (no clone required)
+/plugin marketplace add kiva/kv-ui-elements
+
+# Browse and install from the interactive UI
+/plugin
+
+# Or install directly
+/plugin install kiva-design-system@kv-ui-elements
+```
+
+Installing a plugin gives you all skills in that category. You cannot install
+individual skills via Claude Code's plugin system.
+
+### Codex
+
+```bash
+# Add the marketplace directly from GitHub (no clone required)
+codex plugin marketplace add kiva/kv-ui-elements
+
+# Then open Codex and browse plugins
+codex
+/plugins
+```
+
+Install **Kiva Design System** from the `Kiva UI Elements` marketplace, then
+restart Codex (or reload the session) so it picks up the updated plugin cache.
+
+### claude.ai / web
+
+1. On <https://github.com/kiva/kv-ui-elements>, click **Code → Download ZIP** (or clone the repo).
+2. Open `@kiva/kv-skills/design-system/skills/` and choose the skill folder you
+   need (e.g. `kiva-design-system`).
+3. Upload that folder to your claude.ai Project or Capability per the
+   [claude.ai skills docs](https://support.anthropic.com/).
+
+## Plugin categories
+
+| Category (folder) | Plugin | Skills |
+|---|---|---|
+| `@kiva/kv-skills/design-system` | `kiva-design-system` | `kiva-design-system` (router + color, typography, spacing, radius, layout, color-themes), `kiva-tailwind-css`, `kiva-header-element-audit`, `figma-design-system-to-skill` |
+
+## Adding a skill (to an existing category)
+
+1. Create a branch: `feat/add-{skill-name}`.
+2. Add or edit the skill under
+   `@kiva/kv-skills/<category>/skills/<skill-name>/` with a `SKILL.md` that has
+   valid YAML frontmatter (`name`, `description`; optionally `when_to_use`,
+   `allowed-tools`).
+3. Bump the `version` in **both**
+   `@kiva/kv-skills/<category>/.claude-plugin/plugin.json` and
+   `@kiva/kv-skills/<category>/.codex-plugin/plugin.json`.
+4. Open a PR.
+
+## Adding a plugin (a new category)
+
+Categories are how new plugins are added (Model A — one package, many plugins):
+
+1. Create a branch: `feat/add-{category}-plugin`.
+2. Create `@kiva/kv-skills/<category>/` containing:
+   - `.claude-plugin/plugin.json` (`name: "kiva-<category>"`, `version`, `description`, `keywords`)
+   - `.codex-plugin/plugin.json` (mirror + `"skills": "./skills/"` + an `interface` block)
+   - `README.md` (category overview + install one-liners)
+   - `skills/<skill-name>/SKILL.md` (one or more skills)
+3. Register the plugin in **both** root marketplace files:
+   - `.claude-plugin/marketplace.json` — add
+     `{ "name": "kiva-<category>", "source": "./@kiva/kv-skills/<category>" }`
+   - `.agents/plugins/marketplace.json` — add
+     `{ "name": "kiva-<category>", "source": { "source": "local", "path": "./@kiva/kv-skills/<category>" }, "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" }, "category": "Development" }`
+4. Open a PR. Users install it with `/plugin install kiva-<category>@kv-ui-elements`
+   (Claude) or via `/plugins` (Codex).
+
+Keep each `SKILL.md` under ~500 lines; put longer material in sibling files and
+reference them. Skills follow the [Agent Skills open standard](https://agentskills.io).


### PR DESCRIPTION
Initial setup of a publicly accessible plugin marketplace for kiva skills related to our design system and global style and component packages.

This setup shoud allow others to install these skills without having to pull down or install the repo. If needed we could quickly add configuration to publish this new package to npm as well.

Noting the actual "skills" are the same as the ones that currenty live in the kv-tokens/docs/skills folder but they've been renamed and placed into named folders to be compatible with the actual plugin and skill setup for claude/codex. We'll be able to remove the files from kv-tokens when this approach is finalized.

_Generated in concert with Claude, based on our private skills repo._