### PR TITLE
feat(kv-components): add size prop to KvButton (CIT-4437)

### DIFF
--- a/@kiva/kv-components/src/vue/KvButton.vue
+++ b/@kiva/kv-components/src/vue/KvButton.vue
@@ -103,12 +103,12 @@ export default {
 		 * `default, small`
 		 *
 		 * `default` renders a 48px tall button (`tw-min-h-6`) with 24px of
-		 * horizontal padding (`tw-px-3`), a 16px corner radius (`tw-rounded`),
-		 * and the button-link text style (`tw-text-button-link`). `small`
-		 * renders a 32px tall button (`tw-min-h-4`) with 16px of horizontal
-		 * padding (`tw-px-2`), a smaller 8px corner radius (`tw-rounded-sm`),
-		 * and the label text style (`tw-text-label`). Height is controlled by
-		 * the min-height and vertical centering rather than vertical padding.
+		 * horizontal and vertical padding (`tw-py-1 tw-px-3`), a 16px corner
+		 * radius (`tw-rounded`), and inherits the surrounding text style.
+		 * `small` renders a 32px tall button (`tw-min-h-4`) with 16px of
+		 * horizontal padding and smaller vertical padding (`tw-py-0.5 tw-px-2`),
+		 * a smaller 8px corner radius (`tw-rounded-sm`), and the label text
+		 * style (`tw-text-label`).
 		 */
 		size: {
 			type: String,

--- a/@kiva/kv-components/src/vue/KvButton.vue
+++ b/@kiva/kv-components/src/vue/KvButton.vue
@@ -15,9 +15,9 @@
 		<!-- eslint-disable max-len -->
 		<span
 			ref="buttonInnerRef"
-			class="tw-inline-flex tw-w-full tw-justify-center tw-items-center tw-rounded
-				tw-min-h-6 tw-relative tw-overflow-hidden tw-border tw-font-medium tw-text-center"
-			:class="computedClass"
+			class="tw-inline-flex tw-w-full tw-justify-center tw-items-center
+				tw-relative tw-overflow-hidden tw-border tw-font-medium tw-text-center"
+			:class="[computedClass, heightClass, roundedClass]"
 		>
 			<!-- eslint-enable max-len -->
 			<template v-if="state === 'loading'">
@@ -27,8 +27,8 @@
 				/>
 			</template>
 			<span
-				class="tw-py-1 tw-px-3 tw-z-10"
-				:class="{ 'tw-invisible': state === 'loading' }"
+				class="tw-z-10"
+				:class="[paddingClass, textClass, { 'tw-invisible': state === 'loading' }]"
 			>
 				<slot></slot>
 			</span>
@@ -98,6 +98,25 @@ export default {
 				return ['', 'active', 'disabled', 'loading'].includes(value);
 			},
 		},
+		/**
+		 * Size of the button
+		 * `default, small`
+		 *
+		 * `default` renders a 48px tall button (`tw-min-h-6`) with 24px of
+		 * horizontal padding (`tw-px-3`), a 16px corner radius (`tw-rounded`),
+		 * and the button-link text style (`tw-text-button-link`). `small`
+		 * renders a 32px tall button (`tw-min-h-4`) with 16px of horizontal
+		 * padding (`tw-px-2`), a smaller 8px corner radius (`tw-rounded-sm`),
+		 * and the label text style (`tw-text-label`). Height is controlled by
+		 * the min-height and vertical centering rather than vertical padding.
+		 */
+		size: {
+			type: String,
+			default: 'default',
+			validator(value: string) {
+				return ['default', 'small'].includes(value);
+			},
+		},
 	},
 	emits: [
 		'click',
@@ -109,7 +128,15 @@ export default {
 			type,
 			variant,
 			state,
+			size,
 		} = toRefs(props);
+
+		// `default` keeps the original 48px height / 24px horizontal padding / 16px radius,
+		// `small` renders a 32px tall button with 16px horizontal padding and an 8px radius.
+		const heightClass = computed(() => (size.value === 'small' ? 'tw-min-h-4' : 'tw-min-h-6'));
+		const paddingClass = computed(() => (size.value === 'small' ? 'tw-px-2' : 'tw-px-3'));
+		const roundedClass = computed(() => (size.value === 'small' ? 'tw-rounded-sm' : 'tw-rounded'));
+		const textClass = computed(() => (size.value === 'small' ? 'tw-text-label' : 'tw-text-button-link'));
 
 		const loadingColor = computed(() => {
 			switch (variant.value) {
@@ -278,10 +305,14 @@ export default {
 			buttonInnerRef,
 			computedClass,
 			computedType,
+			heightClass,
 			isDisabled,
 			loadingColor,
 			onClick,
+			paddingClass,
+			roundedClass,
 			tag,
+			textClass,
 		};
 	},
 };

--- a/@kiva/kv-components/src/vue/KvButton.vue
+++ b/@kiva/kv-components/src/vue/KvButton.vue
@@ -134,9 +134,9 @@ export default {
 		// `default` keeps the original 48px height / 24px horizontal padding / 16px radius,
 		// `small` renders a 32px tall button with 16px horizontal padding and an 8px radius.
 		const heightClass = computed(() => (size.value === 'small' ? 'tw-min-h-4' : 'tw-min-h-6'));
-		const paddingClass = computed(() => (size.value === 'small' ? 'tw-px-2' : 'tw-px-3'));
+		const paddingClass = computed(() => (size.value === 'small' ? 'tw-py-0.5 tw-px-2' : 'tw-py-1 tw-px-3'));
 		const roundedClass = computed(() => (size.value === 'small' ? 'tw-rounded-sm' : 'tw-rounded'));
-		const textClass = computed(() => (size.value === 'small' ? 'tw-text-label' : 'tw-text-button-link'));
+		const textClass = computed(() => (size.value === 'small' ? 'tw-text-label' : ''));
 
 		const loadingColor = computed(() => {
 			switch (variant.value) {

--- a/@kiva/kv-components/src/vue/stories/KvButton.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvButton.stories.js
@@ -1,8 +1,22 @@
+import {
+	mdiChevronRight,
+	mdiLink,
+	mdiExportVariant,
+	mdiPencil,
+} from '@mdi/js';
 import KvButton from '../KvButton.vue';
+import KvMaterialIcon from '../KvMaterialIcon.vue';
+import KvButtonDocsMdx from './KvButtonDocs.mdx';
 
 export default {
 	title: 'Forms/KvButton',
 	component: KvButton,
+	parameters: {
+		docs: {
+			page: KvButtonDocsMdx,
+			title: 'Kv Button Docs',
+		},
+	},
 	argTypes: {
 		variant: {
 			control: 'select',
@@ -10,7 +24,11 @@ export default {
 		},
 		state: {
 			control: 'select',
-			options: ['', 'disabled', 'loading'],
+			options: ['', 'active', 'disabled', 'loading'],
+		},
+		size: {
+			control: 'select',
+			options: ['default', 'small'],
 		},
 	},
 };
@@ -140,3 +158,164 @@ export const FullWidth = (args, { argTypes }) => ({
 		onClick(e) { console.log(e); },
 	},
 });
+
+// ---------------------------------------------------------------------------
+// CSF3 stories below support the MDX documentation (KvButtonDocs.mdx).
+// The CSF2 stories above are preserved for backwards compatibility.
+// ---------------------------------------------------------------------------
+
+// Component Overview - Simple examples showing the primary button at each size
+export const ComponentOverview = {
+	render: () => ({
+		components: { KvButton },
+		template: `
+			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
+				<div class="tw-flex tw-gap-8 tw-items-center tw-justify-center">
+					<div class="tw-text-center">
+						<kv-button variant="primary" size="default">Find a borrower</kv-button>
+						<p class="tw-text-small tw-mt-2">Default (48px)</p>
+					</div>
+					<div class="tw-text-center">
+						<kv-button variant="primary" size="small">Find a borrower</kv-button>
+						<p class="tw-text-small tw-mt-2">Small (32px)</p>
+					</div>
+					<div class="tw-text-center">
+						<kv-button variant="secondary" size="default">Find a borrower</kv-button>
+						<p class="tw-text-small tw-mt-2">Secondary</p>
+					</div>
+				</div>
+			</div>
+		`,
+	}),
+};
+
+// All Variations - Every variant rendered at both the default and small size
+export const AllVariations = {
+	render: () => ({
+		components: { KvButton },
+		setup() {
+			return {
+				variants: ['primary', 'secondary', 'link', 'danger', 'ghost', 'caution'],
+			};
+		},
+		template: `
+			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
+				<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-8">
+					<div>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Default (48px)</h3>
+						<ul class="tw-space-y-2">
+							<li v-for="variant in variants" :key="'default-' + variant">
+								<kv-button :variant="variant" size="default">{{ variant }}</kv-button>
+							</li>
+						</ul>
+					</div>
+					<div>
+						<h3 class="tw-text-upper tw-mb-4 tw-font-medium">Small (32px)</h3>
+						<ul class="tw-space-y-2">
+							<li v-for="variant in variants" :key="'small-' + variant">
+								<kv-button :variant="variant" size="small">{{ variant }}</kv-button>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		`,
+	}),
+};
+
+// Button Sizes - Demonstrates the size prop (default vs small)
+export const ButtonSizes = {
+	render: () => ({
+		components: { KvButton },
+		template: `
+			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
+				<p class="tw-text-primary tw-text-small tw-mb-4">
+					The <code>size</code> prop controls the button's height, horizontal padding, corner radius, and text style.
+					<strong>default</strong> is 48px tall with 24px of horizontal padding, a 16px corner radius, and the button-link text style;
+					<strong>small</strong> is 32px tall with 16px of horizontal padding, a smaller 8px corner radius, and the label text style.
+				</p>
+				<div class="tw-flex tw-gap-8 tw-items-center">
+					<div class="tw-text-center">
+						<kv-button variant="primary" size="default">Find a borrower</kv-button>
+						<p class="tw-text-small tw-mt-2">size="default"</p>
+					</div>
+					<div class="tw-text-center">
+						<kv-button variant="primary" size="small">Find a borrower</kv-button>
+						<p class="tw-text-small tw-mt-2">size="small"</p>
+					</div>
+				</div>
+			</div>
+		`,
+	}),
+};
+
+// With Icons - shows KvMaterialIcon alongside the label across both sizes,
+// using the inner flex wrapper to control alignment and spacing.
+export const WithIcons = {
+	render: () => ({
+		components: { KvButton, KvMaterialIcon },
+		setup() {
+			return {
+				sizes: ['default', 'small'],
+				icons: [
+					{ name: 'Chevron Right', icon: mdiChevronRight },
+					{ name: 'Link', icon: mdiLink },
+					{ name: 'Export', icon: mdiExportVariant },
+					{ name: 'Pencil', icon: mdiPencil },
+				],
+			};
+		},
+		template: `
+			<div class="tw-bg-gray-50 tw-rounded-md tw-p-8">
+				<p class="tw-text-primary tw-text-small tw-mb-4">
+					The label and icon are wrapped in a flex container
+					(<code>tw-inline-flex tw-items-center tw-gap-1</code>) to control alignment and spacing.
+				</p>
+				<div v-for="size in sizes" :key="size" class="tw-mb-4">
+					<p class="tw-text-small tw-mb-2 tw-font-medium">size="{{ size }}"</p>
+					<div class="tw-flex tw-flex-wrap tw-gap-3 tw-items-center">
+						<kv-button
+							v-for="item in icons"
+							:key="size + '-' + item.name"
+							variant="primary"
+							:size="size"
+						>
+							<span class="tw-inline-flex tw-items-center tw-justify-center tw-gap-1">
+								{{ item.name }}
+								<kv-material-icon :icon="item.icon" class="tw-w-2.5 tw-h-2.5" />
+							</span>
+						</kv-button>
+					</div>
+				</div>
+			</div>
+		`,
+	}),
+};
+
+// Default story - interactive playground with all props
+export const Default = {
+	args: {
+		variant: 'primary',
+		state: '',
+		size: 'default',
+	},
+	render: (args) => ({
+		components: { KvButton },
+		setup() { return { args }; },
+		template: `
+			<div class="tw-bg-gray-50 tw-rounded-md tw-p-6 tw-inline-block">
+				<kv-button
+					:variant="args.variant"
+					:state="args.state"
+					:size="args.size"
+					@click="onClick"
+				>
+					Find a borrower
+				</kv-button>
+			</div>
+		`,
+		methods: {
+			onClick(e) { console.log('Button clicked', e); },
+		},
+	}),
+};

--- a/@kiva/kv-components/src/vue/stories/KvButton.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvButton.stories.js
@@ -282,7 +282,10 @@ export const WithIcons = {
 						>
 							<span class="tw-inline-flex tw-items-center tw-justify-center tw-gap-1">
 								{{ item.name }}
-								<kv-material-icon :icon="item.icon" class="tw-w-2.5 tw-h-2.5" />
+								<kv-material-icon
+									:icon="item.icon"
+									:class="size === 'small' ? 'tw-w-2 tw-h-2' : 'tw-w-2.5 tw-h-2.5'"
+								/>
 							</span>
 						</kv-button>
 					</div>

--- a/@kiva/kv-components/src/vue/stories/KvButtonDocs.mdx
+++ b/@kiva/kv-components/src/vue/stories/KvButtonDocs.mdx
@@ -136,6 +136,16 @@ KvButton ships in two sizes. The `default` size is 48px tall with 24px of horizo
 		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#c62828'}}>✗ Don't</div>
 		<p style={{fontSize: '0.875rem', margin: 0}}>Place multiple competing primary buttons next to each other, which dilutes the call to action.</p>
 	</div>
+
+	<div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#2e7d32'}}>✓ Do</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Size icons to match the button — use <code>tw-w-2 tw-h-2</code> (16px) in <code>small</code> buttons and <code>tw-w-2.5 tw-h-2.5</code> (20px) in default buttons. For large buttons you may step up to <code>tw-w-3 tw-h-3</code> (24px) when it looks good.</p>
+	</div>
+
+	<div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#c62828'}}>✗ Don't</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Reuse the 20px default icon size inside a small button, which makes the icon look oversized next to the smaller label.</p>
+	</div>
 </div>
 
 ---

--- a/@kiva/kv-components/src/vue/stories/KvButtonDocs.mdx
+++ b/@kiva/kv-components/src/vue/stories/KvButtonDocs.mdx
@@ -1,0 +1,195 @@
+import { Canvas, Meta, Story, Controls } from '@storybook/addon-docs/blocks';
+import * as KvButtonStories from './KvButton.stories.js';
+
+<Meta title="Forms/KvButton" component={KvButtonStories.Component} />
+
+# KvButton
+
+An accessible, themeable button for triggering actions and navigation, available in multiple visual variants and two sizes.
+
+## Component Overview
+
+KvButton is the primary call-to-action element across Kiva's interfaces. It renders as a `<button>`, an `<a>`, or a `router-link` depending on the props provided, and supports a range of visual variants, interaction states, and two sizes (`default` and `small`).
+
+<Story of={KvButtonStories.ComponentOverview} />
+
+## Table of Contents
+
+- [Variations](#variations)
+- [Usage Information](#usage-information)
+- [Behavior](#behavior)
+- [Anatomy](#anatomy)
+- [Specs](#specs)
+- [Best Practices](#best-practices)
+- [Accessibility](#accessibility)
+- [Component Properties + Demo](#component-properties)
+- [Code Examples](#code-examples)
+
+---
+
+## Variations
+
+KvButton supports six visual variants — `primary`, `secondary`, `link`, `danger`, `ghost`, and `caution` — each available in the `default` (48px tall) and `small` (32px tall) sizes.
+
+<Story of={KvButtonStories.AllVariations} />
+
+## Usage Information
+
+Use KvButton for the primary and secondary actions in a view, such as submitting a form, advancing a flow, or navigating to a key destination. Choose the variant that matches the action's emphasis, and the size that fits the surrounding density.
+
+### When to Use
+
+- For primary and secondary actions that need clear emphasis
+- To submit forms or trigger an in-page action
+- For prominent navigation links styled as buttons
+- When you need a compact action (`small`) inside dense UI such as cards, table rows, or toolbars
+
+### When Not to Use
+
+- For icon-only actions — use `KvIconButton` instead
+- For inline, text-style links within body copy — use `KvTextLink`
+- For low-emphasis, tertiary actions where a full button would be visually heavy
+
+---
+
+## Behavior
+
+KvButton communicates interaction through its `state` prop and adapts its footprint through its `size` prop.
+
+### Button States
+
+The `state` prop controls the button's appearance and interactivity: the default empty state, `active`, `disabled`, and `loading`. In the `loading` state the label is hidden, a spinner is shown, and the button is non-interactive.
+
+<Story of={KvButtonStories.StateLoading} />
+
+### Button Sizes
+
+The `size` prop offers two options. `default` renders the original 48px-tall button with 24px of horizontal padding, a 16px corner radius, and the button-link text style (`tw-min-h-6` / `tw-px-3` / `tw-rounded` / `tw-text-button-link`). `small` renders a 32px-tall button with 16px of horizontal padding, a smaller 8px corner radius, and the label text style (`tw-min-h-4` / `tw-px-2` / `tw-rounded-sm` / `tw-text-label`), for use in denser layouts. Height comes from the min-height and vertical centering, so the two sizes stay pixel-accurate without vertical padding.
+
+<Story of={KvButtonStories.ButtonSizes} />
+
+### With Icons
+
+A `KvMaterialIcon` can be rendered alongside the label for both sizes. Wrap the label and icon in a flex container (`tw-inline-flex tw-items-center tw-gap-1`) to keep them aligned and evenly spaced, and size the icon with width/height utilities (e.g. `tw-w-2.5 tw-h-2.5`).
+
+<Story of={KvButtonStories.WithIcons} />
+
+## Anatomy
+
+KvButton is composed of the following parts:
+
+- **Button container**: The rendered element (`button`, `a`, or `router-link`) that handles clicks and focus
+- **Inner label wrapper**: A bordered, rounded span that controls height, background, border, and centering
+- **Label**: The default slot content (text and/or inline elements)
+- **Loading spinner**: Shown in place of the label when `state` is `loading`
+- **Ripple**: A pointer/keyboard-triggered animation that provides click feedback
+
+---
+
+## Specs
+
+### Dimensions
+
+KvButton ships in two sizes. The `default` size is 48px tall with 24px of horizontal padding, a 16px corner radius (`tw-rounded`), and the button-link text style (`tw-text-button-link`); the `small` size is 32px tall with 16px of horizontal padding, a smaller 8px corner radius (`tw-rounded-sm`), and the label text style (`tw-text-label`). Both sizes are available across every variant.
+
+<Story of={KvButtonStories.AllVariations} />
+
+### Spacing
+
+- Horizontal padding is driven by the `size` prop (`tw-px-3` for `default`, `tw-px-2` for `small`); avoid overriding it manually
+- Maintain consistent spacing between adjacent buttons (at least 8px) so touch targets don't overlap
+- Buttons stretch to fill their container when given a full-width utility class (e.g. `tw-w-full`)
+
+---
+
+## Best Practices
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.5rem', margin: '2rem 0'}}>
+	<div>
+		<div style={{marginBottom: '0.5rem'}}>
+			<img src="KvButton/do-use-size-prop.png" alt="" style={{borderRadius: '8px'}} />
+		</div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#2e7d32'}}>✓ Do</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Use the <code>size</code> prop to switch between the default and small button heights so dimensions stay consistent with the design system.</p>
+	</div>
+
+	<div>
+		<div style={{marginBottom: '0.5rem'}}>
+			<img src="KvButton/dont-override-dimensions.png" alt="" style={{borderRadius: '8px'}} />
+		</div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#c62828'}}>✗ Don't</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Manually override the height or horizontal padding with custom classes to fake a different size.</p>
+	</div>
+
+	<div>
+		<div style={{marginBottom: '0.5rem'}}>
+			<img src="KvButton/do-match-variant-to-emphasis.png" alt="" style={{borderRadius: '8px'}} />
+		</div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#2e7d32'}}>✓ Do</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Match the variant to the action's emphasis — one primary button per view, with secondary actions in lower-emphasis variants.</p>
+	</div>
+
+	<div>
+		<div style={{marginBottom: '0.5rem'}}>
+			<img src="KvButton/dont-stack-primaries.png" alt="" style={{borderRadius: '8px'}} />
+		</div>
+		<div style={{fontWeight: 600, marginBottom: '0.5rem', color: '#c62828'}}>✗ Don't</div>
+		<p style={{fontSize: '0.875rem', margin: 0}}>Place multiple competing primary buttons next to each other, which dilutes the call to action.</p>
+	</div>
+</div>
+
+---
+
+## Accessibility
+
+- Renders semantic, focusable elements (`button`, `a`, or `router-link`) with appropriate keyboard support (Enter and Space)
+- The `disabled` and `loading` states set the native `disabled` attribute and disable pointer events so the control cannot be activated
+- Provide a clear, descriptive label via the default slot so the accessible name communicates the action
+- Color variants meet WCAG contrast requirements within the supported themes
+- The ripple animation respects `prefers-reduced-motion` and is suppressed for users who request reduced motion
+
+---
+
+## Component Properties + Demo
+
+<Canvas of={KvButtonStories.Default} />
+<Controls of={KvButtonStories.Default} />
+
+---
+
+## Code Examples
+
+### Default Button
+
+```vue
+<kv-button variant="primary" @click="onSubmit">
+  Find a borrower
+</kv-button>
+```
+
+### Small Button
+
+```vue
+<kv-button variant="secondary" size="small" @click="onFilter">
+  Filter
+</kv-button>
+```
+
+### Button as a Link
+
+```vue
+<kv-button variant="primary" to="/lend">
+  Start lending
+</kv-button>
+```
+
+### Button with an Icon
+
+```vue
+<kv-button variant="primary" @click="onShare">
+  <span class="tw-inline-flex tw-items-center tw-gap-1">
+    Share
+    <kv-material-icon :icon="mdiExportVariant" class="tw-w-2.5 tw-h-2.5" />
+  </span>
+</kv-button>
+```

--- a/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
@@ -89,4 +89,52 @@ describe('Default Button', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+
+	it('renders the default size by default', () => {
+		const { getByText } = renderTestButton();
+		const innerEl = getByText('Test Button');
+		// horizontal padding lives on the inner label span, no vertical padding
+		expect(innerEl).toHaveClass('tw-px-3');
+		expect(innerEl).not.toHaveClass('tw-px-2');
+		expect(innerEl).not.toHaveClass('tw-py-1');
+		// default uses the button-link text style
+		expect(innerEl).toHaveClass('tw-text-button-link');
+		expect(innerEl).not.toHaveClass('tw-text-label');
+		// min-height and corner radius live on the outer span wrapper
+		expect(innerEl.parentElement).toHaveClass('tw-min-h-6');
+		expect(innerEl.parentElement).not.toHaveClass('tw-min-h-4');
+		expect(innerEl.parentElement).toHaveClass('tw-rounded');
+		expect(innerEl.parentElement).not.toHaveClass('tw-rounded-sm');
+	});
+
+	it('renders the default size when size is explicitly "default"', () => {
+		const { getByText } = renderTestButton({ props: { size: 'default' } });
+		const innerEl = getByText('Test Button');
+		expect(innerEl).toHaveClass('tw-px-3');
+		expect(innerEl.parentElement).toHaveClass('tw-min-h-6');
+	});
+
+	it('renders the small size (32px tall, 16px horizontal padding, smaller radius) when size is "small"', () => {
+		const { getByText } = renderTestButton({ props: { size: 'small' } });
+		const innerEl = getByText('Test Button');
+		// 16px horizontal padding, no vertical padding
+		expect(innerEl).toHaveClass('tw-px-2');
+		expect(innerEl).not.toHaveClass('tw-px-3');
+		expect(innerEl).not.toHaveClass('tw-py-1');
+		// small uses the label text style
+		expect(innerEl).toHaveClass('tw-text-label');
+		expect(innerEl).not.toHaveClass('tw-text-button-link');
+		// 32px min-height
+		expect(innerEl.parentElement).toHaveClass('tw-min-h-4');
+		expect(innerEl.parentElement).not.toHaveClass('tw-min-h-6');
+		// smaller corner radius
+		expect(innerEl.parentElement).toHaveClass('tw-rounded-sm');
+		expect(innerEl.parentElement).not.toHaveClass('tw-rounded');
+	});
+
+	it('has no automated accessibility violations in the small size', async () => {
+		const { container } = renderTestButton({ props: { size: 'small' } });
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
 });

--- a/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
+++ b/@kiva/kv-components/tests/unit/specs/components/KvButton.spec.js
@@ -93,12 +93,13 @@ describe('Default Button', () => {
 	it('renders the default size by default', () => {
 		const { getByText } = renderTestButton();
 		const innerEl = getByText('Test Button');
-		// horizontal padding lives on the inner label span, no vertical padding
+		// padding lives on the inner label span
 		expect(innerEl).toHaveClass('tw-px-3');
+		expect(innerEl).toHaveClass('tw-py-1');
 		expect(innerEl).not.toHaveClass('tw-px-2');
-		expect(innerEl).not.toHaveClass('tw-py-1');
-		// default uses the button-link text style
-		expect(innerEl).toHaveClass('tw-text-button-link');
+		expect(innerEl).not.toHaveClass('tw-py-0.5');
+		// default sets no explicit text style — it inherits
+		expect(innerEl).not.toHaveClass('tw-text-button-link');
 		expect(innerEl).not.toHaveClass('tw-text-label');
 		// min-height and corner radius live on the outer span wrapper
 		expect(innerEl.parentElement).toHaveClass('tw-min-h-6');
@@ -117,8 +118,9 @@ describe('Default Button', () => {
 	it('renders the small size (32px tall, 16px horizontal padding, smaller radius) when size is "small"', () => {
 		const { getByText } = renderTestButton({ props: { size: 'small' } });
 		const innerEl = getByText('Test Button');
-		// 16px horizontal padding, no vertical padding
+		// 16px horizontal padding, smaller vertical padding
 		expect(innerEl).toHaveClass('tw-px-2');
+		expect(innerEl).toHaveClass('tw-py-0.5');
 		expect(innerEl).not.toHaveClass('tw-px-3');
 		expect(innerEl).not.toHaveClass('tw-py-1');
 		// small uses the label text style


### PR DESCRIPTION
Adds a `size` prop (`default` | `small`) to KvButton.

[Updated Stories](https://608b4cf87f686c00213841b1-xgihiwltbv.chromatic.com/?path=/docs/forms-kvbutton--docs)

| | height | left/right-padding | top/bottom padding | radius | text style |
|---|---|---|---|---|---|
| `default` | 48px | 24px | 8px | 16px | `inherits default size` |
| `small` | 32px | 16px | 4px | 8px | `tw-text-label` |

Height now comes from min-height + vertical centering (removed inner vertical padding). Includes unit tests, updated Storybook stories (incl. a `WithIcons` story), and new MDX docs.