### PR TITLE
feat: map header element + classes to new semantic type styles in kiv…

### DIFF
--- a/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCardFrame.stories.js
@@ -440,7 +440,7 @@ export const ThemeComparison = {
 				<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-6">
 					<kv-card-frame theme="default">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2">Default Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2">Default Theme</h4>
 							<p class="tw-text-small tw-mb-3">Standard theme for general use.</p>
 							<kv-button variant="primary" size="small">Learn More</kv-button>
 						</div>
@@ -448,7 +448,7 @@ export const ThemeComparison = {
 
 					<kv-card-frame theme="greenLight">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2">Green Light Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2">Green Light Theme</h4>
 							<p class="tw-text-small tw-mb-3">For positive actions or confirmations.</p>
 							<kv-button variant="primary" size="small">Confirm</kv-button>
 						</div>
@@ -456,7 +456,7 @@ export const ThemeComparison = {
 
 					<kv-card-frame theme="greenDark">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2 tw-text-primary">Green Dark Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2 tw-text-primary">Green Dark Theme</h4>
 							<p class="tw-text-small tw-mb-3 tw-text-primary">Dark variant with light text.</p>
 							<kv-button variant="primary" size="small">Continue</kv-button>
 						</div>
@@ -464,7 +464,7 @@ export const ThemeComparison = {
 
 					<kv-card-frame theme="marigoldLight">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2">Marigold Light Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2">Marigold Light Theme</h4>
 							<p class="tw-text-small tw-mb-3">For attention or highlights.</p>
 							<kv-button variant="primary" size="small">View Details</kv-button>
 						</div>
@@ -472,7 +472,7 @@ export const ThemeComparison = {
 
 					<kv-card-frame theme="stoneLight">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2">Stone Light Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2">Stone Light Theme</h4>
 							<p class="tw-text-small tw-mb-3">Neutral theme for secondary content.</p>
 							<kv-button variant="secondary" size="small">More Info</kv-button>
 						</div>
@@ -480,7 +480,7 @@ export const ThemeComparison = {
 
 					<kv-card-frame theme="stoneDark">
 						<div class="tw-p-4">
-							<h4 class="tw-mb-2 tw-text-primary">Stone Dark Theme</h4>
+							<h4 class="tw-text-upper tw-mb-2 tw-text-primary">Stone Dark Theme</h4>
 							<p class="tw-text-small tw-mb-3 tw-text-primary">Dark neutral variant.</p>
 							<kv-button variant="primary" size="small">Explore</kv-button>
 						</div>

--- a/@kiva/kv-components/src/vue/stories/KvCarousel.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCarousel.stories.js
@@ -38,7 +38,7 @@ const generateLoanCardTemplate = (index) => {
 		<div style="width: 336px">
 			<img src="https://placehold.co/336x252/${randomHexColor(index)}/000000" class="tw-w-full tw-rounded tw-mb-2">
 			<h3>Card Title</h3>
-			<h4 class="tw-my-1">$${amounts?.[index] || amounts?.[1]} to go</h4>
+			<h4 class="tw-text-upper tw-my-1">$${amounts?.[index] || amounts?.[1]} to go</h4>
 			<p class="tw-mt-1 tw-mb-9">${cardCopy?.[index] || cardCopy?.[1]}</p>
 			<kv-button
 				variant="primary"

--- a/@kiva/kv-components/src/vue/stories/KvChip.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvChip.stories.js
@@ -37,7 +37,7 @@ export const EmailAddress = (args, { argTypes }) => ({
 	template: `
 			<kv-chip
 			>
-			<h4> @BankofAmerica.com </h4>
+			<h4 class="tw-text-upper"> @BankofAmerica.com </h4>
 			</kv-chip>
 		`,
 });

--- a/@kiva/kv-components/src/vue/stories/KvDatePicker.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvDatePicker.stories.js
@@ -97,7 +97,7 @@ const DefaultTemplate = (args, { argTypes }) => ({
 	},
 	template: `
 		<div>
-			<label class="tw-text-h4 tw-block tw-pb-1">
+			<label class="tw-text-upper tw-block tw-pb-1">
 				Select Date
 			</label>
 			<kv-date-picker
@@ -187,7 +187,7 @@ export const HiddenIcon = (args, { argTypes }) => ({
 	<div>
 			<div class="tw-space-y-4">
 				<div>
-					<label class="tw-text-h4 tw-block tw-pb-1">
+					<label class="tw-text-upper tw-block tw-pb-1">
 						With Icon (Default)
 					</label>
 					<kv-date-picker
@@ -207,7 +207,7 @@ export const HiddenIcon = (args, { argTypes }) => ({
 				</div>
 
 				<div>
-					<label class="tw-text-h4 tw-block tw-pb-1">
+					<label class="tw-text-upper tw-block tw-pb-1">
 						Without Icon (Hidden)
 					</label>
 					<kv-date-picker
@@ -283,7 +283,7 @@ export const WithDisabledField = (args, { argTypes }) => ({
 	template: `
 	<div>
 			<div class="tw-space-y-4 tw-mb-4">
-				<label class="tw-text-h4 tw-block">
+				<label class="tw-text-upper tw-block">
 					Disabled Field
 				</label>
 				<kv-date-picker
@@ -302,7 +302,7 @@ export const WithDisabledField = (args, { argTypes }) => ({
 				/>
 			</div>
 			<div class="tw-space-y-4">
-				<label class="tw-text-h4 tw-block">
+				<label class="tw-text-upper tw-block">
 					Enabled Field
 				</label>
 				<kv-date-picker
@@ -358,7 +358,7 @@ export const DifferentFormats = (args, { argTypes }) => ({
 				:key="format.name"
 				class="tw-border tw-border-gray-200 tw-p-4 tw-rounded"
 			>
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					{{ format.name }}
 				</label>
 				<kv-date-picker
@@ -402,7 +402,7 @@ export const DifferentLocales = (args, { argTypes }) => ({
 				:key="locale.name"
 				class="tw-border tw-border-gray-200 tw-p-4 tw-rounded"
 			>
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					{{ locale.name }}
 				</label>
 				<kv-date-picker
@@ -438,7 +438,7 @@ export const States = (args, { argTypes }) => ({
 	template: `
 		<div class="tw-space-y-4">
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					Normal
 				</label>
 				<kv-date-picker
@@ -450,7 +450,7 @@ export const States = (args, { argTypes }) => ({
 			</div>
 
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					Disabled
 				</label>
 				<kv-date-picker
@@ -463,7 +463,7 @@ export const States = (args, { argTypes }) => ({
 			</div>
 
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					Readonly
 				</label>
 				<kv-date-picker
@@ -496,7 +496,7 @@ export const ModelTypes = (args, { argTypes }) => ({
 	template: `
 		<div class="tw-space-y-4">
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					Timestamp
 				</label>
 				<kv-date-picker
@@ -511,7 +511,7 @@ export const ModelTypes = (args, { argTypes }) => ({
 			</div>
 
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					Format
 				</label>
 				<kv-date-picker
@@ -527,7 +527,7 @@ export const ModelTypes = (args, { argTypes }) => ({
 			</div>
 
 			<div class="tw-border tw-border-gray-200 tw-p-4 tw-rounded">
-				<label class="tw-text-h4 tw-block tw-pb-1">
+				<label class="tw-text-upper tw-block tw-pb-1">
 					ISO
 				</label>
 				<kv-date-picker

--- a/@kiva/kv-components/src/vue/stories/KvIconButton.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvIconButton.stories.js
@@ -138,7 +138,7 @@ export const AllVariations = {
 				<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-8">
 					<!-- Bare (no background, no border) -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Bare</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Bare</h3>
 						<div class="tw-flex tw-gap-4 tw-items-center">
 							<div class="tw-text-center">
 								<kv-icon-button
@@ -166,7 +166,7 @@ export const AllVariations = {
 
 					<!-- With Background -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Background</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Background</h3>
 						<div class="tw-flex tw-gap-4 tw-items-center">
 							<div class="tw-text-center">
 								<kv-icon-button
@@ -197,7 +197,7 @@ export const AllVariations = {
 
 					<!-- With Background and Border -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Border</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Border</h3>
 						<div class="tw-flex tw-gap-4 tw-items-center">
 							<div class="tw-text-center">
 								<kv-icon-button
@@ -234,7 +234,7 @@ export const AllVariations = {
 
 					<!-- Toggle -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Toggle</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Toggle</h3>
 						<div class="tw-flex tw-gap-4 tw-items-center">
 							<div class="tw-text-center">
 								<kv-icon-button

--- a/@kiva/kv-components/src/vue/stories/KvLightbox.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvLightbox.stories.js
@@ -221,7 +221,7 @@ export const CustomHeader = (args, { argTypes }) => ({
 							class="tw-h-2"
 							:icon="mdiLightningBolt"
 						/>
-						<p class="tw-text-h4">Special subhead text</p>
+						<p class="tw-text-upper">Special subhead text</p>
 					</div>
 				</template>
 				<p>Lorem ipsum aliquip labore commodo anim elit amet cupidatat do ex ipsum. Consectetur excepteur ea anim velit reprehenderit qui aliquip ullamco aliquip irure dolor ex. Occaecat excepteur enim eu incididunt ut consectetur aliqua magna et. Reprehenderit duis ex excepteur sit et cupidatat cillum cillum adipisicing ut adipisicing minim ad.</p>

--- a/@kiva/kv-components/src/vue/stories/KvMaterialIcon.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvMaterialIcon.stories.js
@@ -131,7 +131,7 @@ export const InlineWithText = (templateArgs, { argTypes }) => ({
 	setup() { return { args: { ...templateArgs } }; },
 	template: `
 		<a href="#" class="tw-inline-flex">
-			<span class="tw-text-h4">He went thataway</span>
+			<span class="tw-text-upper">He went thataway</span>
 			<kv-material-icon class="tw-w-2.5" :icon="mdiChevronRight" />
 		</a>`,
 	data() {

--- a/@kiva/kv-components/src/vue/stories/KvPieChartV2.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvPieChartV2.stories.js
@@ -224,7 +224,7 @@ export const AllVariations = {
 		template: `
 			<div class="tw-space-y-8">
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Unit Formats</h3>
+					<h3 class="tw-text-upper tw-mb-4">Unit Formats</h3>
 					<div class="tw-flex tw-items-start tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div style="width: 262px;">
 							<KvPieChartV2 :values="sampleValues" unit="percent" />
@@ -242,7 +242,7 @@ export const AllVariations = {
 				</div>
 
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Ring Thickness</h3>
+					<h3 class="tw-text-upper tw-mb-4">Ring Thickness</h3>
 					<div class="tw-flex tw-items-start tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div style="width: 262px;">
 							<KvPieChartV2 :values="sampleValues" :stroke-width="24" />
@@ -260,7 +260,7 @@ export const AllVariations = {
 				</div>
 
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Segment Gap</h3>
+					<h3 class="tw-text-upper tw-mb-4">Segment Gap</h3>
 					<div class="tw-flex tw-items-start tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div style="width: 262px;">
 							<KvPieChartV2 :values="sampleValues" :segment-gap="0" />
@@ -278,7 +278,7 @@ export const AllVariations = {
 				</div>
 
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Data Density</h3>
+					<h3 class="tw-text-upper tw-mb-4">Data Density</h3>
 					<div class="tw-flex tw-items-start tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div style="width: 262px;">
 							<KvPieChartV2 :values="[{ label: 'Total', value: 100 }]" />

--- a/@kiva/kv-components/src/vue/stories/KvProgressCircle.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvProgressCircle.stories.js
@@ -156,7 +156,7 @@ export const AllVariations = {
 			<div class="tw-space-y-8">
 				<!-- Color Variations -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Color Variations</h3>
+					<h3 class="tw-text-upper tw-mb-4">Color Variations</h3>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="65" color="brand" style="width: 80px;" />
@@ -187,7 +187,7 @@ export const AllVariations = {
 
 				<!-- Stroke Width Variations -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Stroke Width Variations</h3>
+					<h3 class="tw-text-upper tw-mb-4">Stroke Width Variations</h3>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="65" :strokeWidth="4" style="width: 80px;" />
@@ -210,7 +210,7 @@ export const AllVariations = {
 
 				<!-- With Number Display -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">With Number Display</h3>
+					<h3 class="tw-text-upper tw-mb-4">With Number Display</h3>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="25" :showNumber="true" style="width: 120px;" />
@@ -233,7 +233,7 @@ export const AllVariations = {
 
 				<!-- Arc Scale Variations -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Arc Scale Variations</h3>
+					<h3 class="tw-text-upper tw-mb-4">Arc Scale Variations</h3>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="65" :arcScale="1" style="width: 80px;" />
@@ -296,7 +296,7 @@ export const ArcConfigurations = {
 		template: `
 			<div class="tw-space-y-6">
 				<div>
-					<h4 class="tw-text-h4 tw-mb-4">Gauge-style Progress</h4>
+					<h4 class="tw-text-upper tw-mb-4">Gauge-style Progress</h4>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="30" :arcScale="0.5" :rotate="90" style="width: 120px;" />
@@ -313,7 +313,7 @@ export const ArcConfigurations = {
 					</div>
 				</div>
 				<div>
-					<h4 class="tw-text-h4 tw-mb-4">Different Rotations</h4>
+					<h4 class="tw-text-upper tw-mb-4">Different Rotations</h4>
 					<div class="tw-flex tw-items-center tw-gap-6 tw-flex-wrap tw-p-6 tw-bg-gray-50 tw-rounded-md">
 						<div class="tw-text-center">
 							<KvProgressCircle :value="50" :arcScale="0.75" :rotate="0" style="width: 100px;" />

--- a/@kiva/kv-components/src/vue/stories/KvRadio.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvRadio.stories.js
@@ -22,7 +22,7 @@ const Template = (args, {
 	template: `
 		<div>
 			<fieldset>
-				<legend class="tw-text-h4 tw-mb-2">Choose a Radio</legend>
+				<legend class="tw-text-upper tw-mb-2">Choose a Radio</legend>
 				<div class="tw-flex tw-flex-col tw-gap-2 tw-mb-2">
 					<kv-radio
 						:disabled="disabled"
@@ -94,7 +94,7 @@ export const WithoutVModel = (args, {
 	template: `
 		<div>
 			<fieldset>
-				<legend class="tw-text-h4 tw-mb-2">Choose a Radio</legend>
+				<legend class="tw-text-upper tw-mb-2">Choose a Radio</legend>
 				<div class="tw-flex tw-flex-col tw-gap-2 tw-mb-2">
 					<kv-radio
 						:disabled="disabled"

--- a/@kiva/kv-components/src/vue/stories/KvSelect.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSelect.stories.js
@@ -19,7 +19,7 @@ const Template = (args, {
 		<div>
 			<label
 				for="example-id"
-				class="tw-text-h4 tw-block"
+				class="tw-text-upper tw-block"
 			>
 				Choose an example
 			</label>
@@ -63,7 +63,7 @@ export const LabelHidden = (args, {
 		<div>
 			<label
 				for="example-id"
-				class="tw-text-h4 tw-block tw-sr-only"
+				class="tw-text-upper tw-block tw-sr-only"
 			>
 				Choose an example
 			</label>
@@ -100,7 +100,7 @@ export const WidthSet = (args, {
 		<div class="w-full">
 			<label
 				for="example-id"
-				class="tw-text-h4 tw-block"
+				class="tw-text-upper tw-block"
 			>
 				Choose an example
 			</label>

--- a/@kiva/kv-components/src/vue/stories/KvSimpleMap.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSimpleMap.stories.js
@@ -307,7 +307,7 @@ export const AllVariations = {
 			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
 				<div class="tw-grid tw-grid-cols-1 lg:tw-grid-cols-2 tw-gap-8">
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Loan-count tiers</h4>
+						<h4 class="tw-text-upper tw-mb-2">Loan-count tiers</h4>
 						<p class="tw-text-small tw-mb-3">
 							Countries fill by loan count: tier 1 (1–3), tier 2 (4–8), tier 3 (9–14), tier 4 (15+).
 							Hover lifts loan-bearing countries to eco-green; loan-less countries hover gray-300.
@@ -315,14 +315,14 @@ export const AllVariations = {
 						<kv-simple-map :countries="TIERED_MARKETS" class="tw-rounded tw-overflow-hidden" />
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Popup placement: top (default)</h4>
+						<h4 class="tw-text-upper tw-mb-2">Popup placement: top (default)</h4>
 						<p class="tw-text-small tw-mb-3">
 							Popup sits centred above the country and auto-flips below if it would clip the top edge.
 						</p>
 						<kv-simple-map :countries="TIERED_MARKETS" popup-placement="top" class="tw-rounded tw-overflow-hidden" />
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Popup placement: bottom-right</h4>
+						<h4 class="tw-text-upper tw-mb-2">Popup placement: bottom-right</h4>
 						<p class="tw-text-small tw-mb-3">
 							Top-left of the popup hugs the country's bottom-right bbox corner.
 						</p>
@@ -334,14 +334,14 @@ export const AllVariations = {
 						/>
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Autoplay (looping)</h4>
+						<h4 class="tw-text-upper tw-mb-2">Autoplay (looping)</h4>
 						<p class="tw-text-small tw-mb-3">
 							Scripted tour cycles indefinitely. Click or drag the map to exit; resume with the play button.
 						</p>
 						<kv-simple-map :countries="TIERED_MARKETS" :autoplay="true" class="tw-rounded tw-overflow-hidden" />
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Autoplay (one-shot)</h4>
+						<h4 class="tw-text-upper tw-mb-2">Autoplay (one-shot)</h4>
 						<p class="tw-text-small tw-mb-3">
 							Tour runs once and stops on the overview. Manual pan/zoom and the play button become available.
 						</p>
@@ -353,7 +353,7 @@ export const AllVariations = {
 						/>
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Narrow / mobile container</h4>
+						<h4 class="tw-text-upper tw-mb-2">Narrow / mobile container</h4>
 						<p class="tw-text-small tw-mb-3">
 							Responsive container with a higher zoomFactor for small viewports.
 						</p>
@@ -367,7 +367,7 @@ export const AllVariations = {
 						/>
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Static / non-interactive</h4>
+						<h4 class="tw-text-upper tw-mb-2">Static / non-interactive</h4>
 						<p class="tw-text-small tw-mb-3">
 							Drag and zoom controls disabled. Hover popups still work.
 						</p>
@@ -379,7 +379,7 @@ export const AllVariations = {
 						/>
 					</div>
 					<div>
-						<h4 class="tw-text-h4 tw-mb-2">Name-only countries</h4>
+						<h4 class="tw-text-upper tw-mb-2">Name-only countries</h4>
 						<p class="tw-text-small tw-mb-3">
 							Country entries without a loanCount fall back to gray base fill; popup shows the name only.
 						</p>

--- a/@kiva/kv-components/src/vue/stories/KvTextInput.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvTextInput.stories.js
@@ -22,7 +22,7 @@ const DefaultTemplate = (args, {
 		<div>
 			<label
 				:for="uuid"
-				class="tw-text-h4 tw-block tw-pb-1"
+				class="tw-text-upper tw-block tw-pb-1"
 			>
 				Street Address
 			</label>
@@ -61,7 +61,7 @@ export const WithoutVModelTemplate = (args, {
 		<div>
 			<label
 				for="without-v-model-id"
-				class="tw-text-h4 tw-block tw-pb-1"
+				class="tw-text-upper tw-block tw-pb-1"
 			>
 				Street Address
 			</label>
@@ -88,7 +88,7 @@ export const Invalid = (args, {
 		<div>
 			<label
 				for="text-input-error-id"
-				class="tw-text-h4 tw-block tw-pb-1"
+				class="tw-text-upper tw-block tw-pb-1"
 			>
 				Street Address
 			</label>
@@ -143,7 +143,7 @@ export const WidthSet = (args, {
 		<div class="w-full">
 			<label
 				for="width-set-id"
-				class="tw-text-h4 tw-block tw-pb-1"
+				class="tw-text-upper tw-block tw-pb-1"
 			>
 				Street Address
 			</label>
@@ -181,7 +181,7 @@ export const PlaceholderText = (args, {
 		<div>
 			<label
 				for="placeholder-example"
-				class="tw-text-h4 tw-block tw-pb-1"
+				class="tw-text-upper tw-block tw-pb-1"
 			>
 				Telephone Number
 			</label>

--- a/@kiva/kv-components/src/vue/stories/KvTextLink.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvTextLink.stories.js
@@ -112,7 +112,7 @@ export const AllVariations = {
 				<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-8">
 					<!-- Link Types -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Link Types</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Link Types</h3>
 						<div class="tw-space-y-4">
 							<div class="tw-flex tw-items-center tw-gap-4">
 								<kv-text-link @click="onClick">
@@ -137,7 +137,7 @@ export const AllVariations = {
 
 					<!-- With Icons -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">With Icons</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">With Icons</h3>
 						<div class="tw-space-y-4">
 							<div class="tw-flex tw-items-center tw-gap-4">
 								<kv-text-link :icon="mdiArrowRight" @click="onClick">
@@ -162,7 +162,7 @@ export const AllVariations = {
 
 					<!-- States -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">States</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">States</h3>
 						<div class="tw-space-y-4">
 							<div class="tw-flex tw-items-center tw-gap-4">
 								<kv-text-link @click="onClick">
@@ -187,7 +187,7 @@ export const AllVariations = {
 
 					<!-- Usage Examples -->
 					<div>
-						<h3 class="tw-text-h4 tw-mb-4 tw-font-medium">Common Use Cases</h3>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Common Use Cases</h3>
 						<div class="tw-space-y-4">
 							<div class="tw-flex tw-items-center tw-gap-4">
 								<kv-text-link :icon="mdiArrowRight" @click="onClick">
@@ -266,7 +266,7 @@ export const LinkRendering = {
 				</p>
 				<div class="tw-space-y-6">
 					<div class="tw-p-4 tw-bg-white tw-rounded tw-border tw-border-tertiary">
-						<h4 class="tw-text-h4 tw-font-medium tw-mb-2">Button (no to or href)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Button (no to or href)</h4>
 						<kv-text-link @click="onClick">
 							Click me
 						</kv-text-link>
@@ -275,7 +275,7 @@ export const LinkRendering = {
 						</p>
 					</div>
 					<div class="tw-p-4 tw-bg-white tw-rounded tw-border tw-border-tertiary">
-						<h4 class="tw-text-h4 tw-font-medium tw-mb-2">Anchor (with href)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Anchor (with href)</h4>
 						<kv-text-link href="https://www.kiva.org">
 							Visit Kiva
 						</kv-text-link>
@@ -284,7 +284,7 @@ export const LinkRendering = {
 						</p>
 					</div>
 					<div class="tw-p-4 tw-bg-white tw-rounded tw-border tw-border-tertiary">
-						<h4 class="tw-text-h4 tw-font-medium tw-mb-2">Router Link (with to)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Router Link (with to)</h4>
 						<kv-text-link to="/lend">
 							Browse loans
 						</kv-text-link>

--- a/@kiva/kv-components/src/vue/stories/KvTextLinkDocs.mdx
+++ b/@kiva/kv-components/src/vue/stories/KvTextLinkDocs.mdx
@@ -76,7 +76,7 @@ When a trailing icon is provided, it animates to the right on hover and focus st
 
 The text link component consists of two main parts:
 
-- **Link Text**: The visible text content provided via the default slot, styled with `tw-text-h4` typography and link color
+- **Link Text**: The visible text content provided via the default slot, styled with `tw-text-upper` typography and link color
 - **Icon (Optional)**: A trailing Material Design icon that animates on hover/focus, sized responsively (smaller on mobile, larger on desktop)
 
 ---
@@ -85,7 +85,7 @@ The text link component consists of two main parts:
 
 ### Typography
 
-The component uses the `tw-text-h4` class for consistent typography across all variants:
+The component uses the `tw-text-upper` class for consistent typography across all variants:
 
 - Font weight and size are inherited from the h4 text style
 - Color is set to the link color (`tw-text-link`)

--- a/@kiva/kv-components/src/vue/stories/KvTooltip.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvTooltip.stories.js
@@ -382,7 +382,7 @@ export const ModifiersShowcase = (args, { argTypes }) => ({
 				<div class="tw-space-y-6">
 					<!-- Custom padding modifier -->
 					<div>
-						<h4 class="tw-font-medium tw-mb-2">Custom Padding (20px from edges)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Custom Padding (20px from edges)</h4>
 						<kv-button id="padding-btn" class="tw-bg-green-500 tw-text-white tw-px-4 tw-py-2 tw-rounded">
 							Custom Padding
 						</kv-button>
@@ -399,7 +399,7 @@ export const ModifiersShowcase = (args, { argTypes }) => ({
 
 					<!-- Offset modifier -->
 					<div>
-						<h4 class="tw-font-medium tw-mb-2">Custom Offset (shifted 20px)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Custom Offset (shifted 20px)</h4>
 						<kv-button id="offset-btn" class="tw-bg-purple-500 tw-text-white tw-px-4 tw-py-2 tw-rounded">
 							Custom Offset
 						</kv-button>
@@ -416,7 +416,7 @@ export const ModifiersShowcase = (args, { argTypes }) => ({
 
 					<!-- Multiple modifiers -->
 					<div>
-						<h4 class="tw-font-medium tw-mb-2">Multiple Modifiers (custom padding + offset)</h4>
+						<h4 class="tw-text-upper tw-font-medium tw-mb-2">Multiple Modifiers (custom padding + offset)</h4>
 						<kv-button id="multiple-btn" class="tw-bg-red-500 tw-text-white tw-px-4 tw-py-2 tw-rounded">
 							Multiple Modifiers
 						</kv-button>

--- a/@kiva/kv-components/src/vue/stories/KvUserAvatar.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvUserAvatar.stories.js
@@ -87,7 +87,7 @@ export const AllVariations = {
 			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
 				<!-- Size Variations -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Size Variations</h3>
+					<h3 class="tw-text-upper tw-mb-4">Size Variations</h3>
 					<div class="tw-flex tw-gap-6 tw-items-end">
 						<div class="tw-text-center">
 							<KvUserAvatar
@@ -127,7 +127,7 @@ export const AllVariations = {
 
 				<!-- Display Types -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Display Types</h3>
+					<h3 class="tw-text-upper tw-mb-4">Display Types</h3>
 					<div class="tw-flex tw-gap-6 tw-items-end">
 						<div class="tw-text-center">
 							<KvUserAvatar
@@ -165,7 +165,7 @@ export const AllVariations = {
 
 				<!-- Theme Variations -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Theme Variations (Anonymous)</h3>
+					<h3 class="tw-text-upper tw-mb-4">Theme Variations (Anonymous)</h3>
 					<div class="tw-flex tw-gap-6 tw-items-end">
 						<div class="tw-text-center">
 							<KvUserAvatar
@@ -188,7 +188,7 @@ export const AllVariations = {
 
 				<!-- Initial Letter Color Variations -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Initial Letter Colors (Randomized by Name)</h3>
+					<h3 class="tw-text-upper tw-mb-4">Initial Letter Colors (Randomized by Name)</h3>
 					<div class="tw-flex tw-gap-4 tw-items-end tw-flex-wrap">
 						<div class="tw-text-center">
 							<KvUserAvatar lender-name="Alice" class="tw-w-6 tw-h-6" />

--- a/@kiva/kv-components/src/vue/stories/KvUtilityMenu.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvUtilityMenu.stories.js
@@ -129,7 +129,7 @@ export const AllVariations = {
 			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8" style="min-height: 500px;">
 				<!-- Size Variations -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Button Sizes</h3>
+					<h3 class="tw-text-upper tw-mb-4">Button Sizes</h3>
 					<div class="tw-flex tw-gap-8 tw-items-start">
 						<div class="tw-text-center">
 							<p class="tw-text-small tw-text-secondary tw-mb-2">Small</p>
@@ -172,7 +172,7 @@ export const AllVariations = {
 
 				<!-- Button Radius Variations -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Button Radius</h3>
+					<h3 class="tw-text-upper tw-mb-4">Button Radius</h3>
 					<div class="tw-flex tw-gap-8 tw-items-start">
 						<div class="tw-text-center">
 							<p class="tw-text-small tw-text-secondary tw-mb-2">Rounded Full</p>
@@ -215,7 +215,7 @@ export const AllVariations = {
 
 				<!-- Menu Position -->
 				<div class="tw-mb-8">
-					<h3 class="tw-text-h4 tw-mb-4">Menu Position</h3>
+					<h3 class="tw-text-upper tw-mb-4">Menu Position</h3>
 					<div class="tw-flex tw-gap-16 tw-items-start">
 						<div class="tw-text-center">
 							<p class="tw-text-small tw-text-secondary tw-mb-2">Left Aligned (default)</p>
@@ -246,7 +246,7 @@ export const AllVariations = {
 
 				<!-- Custom Icons -->
 				<div>
-					<h3 class="tw-text-h4 tw-mb-4">Custom Icons</h3>
+					<h3 class="tw-text-upper tw-mb-4">Custom Icons</h3>
 					<div class="tw-flex tw-gap-8 tw-items-start">
 						<div class="tw-text-center">
 							<p class="tw-text-small tw-text-secondary tw-mb-2">Dots (default)</p>

--- a/@kiva/kv-components/src/vue/stories/KvVerticalCarousel.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvVerticalCarousel.stories.js
@@ -37,7 +37,7 @@ const generateLoanCardTemplate = (index) => {
 		<div style="width: 336px">
 			<img src="https://placehold.co/336x252/${randomHexColor(index)}/000000" class="tw-w-full tw-rounded tw-mb-2">
 			<h3>Card Title</h3>
-			<h4 class="tw-my-1">$${amounts?.[index] || amounts?.[1]} to go</h4>
+			<h4 class="tw-text-upper tw-my-1">$${amounts?.[index] || amounts?.[1]} to go</h4>
 			<p class="tw-mt-1 tw-mb-9">${cardCopy?.[index] || cardCopy?.[1]}</p>
 			<kv-button
 				variant="primary"

--- a/@kiva/kv-tokens/configs/kivaTypography.js
+++ b/@kiva/kv-tokens/configs/kivaTypography.js
@@ -6,7 +6,6 @@ const {
 	fontSizes,
 	fontWeights,
 	letterSpacings,
-	lineHeights,
 	lineHeightsAbsolute,
 	radii,
 	semanticFontSizes,
@@ -288,99 +287,6 @@ export const textBaseColor = 'rgb(var(--text-primary))';
  REUSABLE TYPE STYLES
 */
 export const textStyles = (() => {
-	const textJumbo = {
-		fontFamily: fonts.serif,
-		fontWeight: fontWeights.medium,
-		fontSize: rem(fontSizes.jumbo.sm),
-		letterSpacing: letterSpacings['-1'],
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.jumbo.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.jumbo.lg),
-		},
-	};
-
-	const textH1 = {
-		fontFamily: fonts.serif,
-		fontSize: rem(fontSizes.h1.sm),
-		fontWeight: fontWeights.medium,
-		letterSpacing: em(letterSpacings['-0.5'], fontSizes.h1.md),
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.h1.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.h1.lg),
-		},
-	};
-
-	const textH2 = {
-		fontFamily: fonts.serif,
-		fontSize: rem(fontSizes.h2.sm),
-		fontWeight: fontWeights.medium,
-		letterSpacing: em(letterSpacings.normal, fontSizes.h2.sm),
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.h2.md),
-			letterSpacing: em(letterSpacings['-0.3'], fontSizes.h2.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.h2.lg),
-			letterSpacing: em(letterSpacings['-0.3'], fontSizes.h2.lg),
-			lineHeight: lineHeights['nearly-none'],
-		},
-	};
-
-	const textH3 = {
-		fontSize: rem(fontSizes.h3.sm),
-		fontWeight: fontWeights.normal,
-		letterSpacing: em(letterSpacings['-1'], fontSizes.h3.sm),
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.h3.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.h3.lg),
-		},
-	};
-
-	const textH4 = {
-		fontSize: rem(fontSizes.h4.sm),
-		fontWeight: fontWeights.normal,
-		lineHeight: lineHeights.normal,
-		textTransform: 'uppercase',
-		'@screen md': {
-			fontSize: rem(fontSizes.h4.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.h4.lg),
-		},
-	};
-
-	const textH5 = {
-		fontFamily: fonts.sans,
-		fontSize: rem(fontSizes.h4.sm),
-		fontWeight: fontWeights.normal,
-		letterSpacing: em(letterSpacings.normal, fontSizes.subhead.sm),
-		lineHeight: lineHeights['nearly-none'],
-	};
-
-	const textSubhead = {
-		fontFamily: fonts.sans,
-		fontSize: rem(fontSizes.subhead.sm),
-		fontWeight: fontWeights.light,
-		letterSpacing: em(letterSpacings.normal, fontSizes.subhead.sm),
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.subhead.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.subhead.lg),
-		},
-	};
-
 	const textBase = {
 		fontWeight: fontWeights.light,
 		fontSize: rem(fontSizes.base.sm),
@@ -409,21 +315,6 @@ export const textStyles = (() => {
 		fontWeight: fontWeights.light,
 	};
 
-	const textBlockquote = {
-		fontFamily: fonts.serif,
-		fontSize: rem(fontSizes.h2.sm),
-		fontStyle: 'italic',
-		fontWeight: fontWeights.medium,
-		letterSpacing: em(letterSpacings['-0.5'], fontSizes.h2.sm),
-		lineHeight: lineHeights.tight,
-		'@screen md': {
-			fontSize: rem(fontSizes.h2.md),
-		},
-		'@screen lg': {
-			fontSize: rem(fontSizes.h2.lg),
-		},
-	};
-
 	const textDisplay = {
 		fontFamily: fonts.serif,
 		fontWeight: fontWeights.medium,
@@ -442,6 +333,8 @@ export const textStyles = (() => {
 		},
 	};
 
+	const textJumbo = { ...textDisplay };
+
 	const textHeadline = {
 		fontFamily: fonts.serif,
 		fontWeight: fontWeights.medium,
@@ -451,6 +344,7 @@ export const textStyles = (() => {
 		'@screen md': {
 			fontSize: rem(semanticFontSizes.h1.md),
 			letterSpacing: em(letterSpacings['-200'], semanticFontSizes.h1.md),
+			lineHeight: em(lineHeightsAbsolute.h1.md, semanticFontSizes.h1.md),
 		},
 		'@screen lg': {
 			fontSize: rem(semanticFontSizes.h1.lg),
@@ -458,6 +352,8 @@ export const textStyles = (() => {
 			lineHeight: em(lineHeightsAbsolute.h1.lg, semanticFontSizes.h1.lg),
 		},
 	};
+
+	const textH1 = { ...textHeadline };
 
 	const textHeadlineTwo = {
 		fontFamily: fonts.serif,
@@ -468,12 +364,20 @@ export const textStyles = (() => {
 		'@screen md': {
 			fontSize: rem(semanticFontSizes.h2.md),
 			letterSpacing: em(letterSpacings['-200'], semanticFontSizes.h2.md),
+			lineHeight: em(lineHeightsAbsolute.h2.md, semanticFontSizes.h2.md),
 		},
 		'@screen lg': {
 			fontSize: rem(semanticFontSizes.h2.lg),
 			letterSpacing: em(letterSpacings['-300'], semanticFontSizes.h2.lg),
 			lineHeight: em(lineHeightsAbsolute.h2.lg, semanticFontSizes.h2.lg),
 		},
+	};
+
+	const textH2 = { ...textHeadlineTwo };
+
+	const textBlockquote = {
+		...textHeadlineTwo,
+		fontStyle: 'italic',
 	};
 
 	const textSubheadline = {
@@ -484,12 +388,18 @@ export const textStyles = (() => {
 		lineHeight: em(lineHeightsAbsolute.h3.sm, semanticFontSizes.h3.sm),
 		'@screen md': {
 			fontSize: rem(semanticFontSizes.h3.md),
+			letterSpacing: em(letterSpacings.normal, semanticFontSizes.h3.md),
+			lineHeight: em(lineHeightsAbsolute.h3.md, semanticFontSizes.h3.md),
 		},
 		'@screen lg': {
 			fontSize: rem(semanticFontSizes.h3.lg),
+			letterSpacing: em(letterSpacings.normal, semanticFontSizes.h3.lg),
 			lineHeight: em(lineHeightsAbsolute.h3.lg, semanticFontSizes.h3.lg),
 		},
 	};
+
+	const textH3 = { ...textSubheadline };
+	const textSubhead = { ...textSubheadline };
 
 	const textTitle = {
 		fontFamily: fonts.sans,
@@ -499,12 +409,19 @@ export const textStyles = (() => {
 		lineHeight: em(lineHeightsAbsolute.h3.sm, semanticFontSizes.h3.sm),
 		'@screen md': {
 			fontSize: rem(semanticFontSizes.h3.md),
+			letterSpacing: em(letterSpacings.normal, semanticFontSizes.h3.md),
+			lineHeight: em(lineHeightsAbsolute.h3.md, semanticFontSizes.h3.md),
 		},
 		'@screen lg': {
 			fontSize: rem(semanticFontSizes.h3.lg),
+			letterSpacing: em(letterSpacings.normal, semanticFontSizes.h3.lg),
 			lineHeight: em(lineHeightsAbsolute.h3.lg, semanticFontSizes.h3.lg),
 		},
 	};
+
+	const textH4 = { ...textTitle };
+
+	const textH5 = { ...textBase };
 
 	const textButtonLink = {
 		fontFamily: fonts.sans,
@@ -540,27 +457,27 @@ export const textStyles = (() => {
 	};
 
 	return {
+		textDisplay,
 		textJumbo,
+		textHeadline,
 		textH1,
+		textHeadlineTwo,
 		textH2,
+		textBlockquote,
+		textSubheadline,
+		textSubhead,
 		textH3,
+		textTitle,
 		textH4,
 		textH5,
-		textSubhead,
 		textBase,
 		textSmall,
+		textCaption,
 		textLink,
-		textPlaceholder,
-		textBlockquote,
-		textDisplay,
-		textHeadline,
-		textHeadlineTwo,
-		textSubheadline,
-		textTitle,
 		textButtonLink,
 		textUpper,
 		textLabel,
-		textCaption,
+		textPlaceholder,
 	};
 })();
 
@@ -617,9 +534,16 @@ export const proseOverrides = () => ({
 			h2: false,
 			h3: false,
 			h4: false,
+			caption: {
+				...textStyles.textCaption,
+			},
 			figcaption: {
-				fontSize: false,
-				lineHeight: false,
+				// fontSize: false,
+				// lineHeight: false,
+				...textStyles.textCaption,
+			},
+			label: {
+				...textStyles.textLabel,
 			},
 			code: {
 				color: false,
@@ -636,39 +560,47 @@ export const proseOverrides = () => ({
 				marginBottom: rem(space[2]),
 			},
 			blockquote: {
+				...textStyles?.textBlockquote,
 				marginTop: rem(space[2]),
 				marginBottom: rem(space[2]),
 				padding: `0 0 0 ${rem(space['6'])}`,
 			},
 			h1: {
-				fontSize: false,
-				letterSpacing: false,
+				...textStyles?.textDisplay,
+				// fontSize: false,
+				// letterSpacing: false,
 				marginTop: '0',
 				marginBottom: rem(space[2]),
 				color: textBaseColor,
 			},
 			h2: {
-				fontSize: false,
-				letterSpacing: false,
+				// fontSize: false,
+				// letterSpacing: false,
+				...textStyles?.textHeadline,
 				marginTop: rem(space[2]),
 				marginBottom: rem(space[2]),
 				color: textBaseColor,
 			},
 			h3: {
-				fontSize: false,
-				letterSpacing: false,
+				// fontSize: false,
+				// letterSpacing: false,
+				...textStyles?.textHeadlineTwo,
 				marginTop: rem(space[2]),
 				marginBottom: rem(space[2]),
 				color: textBaseColor,
 			},
 			h4: {
-				letterSpacing: false,
+				// fontSize: false,
+				// letterSpacing: false,
+				...textStyles?.textSubheadline,
 				marginTop: false,
 				marginBottom: rem(space[2]),
 				color: textBaseColor,
 			},
 			h5: {
-				letterSpacing: false,
+				// fontSize: false,
+				// letterSpacing: false,
+				...textStyles?.textTitle,
 				marginTop: false,
 				marginBottom: rem(space[2]),
 				color: textBaseColor,

--- a/@kiva/kv-tokens/configs/tailwind.config.js
+++ b/@kiva/kv-tokens/configs/tailwind.config.js
@@ -215,7 +215,9 @@ export default {
 					fontSize: '0.875em',
 				},
 				blockquote: textStyles.textBlockquote,
-				'figure figcaption': textStyles.textBase,
+				'figure figcaption': textStyles.textCaption,
+				caption: textStyles.textCaption,
+				label: textStyles.textLabel,
 				'button:focus': {
 					outline: 'revert', // undo tailwind button focus styling
 				},

--- a/@kiva/kv-tokens/tokens/core/typography.json
+++ b/@kiva/kv-tokens/tokens/core/typography.json
@@ -42,7 +42,7 @@
 		"150":         { "$type": "number", "$value": 1.5 }
 	},
 	"line-height-absolute": {
-		"jumbo":   { "sm": { "$type": "number", "$value": 47 }, "md": { "$type": "number", "$value": 52 }, "lg": { "$type": "number", "$value": 57 } },
+		"jumbo":   { "sm": { "$type": "number", "$value": 52 }, "md": { "$type": "number", "$value": 52 }, "lg": { "$type": "number", "$value": 57 } },
 		"h1":      { "sm": { "$type": "number", "$value": 31 }, "md": { "$type": "number", "$value": 31 }, "lg": { "$type": "number", "$value": 36 } },
 		"h2":      { "sm": { "$type": "number", "$value": 26 }, "md": { "$type": "number", "$value": 26 }, "lg": { "$type": "number", "$value": 31 } },
 		"h3":      { "sm": { "$type": "number", "$value": 23 }, "md": { "$type": "number", "$value": 23 }, "lg": { "$type": "number", "$value": 26 } },


### PR DESCRIPTION
…aTypography + tailwind config.

This update assignes our new semantic type styles to all Header styles. It maps them over html `H1-H5` elements and our tw-text-h#` classes. It also establishes the shifted type scale for tw-prose to ensure marketing pages using rich text fields do not change too drastically.

_Note: The DynamicHeroClassic style updates will be made within that component. Overriding the class within the contentful interface should still work fine._
