### PR TITLE
chore: add all color themes to kvSecondaryNav

### DIFF
--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -7,13 +7,13 @@
 			class="
 				tw-z-1 tw-w-full kv-secondary-nav-holder relative
 				tw-text-primary"
-			:class="theme === 'default' ? 'tw-bg-secondary' : 'tw-bg-primary'"
+			:class="bgClass"
 		>
 			<div
 				class="
 				tw-w-full tw-overflow-x-auto kv-secondary-nav
 				tw-absolute tw-top-0 tw-left-0 tw-right-0"
-				:class="theme === 'default' ? 'tw-bg-secondary' : 'tw-bg-primary'"
+				:class="bgClass"
 			>
 				<kv-page-container>
 					<div
@@ -111,7 +111,19 @@ import {
 } from 'vue';
 
 // Theme
-import { defaultTheme, greenDarkTheme } from '@kiva/kv-tokens';
+import {
+	defaultTheme,
+	greenLightTheme,
+	greenDarkTheme,
+	marigoldLightTheme,
+	stoneLightTheme,
+	stoneDarkTheme,
+	darkTheme,
+	mintTheme,
+	darkGreenTheme,
+	darkMintTheme,
+	darkStoneTheme,
+} from '@kiva/kv-tokens';
 
 // Components
 import { mdiChevronUp, mdiChevronDown } from '@mdi/js';
@@ -174,7 +186,20 @@ export default {
 			type: String,
 			default: 'default',
 			validator(value: string) {
-				return ['default', 'dark'].includes(value);
+				return [
+					'default',
+					'dark',
+					'greenLight',
+					'greenDark',
+					'marigoldLight',
+					'stoneLight',
+					'stoneDark',
+					'mint',
+					'darkGreen',
+					'darkMint',
+					'darkStone',
+					'classicDark',
+				].includes(value);
 			},
 		},
 	},
@@ -207,14 +232,22 @@ export default {
 			}
 			return '';
 		});
-
-		const themeStyle = computed(() => {
-			const themeMapper = {
-				default: defaultTheme,
-				dark: greenDarkTheme,
-			};
-			return themeMapper[theme.value];
-		});
+		const themeConfig: Record<string, { style: object; bgClass: string }> = {
+			default: { style: defaultTheme, bgClass: 'tw-bg-secondary' },
+			dark: { style: greenDarkTheme, bgClass: 'tw-bg-primary' },
+			greenLight: { style: greenLightTheme, bgClass: 'tw-bg-secondary' },
+			greenDark: { style: greenDarkTheme, bgClass: 'tw-bg-primary' },
+			marigoldLight: { style: marigoldLightTheme, bgClass: 'tw-bg-secondary' },
+			stoneLight: { style: stoneLightTheme, bgClass: 'tw-bg-secondary' },
+			stoneDark: { style: stoneDarkTheme, bgClass: 'tw-bg-primary' },
+			mint: { style: mintTheme, bgClass: 'tw-bg-secondary' },
+			darkGreen: { style: darkGreenTheme, bgClass: 'tw-bg-primary' },
+			darkMint: { style: darkMintTheme, bgClass: 'tw-bg-primary' },
+			darkStone: { style: darkStoneTheme, bgClass: 'tw-bg-primary' },
+			classicDark: { style: darkTheme, bgClass: 'tw-bg-primary' },
+		};
+		const themeStyle = computed(() => themeConfig[theme.value]?.style);
+		const bgClass = computed(() => themeConfig[theme.value]?.bgClass ?? 'tw-bg-primary');
 
 		const toggleSubNavigation = () => {
 			subNavigationOpen.value = !subNavigationOpen.value;
@@ -233,6 +266,7 @@ export default {
 			mdiChevronDown,
 			subNavigation,
 			themeStyle,
+			bgClass,
 			handleLinkClick,
 		};
 	},

--- a/@kiva/kv-components/src/vue/KvSecondaryNav.vue
+++ b/@kiva/kv-components/src/vue/KvSecondaryNav.vue
@@ -117,12 +117,6 @@ import {
 	greenDarkTheme,
 	marigoldLightTheme,
 	stoneLightTheme,
-	stoneDarkTheme,
-	darkTheme,
-	mintTheme,
-	darkGreenTheme,
-	darkMintTheme,
-	darkStoneTheme,
 } from '@kiva/kv-tokens';
 
 // Components
@@ -193,12 +187,6 @@ export default {
 					'greenDark',
 					'marigoldLight',
 					'stoneLight',
-					'stoneDark',
-					'mint',
-					'darkGreen',
-					'darkMint',
-					'darkStone',
-					'classicDark',
 				].includes(value);
 			},
 		},
