### PR TITLE
feat(kv-skills): cit 4431 cit 4432 border elevation skills

### DIFF
--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kiva-design-system
-description: Index and router for the Kiva design-system sub-skills — typography, layout, spacing, radius, border, color, and color-themes. Entry point for any task touching Kiva's visual language — auditing existing code for design-system compliance, generating new UI with correct tokens and Tailwind utilities, answering design-token questions, or performing a Figma-to-code handoff. Routes to the relevant sub-skill(s); load only what the task requires, never all at once.
+description: Index and router for the Kiva design-system sub-skills — typography, layout, spacing, radius, border, elevation, color, and color-themes. Entry point for any task touching Kiva's visual language — auditing existing code for design-system compliance, generating new UI with correct tokens and Tailwind utilities, answering design-token questions, or performing a Figma-to-code handoff. Routes to the relevant sub-skill(s); load only what the task requires, never all at once.
 when_to_use: Invoke when — auditing a component, page, or PR for design-system compliance (wrong token, missing class, incorrect radius, hardcoded color); generating new Vue/HTML/Tailwind code and needing the correct token name, utility class, or component pattern for color, type, spacing, radius, or layout; answering which-token questions (e.g. "right text color for a disabled button in the Marigold theme?"); or handing a Figma design off to code (mapping Figma token and theme names to @kiva/kv-tokens utilities). Trigger phrases — "design system", "kiva token", "tw- class", "which token", "audit", "design compliance", "Figma handoff", "color theme", "type style", "spacing token", "border radius", "layout grid", "breakpoint".
 ---
 
@@ -27,6 +27,7 @@ Load only the sub-skill(s) relevant to the current task. Do not load all of them
 | **spacing** | [spacing.md](spacing.md) | Semantic spacing categories (Structure, Component Gap, Component Inset, Micro), the 4px-grain ramp, responsive per-tier values, and the "between vs. inside" decision for picking a token. |
 | **radius** | [radius.md](radius.md) | Border-radius token scale (`none` → `full`), per-component use cases, the `inner = outer − gap` concentric formula, and the `tw-rounded` = 16px gotcha. |
 | **border** | [border.md](border.md) | Border stroke-weight scale (1px resting → 2px emphasis → dashed → none), the weight-as-signal model, width + color pairing for states, per-component usage recommendations, and `tw-border-*` mappings. |
+| **elevation** | [elevation.md](elevation.md) | Interaction-state shadow tokens (`elevation/default` / `hover` / `click-active`), their exact shadow values, the rest → lift → settle flow, Do/Don't rules, and `tw-shadow-*` mappings. Elevation = interaction state, not depth. |
 
 ---
 
@@ -44,6 +45,7 @@ Load only the sub-skill(s) relevant to the current task. Do not load all of them
 | Answer a token question about space | spacing |
 | Answer a token question about corners | radius |
 | Answer a token question about borders / strokes | border (+ color for the border-color slot) |
+| Answer a token question about shadows / elevation | elevation |
 | Answer a question about the grid / breakpoints | layout |
 | Figma-to-code handoff involving color | color + color-themes |
 | Figma-to-code handoff involving a full component | All sub-skills that the component's design touches |
@@ -55,6 +57,7 @@ Load only the sub-skill(s) relevant to the current task. Do not load all of them
 - **"spacing", "padding", "gap", "margin between"** → spacing
 - **"radius", "rounded", "corner"** → radius
 - **"border", "stroke", "outline", "border width", "tw-border-"** → border (+ color for the border-color slot)
