### PR TITLE
feat: allow for anonymous matching organizations

### DIFF
--- a/@kiva/kv-components/src/vue/KvLoanTag.vue
+++ b/@kiva/kv-components/src/vue/KvLoanTag.vue
@@ -16,10 +16,10 @@
 			>
 				<p
 					v-for="org in multiMatchingOrgs"
-					:key="org.displayName"
+					:key="org.managedAccountId"
 					class="tw-m-0"
 				>
-					{{ org.ratio + 1 }}x matching by {{ org.displayName }}
+					{{ org.ratio + 1 }}x matching by {{ org.displayName || 'a Kiva supporter' }}
 				</p>
 			</kv-tooltip>
 		</template>
@@ -61,6 +61,7 @@ export const KV_LOAN_TAG_FRAGMENT = gql`
 		matchRatio
 		matchingText
 		simultaneousMatching {
+			managedAccountId
 			displayName
 			ratio
 		}
@@ -134,7 +135,7 @@ export default {
 					if (this.enableMultiMatching && this.multiMatchingOrgs.length === 1) {
 						const org = this.multiMatchingOrgs[0];
 						// eslint-disable-next-line max-len
-						return `${this.useExpandedStyles ? '🤝 ' : ''}${org.ratio + 1}x matching by ${org.displayName}`;
+						return `${this.useExpandedStyles ? '🤝 ' : ''}${org.ratio + 1}x matching by ${org.displayName || 'a Kiva supporter'}`;
 					}
 					// eslint-disable-next-line max-len
 					return `${this.useExpandedStyles ? '🤝 ' : ''}${this.matchRatio + 1}x matching by ${this.loan?.matchingText}`;

--- a/@kiva/kv-components/src/vue/stories/KvClassicLoanCard.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvClassicLoanCard.stories.js
@@ -180,8 +180,8 @@ export const MultiMatching = story({
 	loan: {
 		...loan,
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'PG&E' },
-			{ ratio: 1, displayName: 'US Bank' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'PG&E' },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 		loanFundraisingInfo: {
 			id: loan.id,

--- a/@kiva/kv-components/src/vue/stories/KvCompactLoanCard.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvCompactLoanCard.stories.js
@@ -202,8 +202,8 @@ export const MultiMatching = story({
 	loan: {
 		...loan,
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'PG&E' },
-			{ ratio: 1, displayName: 'US Bank' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'PG&E' },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 		loanFundraisingInfo: {
 			id: loan.id,

--- a/@kiva/kv-components/src/vue/stories/KvIntroductionLoanCard.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvIntroductionLoanCard.stories.js
@@ -122,8 +122,8 @@ export const MultiMatching = story({
 	loan: {
 		...loan,
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'PG&E' },
-			{ ratio: 1, displayName: 'US Bank' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'PG&E' },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 	},
 	kvTrackFunction,

--- a/@kiva/kv-components/src/vue/stories/KvLoanTag.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvLoanTag.stories.js
@@ -57,8 +57,8 @@ export const MultiMatching = story({
 		loanAmount: 199,
 		loanFundraisingInfo: { fundedAmount: 0, reservedAmount: 0 },
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'PG&E' },
-			{ ratio: 1, displayName: 'US Bank' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'PG&E' },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 	},
 	enableMultiMatching: true,
@@ -71,7 +71,21 @@ export const MultiMatching1Org = story({
 		loanAmount: 199,
 		loanFundraisingInfo: { fundedAmount: 0, reservedAmount: 0 },
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'Bank Of America' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'Bank Of America' },
+		],
+	},
+	enableMultiMatching: true,
+});
+
+export const MultiMatchingAnonymous = story({
+	loan: {
+		id: 1,
+		plannedExpirationDate: nextWeek.toISOString(),
+		loanAmount: 199,
+		loanFundraisingInfo: { fundedAmount: 0, reservedAmount: 0 },
+		simultaneousMatching: [
+			{ managedAccountId: 1, ratio: 1, displayName: null },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 	},
 	enableMultiMatching: true,

--- a/@kiva/kv-components/src/vue/stories/KvWideLoanCard.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvWideLoanCard.stories.js
@@ -132,8 +132,8 @@ export const MultiMatching = story({
 	loan: {
 		...loan,
 		simultaneousMatching: [
-			{ ratio: 1, displayName: 'PG&E' },
-			{ ratio: 1, displayName: 'US Bank' },
+			{ managedAccountId: 1, ratio: 1, displayName: 'PG&E' },
+			{ managedAccountId: 2, ratio: 1, displayName: 'US Bank' },
 		],
 		loanFundraisingInfo: {
 			id: loan.id,


### PR DESCRIPTION
I did not realize that matching organizations can be anonymous, display "a Kiva supporter" in that case, to match the legacy text