@@ -239,12 +227,6 @@ export default {
 			greenDark: { style: greenDarkTheme, bgClass: 'tw-bg-primary' },
 			marigoldLight: { style: marigoldLightTheme, bgClass: 'tw-bg-secondary' },
 			stoneLight: { style: stoneLightTheme, bgClass: 'tw-bg-secondary' },
-			stoneDark: { style: stoneDarkTheme, bgClass: 'tw-bg-primary' },
-			mint: { style: mintTheme, bgClass: 'tw-bg-secondary' },
-			darkGreen: { style: darkGreenTheme, bgClass: 'tw-bg-primary' },
-			darkMint: { style: darkMintTheme, bgClass: 'tw-bg-primary' },
-			darkStone: { style: darkStoneTheme, bgClass: 'tw-bg-primary' },
-			classicDark: { style: darkTheme, bgClass: 'tw-bg-primary' },
 		};
 		const themeStyle = computed(() => themeConfig[theme.value]?.style);
 		const bgClass = computed(() => themeConfig[theme.value]?.bgClass ?? 'tw-bg-primary');

--- a/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
@@ -3,6 +3,25 @@ import KvSecondaryNav from '../KvSecondaryNav.vue';
 export default {
 	title: 'Page Frame/KvSecondaryNav',
 	component: KvSecondaryNav,
+	argTypes: {
+		theme: {
+			control: 'select',
+			options: [
+				'default',
+				'dark',
+				'greenLight',
+				'greenDark',
+				'marigoldLight',
+				'stoneLight',
+				'stoneDark',
+				'mint',
+				'darkGreen',
+				'darkMint',
+				'darkStone',
+				'classicDark',
+			],
+		},
+	},
 	args: {
 		heading: 'Due Diligence',
 		headingLink: {
@@ -61,6 +80,56 @@ Default.args = {
 export const Dark = Template.bind({});
 Dark.args = {
 	theme: 'dark',
+};
+
+export const GreenLight = Template.bind({});
+GreenLight.args = {
+	theme: 'greenLight',
+};
+
+export const GreenDark = Template.bind({});
+GreenDark.args = {
+	theme: 'greenDark',
+};
+
+export const MarigoldLight = Template.bind({});
+MarigoldLight.args = {
+	theme: 'marigoldLight',
+};
+
+export const StoneLight = Template.bind({});
+StoneLight.args = {
+	theme: 'stoneLight',
+};
+
+export const StoneDark = Template.bind({});
+StoneDark.args = {
+	theme: 'stoneDark',
+};
+
+export const Mint = Template.bind({});
+Mint.args = {
+	theme: 'mint',
+};
+
+export const DarkGreen = Template.bind({});
+DarkGreen.args = {
+	theme: 'darkGreen',
+};
+
+export const DarkMint = Template.bind({});
+DarkMint.args = {
+	theme: 'darkMint',
+};
+
+export const DarkStone = Template.bind({});
+DarkStone.args = {
+	theme: 'darkStone',
+};
+
+export const ClassicDark = Template.bind({});
+ClassicDark.args = {
+	theme: 'classicDark',
 };
 
 export const Centered = Template.bind({});

--- a/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
+++ b/@kiva/kv-components/src/vue/stories/KvSecondaryNav.stories.js
@@ -13,12 +13,6 @@ export default {
 				'greenDark',
 				'marigoldLight',
 				'stoneLight',
-				'stoneDark',
-				'mint',
-				'darkGreen',
-				'darkMint',
-				'darkStone',
-				'classicDark',
 			],
 		},
 	},
@@ -100,36 +94,6 @@ MarigoldLight.args = {
 export const StoneLight = Template.bind({});
 StoneLight.args = {
 	theme: 'stoneLight',
-};
-
-export const StoneDark = Template.bind({});
-StoneDark.args = {
-	theme: 'stoneDark',
-};
-
-export const Mint = Template.bind({});
-Mint.args = {
-	theme: 'mint',
-};
-
-export const DarkGreen = Template.bind({});
-DarkGreen.args = {
-	theme: 'darkGreen',
-};
-
-export const DarkMint = Template.bind({});
-DarkMint.args = {
-	theme: 'darkMint',
-};
-
-export const DarkStone = Template.bind({});
-DarkStone.args = {
-	theme: 'darkStone',
-};
-
-export const ClassicDark = Template.bind({});
-ClassicDark.args = {
-	theme: 'classicDark',
 };
 
 export const Centered = Template.bind({});


### PR DESCRIPTION
Ticket: [KUSPMTM-25](https://kiva.atlassian.net/browse/KUSPMTM-25)

Expands KvSecondaryNav to accept the full set of Kiva color themes so the mint palette in the designs can actually reach the component. Added all 11 available themes at once, same amount of work as adding one, and it avoids revisiting this if/when other themes come up.

The two hardcoded `theme === 'default'` ternaries are replaced by a themeConfig table where each theme declares both its token bundle and which background slot the nav uses (light palettes → `bg-secondary`, dark palettes → `bg-primary`).

Note on backwards compatibility: existing `theme="default"` and `theme="dark"` consumers render identically to main. Invalid theme strings also render identically. `themeStyle` returns undefined and `bgClass` falls back to `tw-bg-primary`, matching the old ternary's else branch. I kept it this way intentionally so a consumer that accidentally passes an unrecognized string doesn't silently switch from the dark-themed fallback to a default one.

[KUSPMTM-25]: https://kiva.atlassian.net/browse/KUSPMTM-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