+- **"elevation", "shadow", "drop shadow", "box-shadow", "tw-shadow-", "hover lift"** → elevation
 - **"grid", "column", "breakpoint", "responsive", "layout"** → layout
 
 ---

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kiva-design-system
-description: Index and router for the Kiva design-system sub-skills — typography, layout, spacing, radius, color, and color-themes. Entry point for any task touching Kiva's visual language — auditing existing code for design-system compliance, generating new UI with correct tokens and Tailwind utilities, answering design-token questions, or performing a Figma-to-code handoff. Routes to the relevant sub-skill(s); load only what the task requires, never all at once.
+description: Index and router for the Kiva design-system sub-skills — typography, layout, spacing, radius, border, color, and color-themes. Entry point for any task touching Kiva's visual language — auditing existing code for design-system compliance, generating new UI with correct tokens and Tailwind utilities, answering design-token questions, or performing a Figma-to-code handoff. Routes to the relevant sub-skill(s); load only what the task requires, never all at once.
 when_to_use: Invoke when — auditing a component, page, or PR for design-system compliance (wrong token, missing class, incorrect radius, hardcoded color); generating new Vue/HTML/Tailwind code and needing the correct token name, utility class, or component pattern for color, type, spacing, radius, or layout; answering which-token questions (e.g. "right text color for a disabled button in the Marigold theme?"); or handing a Figma design off to code (mapping Figma token and theme names to @kiva/kv-tokens utilities). Trigger phrases — "design system", "kiva token", "tw- class", "which token", "audit", "design compliance", "Figma handoff", "color theme", "type style", "spacing token", "border radius", "layout grid", "breakpoint".
 ---
 
@@ -16,7 +16,7 @@ This file is the **entry point and router** for the Kiva design system knowledge
 
 ## Sub-skills
 
-Load only the sub-skill(s) relevant to the current task. Do not load all six unless the task genuinely spans all categories.
+Load only the sub-skill(s) relevant to the current task. Do not load all of them unless the task genuinely spans all categories.
 
 | Sub-skill | File | What it covers |
 |---|---|---|
@@ -26,6 +26,7 @@ Load only the sub-skill(s) relevant to the current task. Do not load all six unl
 | **layout** | [layout.md](layout.md) | Breakpoint tiers (XS/SM/MD/LG/XL), column/gutter/margin specs, content max-width rules, nested grids, and rules for aligning content on the grid. |
 | **spacing** | [spacing.md](spacing.md) | Semantic spacing categories (Structure, Component Gap, Component Inset, Micro), the 4px-grain ramp, responsive per-tier values, and the "between vs. inside" decision for picking a token. |
 | **radius** | [radius.md](radius.md) | Border-radius token scale (`none` → `full`), per-component use cases, the `inner = outer − gap` concentric formula, and the `tw-rounded` = 16px gotcha. |
+| **border** | [border.md](border.md) | Border stroke-weight scale (1px resting → 2px emphasis → dashed → none), the weight-as-signal model, width + color pairing for states, per-component usage recommendations, and `tw-border-*` mappings. |
 
 ---
 
@@ -35,13 +36,14 @@ Load only the sub-skill(s) relevant to the current task. Do not load all six unl
 
 | Task | Load these sub-skills |
 |---|---|
