### PR TITLE
chore: design skill index formatting fix

### DIFF
--- a/@kiva/kv-skills/design-system/.claude-plugin/plugin.json
+++ b/@kiva/kv-skills/design-system/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kiva-design-system",
   "description": "Kiva design-system skills: design tokens, Tailwind preset, typography, color, spacing, radius, layout, header audits, and Figma-to-skill extraction.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": ["kiva", "design-system", "design-tokens", "tailwind", "figma"]
 }

--- a/@kiva/kv-skills/design-system/.codex-plugin/plugin.json
+++ b/@kiva/kv-skills/design-system/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kiva-design-system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kiva design-system skills: design tokens, Tailwind preset, typography, color, spacing, radius, layout, header audits, and Figma-to-skill extraction.",
   "author": {
     "name": "Kiva"

--- a/@kiva/kv-skills/design-system/README.md
+++ b/@kiva/kv-skills/design-system/README.md
@@ -25,3 +25,35 @@ codex plugin marketplace add kiva/kv-ui-elements
 
 See the repo-root [`SKILLS.md`](../../../SKILLS.md) for the full per-audience
 install matrix (including claude.ai / web).
+
+## Updating
+
+Installed plugins are served from a local **clone of the GitHub remote**, not
+from your working tree. Editing files under
+`kv-ui-elements/@kiva/kv-skills/…` does **not** change what an installed plugin
+runs until those edits are committed and pushed, then re-pulled. The flow:
+
+1. **Commit and push** your changes to `kiva/kv-ui-elements` (the branch the
+   marketplace tracks — `main`).
+2. **Bump the patch version** in both
+   [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) and
+   [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) (e.g. `0.1.1` →
+   `0.1.2`). The install cache is keyed by version, so a bump is what reliably
+   signals consumers' clients to refresh.
+3. **Refresh and reinstall** on each client:
+
+   ```bash
+   # Claude Code
+   /plugin marketplace update kv-ui-elements   # re-pull the remote clone
+   /plugin install kiva-design-system@kv-ui-elements   # rebuild the cache
+   /reload-skills                              # surface changes in this session
+
+   # Codex
+   codex plugin marketplace update kiva/kv-ui-elements
+   # then: codex → /plugins → reinstall "Kiva Design System"
+   ```
+
+> **Note:** sub-skill content files (`color.md`, `typography.md`, `spacing.md`,
+> `radius.md`, `layout.md`, `color-themes.md`) are supporting files loaded by
+> the `kiva-design-system` router on demand — editing them follows the same
+> commit → push → bump → refresh flow as `SKILL.md`.

--- a/@kiva/kv-skills/design-system/README.md
+++ b/@kiva/kv-skills/design-system/README.md
@@ -26,6 +26,46 @@ codex plugin marketplace add kiva/kv-ui-elements
 See the repo-root [`SKILLS.md`](../../../SKILLS.md) for the full per-audience
 install matrix (including claude.ai / web).
 
+## Install on the Claude app (claude.ai / desktop)
+
+Of these skills, the **`kiva-design-system`** router is the one meant for the
+Claude app and non-developer use. The others (`kiva-tailwind`,
+`kiva-header-element-audit`, `figma-design-system-to-skill`) are
+developer-experience skills aimed at Claude Code / Codex, where a repo is
+present — they assume access to files in the monorepo and aren't useful in the
+app.
+
+The Claude app has no marketplace; you upload a skill as a **folder**. To add
+the design-system skill:
+
+1. **Get the files.** Either download/clone this repo, or download the single
+   skill folder. Keep the folder structure intact — the router `SKILL.md` and
+   its supporting files must stay together in one folder:
+
+   ```
+   kiva-design-system/
+     SKILL.md          ← the router (entry point)
+     color.md
+     color-themes.md
+     typography.md
+     layout.md
+     spacing.md
+     radius.md
+   ```
+
+   The simplest path: clone the repo and copy just
+   `@kiva/kv-skills/design-system/skills/kiva-design-system/` — that one folder
+   is the whole skill.
+
+2. **Upload it.** In the Claude app, go to **Settings → Capabilities → Skills**
+   and add the `kiva-design-system` folder. The app reads `SKILL.md` and loads
+   the supporting `.md` files on demand, so the folder must be uploaded whole —
+   don't flatten or split it.
+
+> The folder structure is load-bearing: the router reads its sibling `.md`
+> files by relative name. Uploading `SKILL.md` alone, or renaming/moving the
+> supporting files, breaks routing.
+
 ## Updating
 
 Installed plugins are served from a local **clone of the GitHub remote**, not

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
@@ -1,29 +1,7 @@
-
 ---
 name: kiva-design-system
-description: >
-  Index and router for the Kiva design system skills — typography, layout,
-  spacing, radius, color, and color-themes. Use this as the entry point for any
-  task that touches Kiva's visual language: auditing existing code for
-  design-system compliance, generating new UI that uses correct tokens and
-  Tailwind utilities, answering design token questions, or performing a
-  Figma-to-code handoff. This skill routes to the relevant sub-skill(s); do
-  not load all sub-skills at once — load only what the task requires.
-when_to_use: >
-  Invoke when any of the following apply:
-  — Auditing a component, page, or PR for design-system compliance (wrong token,
-    missing class, incorrect radius, hardcoded color, etc.).
-  — Generating new Vue/HTML/Tailwind code and need to know the correct token
-    name, utility class, or component pattern for color, type, spacing, radius,
-    or layout.
-  — Answering a question about which design token to use for a given purpose
-    (e.g. "what's the right text color for a disabled button in the Marigold
-    theme?").
-  — Handing off a Figma design to code (mapping Figma token names and theme
-    values to `@kiva/kv-tokens` utilities).
-  Trigger phrases: "design system", "kiva token", "tw- class", "which token",
-  "audit", "design compliance", "Figma handoff", "color theme", "type style",
-  "spacing token", "border radius", "layout grid", "breakpoint".
+description: Index and router for the Kiva design-system sub-skills — typography, layout, spacing, radius, color, and color-themes. Entry point for any task touching Kiva's visual language — auditing existing code for design-system compliance, generating new UI with correct tokens and Tailwind utilities, answering design-token questions, or performing a Figma-to-code handoff. Routes to the relevant sub-skill(s); load only what the task requires, never all at once.
+when_to_use: Invoke when — auditing a component, page, or PR for design-system compliance (wrong token, missing class, incorrect radius, hardcoded color); generating new Vue/HTML/Tailwind code and needing the correct token name, utility class, or component pattern for color, type, spacing, radius, or layout; answering which-token questions (e.g. "right text color for a disabled button in the Marigold theme?"); or handing a Figma design off to code (mapping Figma token and theme names to @kiva/kv-tokens utilities). Trigger phrases — "design system", "kiva token", "tw- class", "which token", "audit", "design compliance", "Figma handoff", "color theme", "type style", "spacing token", "border radius", "layout grid", "breakpoint".
 ---
 
 # Kiva Design System — Index Skill

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/layout.md
@@ -46,8 +46,6 @@ The canonical reference for all five breakpoint tiers:
 | **LG** | 1024px – 1439px | 12 | 32px | 64px |
 | **XL** | 1440px – up | 12 | 32px | 120px |
 
-> **Figma label note (SM columns):** the SM *breakpoint diagram* in Figma is tagged `col: 8`, but that label is stale — the spec table above, the diagram's own drawn columns, and the "Building Layouts" SM example all show **4** columns for SM. Use **4**; the `col: 8` tag is a Figma typo flagged to the design system team.
-
 ### What XS is for
 
 XS exists as a **boundary tier only**. There is no XS Figma frame to design in — SM at 390px is the practical mobile design frame. XS guarantees the grid still resolves below 320px if a viewport ever lands there.

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/spacing.md
@@ -119,7 +119,7 @@ Quick formula: `N` = `N × 8px`, and `N-5` = `N × 8px + 4px` — both of which 
 
 The raw ramp is the layer the **Tailwind config** ships today (e.g., `tw-p-2.5` = 20px). The semantic categories above are not yet exposed in code — see "Outstanding discrepancies."
 
-> **Caveat about the Figma table:** the Spacing Scales & Tokens panel in Figma has typos in the `rem` column from row `10-5` onward (the values appear to have wrapped), and the panel labels the bottom two rows as `16 = 124px` and `16-5 = 128px` when they are actually `15-5` and `16` on the ramp. The shipped `tokens/core/size.json` is authoritative — trust it (and the formula above) over the rendered Figma table.
+> **Authoritative source:** the shipped `tokens/core/size.json` is the canonical source for ramp values — trust it (and the formula above) if the rendered Figma table ever drifts.
 
 ## Best practices
 

--- a/@kiva/kv-skills/design-system/skills/kiva-tailwind-css/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-tailwind-css/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tailwind
+name: kiva-tailwind
 description: How to use Tailwind CSS v3 when it is backed by Kiva's design tokens — what the @kiva/kv-tokens preset changes about stock Tailwind (the tw- prefix, themable colors compiled to CSS custom properties, disabled core plugins, token-driven scales, an opinionated base layer), how to wire the preset into a project, and how the preset is compiled from DTCG tokens. Mechanical and integration-focused; for which token to pick, defer to the per-topic skills (color, spacing, radius, typography, layout).
 when_to_use: When authoring or reviewing Tailwind utility classes in any repo that uses the Kiva preset (kv-components, kiva/ui, and other consumers), when setting up the preset in a new project, when a Tailwind class behaves differently than stock Tailwind would suggest (e.g. tw-text-lg or tw-font-bold "not working"), or when modifying the design-token → Tailwind pipeline inside this monorepo. Read this for how the system works and how to use it; read color/spacing/radius/typography/layout for which value to choose.
 make_kit:


### PR DESCRIPTION
This pull request updates the Kiva Design System skills to improve documentation, clarify installation and update procedures, and correct minor metadata and naming issues. The most significant changes are new installation instructions for the Claude app, improved update guidance, and several clarifications and corrections to skill metadata and documentation.

**Documentation improvements:**

* Added a new section to `README.md` with step-by-step instructions for installing the `kiva-design-system` skill in the Claude app, including folder structure requirements and caveats. Also clarified the distinction between skills intended for Claude app users and developer-oriented skills.
* Expanded the update process documentation in `README.md`, detailing the need to bump the patch version in both plugin manifests and how to refresh and reinstall skills in Claude Code and Codex.
* Clarified that `tokens/core/size.json` is the authoritative source for spacing ramp values, updating prior language about Figma typos in `spacing.md`.
* Removed an outdated note about a Figma label typo in the SM breakpoint diagram from `layout.md`, as the correct value is now clear.

**Metadata and naming corrections:**

* Bumped the skill version from `0.1.0` to `0.1.1` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to reflect these documentation and metadata updates. [[1]](diffhunk://#diff-92ff1a8491fb5fc46a2968c24cf93f33f449c9db9cf9a5a7bb6067f9f9efdd84L4-R4) [[2]](diffhunk://#diff-b6e96a0955f0e8b97213f0cbcd11b50801c2137bf6547935a98c17d280862ef0L3-R3)
* Changed the skill name in `kiva-tailwind-css/SKILL.md` from `tailwind` to `kiva-tailwind` for consistency with naming conventions.
* Condensed and clarified the YAML front matter in `kiva-design-system/SKILL.md` to make the descriptions more concise and actionable.

These changes collectively improve the clarity and usability of the Kiva Design System skills for both end users and developers.