-| Audit component for design compliance | color + typography + spacing + radius (the four most commonly violated) |
+| Audit component for design compliance | color + typography + spacing + radius (the four most commonly violated); add border when the component has strokes/states |
 | Audit layout / responsive breakpoints | layout |
 | Generate a new component | Load the sub-skills that match the component's visual categories (color + typography is almost always needed; add spacing, radius, layout as the component requires) |
 | Answer a token question about color | color (+ color-themes if a specific theme's values are needed) |
 | Answer a token question about type | typography |
 | Answer a token question about space | spacing |
 | Answer a token question about corners | radius |
+| Answer a token question about borders / strokes | border (+ color for the border-color slot) |
 | Answer a question about the grid / breakpoints | layout |
 | Figma-to-code handoff involving color | color + color-themes |
 | Figma-to-code handoff involving a full component | All sub-skills that the component's design touches |
@@ -52,6 +54,7 @@ Load only the sub-skill(s) relevant to the current task. Do not load all six unl
 - **"font", "heading", "type style", "text size", "tw-text-"** → typography
 - **"spacing", "padding", "gap", "margin between"** → spacing
 - **"radius", "rounded", "corner"** → radius
+- **"border", "stroke", "outline", "border width", "tw-border-"** → border (+ color for the border-color slot)
 - **"grid", "column", "breakpoint", "responsive", "layout"** → layout
 
 ---

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/border.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/border.md
@@ -1,0 +1,129 @@
+---
+name: border
+description: Border token system from the Kiva design system — the stroke-weight scale (1px resting / hover / active, 2px emphasis, 2px dashed, none) paired with semantic border colors, the weight-as-signal model, per-component usage recommendations, and Do/Don't rules. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing any UI element with a stroke — form inputs, dropdowns, cards, secondary buttons, selected/error states, empty-state placeholders, dividers. Use it whenever someone reaches for a raw border-width value, picks a `tw-border-*` utility, signals selection or error with a border, or chooses between solid and dashed. Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 70
+---
+
+# Kiva Border
+
+## Source of truth
+
+This skill captures the **border system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which width and style tokens exist, what each communicates, and how to choose between them for any given component state.
+
+Numeric values, token names, and class references in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any token reference against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps.
+
+## About
+
+Borders help organize and emphasize interface elements through a combination of **width** and **color** tokens. Width defines the level of visual emphasis, while color provides contextual meaning. Together, these tokens help define purposes such as separation, hierarchy, and interactive states.
+
+A border is two decisions, not one: pick a **width** from the scale below for the level of emphasis, and pair it with a semantic **border color** (from the [color](color.md) system) for the contextual meaning. Width without the right color reads as noise; color without the right width can be missed.
+
+Common alternative names you may see used interchangeably: **stroke**, **outline**, **border width**.
+
+## Design principles
+
+1. **Weight as signal.** Border weight communicates state. 1px = resting, 2px = active / selected / error. Never use heavy borders on resting elements.
+2. **Style discipline.** Solid borders for all filled content. Dashed borders exclusively for empty / unearned states. Never mix styles in the same component.
+3. **Token-first.** Always reference the token, never hardcode pixel values. Interactive states use `--border-hover` and `--border-active` for subtle visual feedback.
+
+## The scale
+
+Border weight is the emphasis dial. Pick the width by the element's **state**, not by eyeballing a stroke.
+
+| Token | Width | Style | What it signals |
+|---|---|---|---|
+| **default** | 1px | solid | Resting state — the baseline for all standard bordered elements |
+| **hover** | 1px | solid | Pointer hover on an interactive element — subtle feedback |
+| **active** | 1px | solid | Active / focus interaction — subtle feedback |
+| **emphasis** | 2px | solid | Selected, error, or open state — the element is "lit up" |
+| **dashed** | 2px | dashed | Empty / unearned placeholder containers only |
+| **none** | 0 | none | Filled elements that carry their emphasis through fill, not stroke (e.g. primary buttons) |
+
+Hover and active share the **1px** resting width — they differ from `default` by **color** (`--border-hover` / `--border-active`), not weight. The only width step up the scale is **2px** for emphasis. Width alone has just two live values: 1px and 2px.
+
+## Usage recommendations
+
+The canonical width-token → component-state mapping, pairing each width with the semantic border color it's meant to carry.
+
+| Width | Border color token(s) | Use cases |
+|---|---|---|
+| **1px** | `--border-default` | Form input (entered), dropdown, secondary button, card |
+| **1px** | `--border-secondary-disabled` | Disabled input |
+| **1px** | `--border-hover`, `--border-active` | Input hover, active interaction |
+| **2px** | emphasis — `--border-action` (selected) / danger (error) | Selected card, error input, open dropdown |
+| **2px dashed** | empty state | Empty badge / placeholder container |
+| **none** | `border: none` | Primary button |
+
+Selected states pair the **2px** weight with `--border-action`; error states pair **2px** with the danger border color. The weight change is what makes the signal survive for users who can't rely on color alone (see Best Practices, below).
+
+## Best practices
+
+### Keep resting elements light
+
+- **Do** use 1px (`--border-default`) for all resting form controls. Lightweight borders keep the UI clean and let content lead.
+- **Don't** use 2px or thicker borders on resting elements. Heavy borders at rest compete with content and create visual noise.
+
+### Pair weight with color for state changes
+
+- **Do** use 2px with `border-action` for selected states. The combined weight + color change ensures the selection signal is never color-only.
+- **Don't** signal selection with a color change alone at the same weight. Users with low vision may miss a color-only shift. Always pair weight + color.
+
+### Reserve dashed borders for emptiness
+
+- **Do** use dashed borders only for empty / unearned placeholder containers. The dashed pattern signals "content goes here" at a glance.
+- **Don't** use dashed borders on filled content containers. Dashed borders imply emptiness, which contradicts the presence of content inside.
+
+## How to use in Figma
+
+Border width and border color are published as variables in the Kiva Ecosystem library. When applying a border:
+
+- Bind the stroke weight to the border-width variable and the stroke color to the border-color variable instead of typing raw values.
+- Hover a variable to see its value and intended use cases.
+- Solid vs. dashed is a style decision, not a width decision — keep the style consistent within a single component.
+- Before handoff, inspect the frame: if the stroke shows a raw number or hex instead of a variable name, **re-bind it from the library**. A raw value is a detached decision that won't follow updates and leaves developers without a token to map to.
+
+## Using with Tailwind
+
+Border utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered the preset yet? See the **kiva-tailwind-css** skill (kiva-design-to-code plugin) → "Consuming the preset". Not using the preset at all? See [Without the preset](#without-the-preset) below.
+
+A border in code is the same two decisions as in Figma — **width** and **color** — expressed as separate utilities:
+
+- **Width** — `tw-border` (the bare class) is the `DEFAULT` 1px resting weight; `tw-border-2` is the 2px emphasis weight. Reach for `tw-border` on resting elements and `tw-border-2` for selected / error / open states, mirroring the [scale](#the-scale) above.
+- **Style** — dashed comes from stock Tailwind's `tw-border-dashed`; pair it with `tw-border-2` for the 2px-dashed empty-state treatment. Solid is the default and needs no class.
+- **Color** — apply a semantic border color with `tw-border-{slot}` (e.g. `tw-border-action` for selected, a danger slot for error). These are the same themable color slots documented in the [color](color.md) skill — never a hex value or a raw primitive.
+
+**Shipped today** (verify against `@kiva/kv-tokens/configs/tailwind.config.js → theme.borderWidth` and the semantic `border` color block before depending):
+
+- `tw-border` → `1px` (the `DEFAULT` key, the only width sourced from `tokens/core/size.json → border-width.default`)
+- `tw-border-0` → `0px`, `tw-border-2` → `2px`, `tw-border-4` → `4px`, `tw-border-8` → `8px` (these four are hardcoded in the preset, **not** token-sourced)
+- Border **colors** ship as the semantic slots `primary`, `primary-inverse`, `secondary`, `tertiary`, `action`, `action-highlight`, `caution`, `caution-highlight`, `danger`, `danger-highlight` — each exposed as `tw-border-{slot}` and themed per active theme.
+
+Resting, hover, and active all use the same 1px width (`tw-border`); they differ only by border color. The single width step up the scale is `tw-border-2` for emphasis — see "Outstanding discrepancies" for what is and isn't token-backed.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — the **kiva-tailwind-css** skill (kiva-design-to-code plugin) → "Consuming the preset". Until then, arbitrary values (`border-[2px]`) are a stopgap.
+- **Stock-Tailwind / non-Kiva project:** replicate the intent from the [scale](#the-scale) — `border` (1px), `border-2` (2px), `border-dashed` — and pull border colors from `@kiva/kv-tokens/css` (the `--border-*` custom properties) so runtime theming is preserved. Hardcoded hex values are a point-in-time copy and lose theming; re-check them if the tokens change.
+
+## Outstanding discrepancies
+
+- **Border *width* is almost entirely un-tokenized in code.** Only `border-width.default` (1px) exists in `tokens/core/size.json`; the `tw-border-0/2/4/8` steps are hardcoded in the Tailwind preset. The 2px emphasis weight is only available via the hardcoded `tw-border-2`, not a named token. Closing this means adding an `emphasis` width token (2px) to the core size scale.
+- **Border *color* tokens referenced in Figma that don't ship yet.** The Usage Recommendations panel names these color slots; the shipped semantic `border` block only includes `action`:
+  - `--border-default`
+  - `--border-hover`
+  - `--border-active`
+  - `--border-secondary-disabled`
+
+When you find a divergence from the shipped tokens, flag it — each is a data point for the design-system team.
+
+## Figma source references
+
+- Border Overview: node `19661:2006` (scale strip, About, design principles)
+- Border Scale: node `19661:2006` (same panel as Overview)
+- Border Guidelines: node `19661:1774` (Best Practices, Usage Recommendations)
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)

--- a/@kiva/kv-skills/design-system/skills/kiva-design-system/elevation.md
+++ b/@kiva/kv-skills/design-system/skills/kiva-design-system/elevation.md
@@ -1,0 +1,118 @@
+---
+name: elevation
+description: Elevation (shadow) token system from the Kiva design system — the three interaction-state shadow tokens (elevation/default, elevation/hover, elevation/click-active), their exact shadow values, the rest → lift → settle interaction flow, Do/Don't usage rules, and the `tw-shadow-*` mappings. In Kiva, elevation communicates interaction state, not depth or layering. Sourced from Figma; values describe design intent and may diverge from current code implementation.
+when_to_use: When designing or implementing shadows on interactive surfaces — cards, banners, tiles, buttons, anything that lifts on hover or settles on click. Use it whenever someone reaches for a one-off `box-shadow`, picks a `tw-shadow-*` utility, needs the resting / hover / active shadow for a component, or is deciding whether a shadow should convey interaction state (yes) versus depth or stacking (no — that's out of scope). Reference design intent first; verify token names against current code before relying on them.
+make_kit:
+  include: true
+  category: foundations
+  order: 80
+---
+
+# Kiva Elevation
+
+## Source of truth
+
+This skill captures the **elevation system** as defined in Figma (the Kiva Ecosystem 2026 file). Figma is the canonical source for design intent: which shadow tokens exist, the exact value of each, what interaction state each represents, and how to choose between them.
+
+Numeric values, token names, and class references in this document reflect the Figma specifications. The shipped code in `@kiva/kv-tokens` may temporarily lag behind these specs while the token sync work is in progress. **Verify any token reference against the current code before depending on it.** See "Outstanding discrepancies" at the end of this skill for known gaps.
+
+## About
+
+Elevation uses shadow to communicate interactive surface states. It helps users understand when a surface is available for interaction, responding to attention, or actively engaged.
+
+Kiva uses elevation to communicate **interaction states**, not page hierarchy, z-index, or layer depth.
+
+Common alternative names you may see used interchangeably: **shadows**, **drop shadows**, **shadow tokens**.
+
+## Design principles
+
+1. **State over depth.** In Kiva, elevation communicates interaction state rather than physical depth. Shadows help users understand when a surface is available, hovered, or active.
+2. **Token-first.** Use an elevation token instead of creating a one-off shadow. Tokens keep shadows consistent across Figma, Storybook, and code. Avoid adjusting blur, opacity, spread, or direction manually unless the design system introduces a new token.
+3. **Elevation is not layering.** The new elevation guidance focuses on semantic interaction states. Some existing components may still use shadow for layering or surface separation. Those current uses are outside this interactive elevation guidance and can remain until overlay / layering guidance is defined separately.
+
+## Shadow tokens
+
+Three tokens, one per interaction state. All are drop shadows in pure black (`#000000`) with the opacity — not the color — doing the work. Pick by **what the surface is doing**, not by eyeballing a shadow.
+
+| Token | Type | X | Y | Blur | Opacity | Color | Purpose |
+|---|---|---|---|---|---|---|---|
+| **elevation/default** | Drop shadow | 0px | 4px | 12px | 8% | #000000 | Shows an interactive surface is available |
+| **elevation/hover** | Drop shadow | 0px | 4px | 16px | 16% | #000000 | Confirms the surface is responding to the pointer |
+| **elevation/click-active** | Drop shadow | 0px | 4px | 12px | 8% | #000000 | Shows the surface has settled after interaction |
+
+> **Same value, different state.** `elevation/default` and `elevation/click-active` currently share the same shadow value (`0 4px 12px` at 8%), but they represent different moments in the interaction cycle. **Default** means the surface is ready to use. **Click/active** means the surface has responded and settled after interaction. Keep both token names in use even though the value is identical today — they may diverge, and the name documents intent.
+
+## Interaction flow
+
+Elevation states follow a simple flow: the surface starts at rest, lifts on hover, and settles after click or activation.
+
+> **Rest** (`elevation/default`) → **Lift** (`elevation/hover`) → **Settle** (`elevation/click-active`)
+
+The hover state is the only "lifted" step — its larger blur (16px) and doubled opacity (16%) read as the surface rising toward the pointer. On settle, it returns to the resting shadow value.
+
+## Best practices
+
+### Support interactivity
+
+- **Do** apply elevation to surfaces that respond to user input. Shadow acts as a tactile affordance, helping users understand that the surface is interactive.
+- **Don't** use elevation on static or decorative elements. Shadows can create a false affordance and make users think a surface is clickable.
+
+### Show responsive feedback
+
+- **Do** use `elevation/hover` to confirm interactivity when the pointer enters a surface. The visual lift helps users understand that the element is responsive.
+- **Don't** leave hover and resting states visually identical for elevated interactive surfaces. Without a visible response, users may second-guess whether the element is clickable.
+
+### Keep sibling surfaces equal
+
+- **Do** use consistent elevation for sibling surfaces. Equal shadows help users understand that items share the same level of importance and interaction.
+- **Don't** mix shadow depths within a group to create emphasis. This breaks the rhythm of the layout and can make one surface feel more interactive or important than its peers.
+
+## How to use in Figma
+
+Elevation tokens are published as effect styles / variables in the Kiva Ecosystem library, named by interaction state (`elevation/default`, `elevation/hover`, `elevation/click-active`).
+
+- Apply the named elevation style rather than typing blur / opacity / offset values by hand.
+- Don't adjust blur, spread, opacity, or direction on an applied token — if a surface needs something the three tokens don't cover, that's a design-system conversation, not a one-off.
+- Before handoff, inspect the layer: if the effect shows raw values instead of a named elevation style, **re-bind it from the library** so developers have a token to map to.
+
+## Using with Tailwind
+
+Shadow utilities come from the `@kiva/kv-tokens` Tailwind preset. Haven't registered the preset yet? See the **kiva-tailwind-css** skill (kiva-design-to-code plugin) → "Consuming the preset". Not using the preset at all? See [Without the preset](#without-the-preset) below.
+
+There are **no semantic `elevation/*` utilities yet** — the elevation tokens are named by interaction state, but the preset only ships generic `tw-shadow` utilities. The mappings below are the temporary implementation bridge Figma specifies until dedicated semantic elevation utilities are added.
+
+| Elevation token | Tailwind utility | Status |
+|---|---|---|
+| `elevation/default` | `tw-shadow-lg` | Ships — exact match (`0 4px 12px` at 8%) |
+| `elevation/hover` | `tw-shadow-xl` | **Proposed — not shipped.** No utility currently produces the `0 4px 16px` at 16% hover shadow |
+| `elevation/click-active` | `tw-shadow-lg` | Ships — same value as default |
+
+`tw-shadow-default` (the bare `tw-shadow`, `0 1px 4px` at 8%) is **not part of the elevation model** — the preset's default shadow is lighter than `elevation/default` and isn't one of the three semantic states. Don't reach for it when you mean an interaction-state shadow.
+
+**Shipped today** (verify against `@kiva/kv-tokens/configs/tailwind.config.js → theme.boxShadow` before depending):
+
+- `tw-shadow` → `0 1px 4px 0 rgb(0 0 0 / 0.08)` (the `DEFAULT` key)
+- `tw-shadow-lg` → `0 4px 12px rgba(0, 0, 0, 0.08)` (matches `elevation/default` / `elevation/click-active`)
+
+Because `boxShadow` is set on `theme` (not `theme.extend`), it **replaces** the stock Tailwind shadow scale — `tw-shadow-sm`, `tw-shadow-md`, `tw-shadow-xl`, `tw-shadow-2xl`, and `tw-shadow-inner` do **not** exist in this preset. Only `tw-shadow` and `tw-shadow-lg` are available.
+
+### Without the preset
+
+- **Kiva (or Kiva-adjacent) repo, preset not registered yet:** install and register it — the **kiva-tailwind-css** skill (kiva-design-to-code plugin) → "Consuming the preset". Until then, arbitrary values (`shadow-[0_4px_12px_rgba(0,0,0,0.08)]`) are a stopgap.
+- **Stock-Tailwind / non-Kiva project:** replicate the intent from the [shadow tokens table](#shadow-tokens) as arbitrary values — `elevation/default` and `elevation/click-active` are `shadow-[0_4px_12px_rgba(0,0,0,0.08)]`; `elevation/hover` is `shadow-[0_4px_16px_rgba(0,0,0,0.16)]`. These are point-in-time copies of the token values; re-check them if the tokens change.
+
+## Outstanding discrepancies
+
+- **Shadows are not tokenized in the JSON token source.** The `boxShadow` scale is hardcoded directly in `configs/tailwind.config.js`; there are no shadow entries in `tokens/core/*.json`. A sync gap worth closing so elevation flows from tokens like the rest of the system.
+- **No semantic `elevation/*` utilities ship.** The Figma tokens are named by interaction state, but code only has generic `tw-shadow` / `tw-shadow-lg`. Adding `tw-shadow-elevation-default` / `-hover` / `-click-active` (or equivalent) would close the naming gap; the Figma panel explicitly frames the current generic utilities as "temporary implementation mappings until dedicated semantic elevation utilities are added."
+- **`elevation/hover` has no shipped utility.** Its value (`0 4px 16px` at 16%) maps to a *proposed* `tw-shadow-xl` that does not exist in the preset. Until it's added, the hover elevation can only be expressed via an arbitrary value.
+
+When you find a divergence from the shipped tokens, flag it — each is a data point for the design-system team.
+
+## Figma source references
+
+- Elevation Overview: node `19910:612` (scale strip, About, design principles)
+- Elevation Tokens & Values: node `19910:468` (shadow tokens table, interaction flow, Tailwind mapping)
+- Elevation Guidelines: node `19910:353` (Best Practices — Support interactivity / Show responsive feedback / Keep sibling surfaces equal)
+
+File: `TPmBUB4olYPMF6glEhBGDG` (Ecosystem 2026 — WIP)


### PR DESCRIPTION
Adds two new sub-skills to the kiva-design-system skill, extracted 1:1 from the Figma Ecosystem 2026 panels.

- Border (border.md, CIT-4431) — stroke-weight scale (1px resting/hover/active, 2px emphasis, 2px dashed, none), weight-as-signal model, width + color pairing, per-component usage recommendations, and tw-border-* mappings.
- Elevation (elevation.md, CIT-4432) — interaction-state shadow tokens (elevation/default / hover / click-active), exact shadow values, the rest → lift → settle flow, Do/Don't rules, and tw-shadow-* mappings.

Both are wired into the index (SKILL.md): sub-skills table, routing rules, and keyword list. Each flags current Figma-vs-code sync gaps in its "Outstanding discrepancies" section.