### PR TITLE
chore: docs and skill for code connect

### DIFF
--- a/@kiva/kv-components/docs/code-connect.md
+++ b/@kiva/kv-components/docs/code-connect.md
@@ -144,6 +144,11 @@ case exactly, and the **`label` is a nested TEXT layer** read with `findText(...
 
 ## Publishing
 
+> **Publishing workflow (agents & humans):** for the step-by-step detect →
+> validate → reconcile → publish → verify flow, plus token setup, use the
+> **`publish-code-connect`** skill in `@kiva/kv-skills` (`kiva-design-to-code`
+> plugin). This section is the reference it defers to for authoring/reconciling.
+
 Publish writes the mapping to the **shared Figma org library** — every designer and
 engineer with access to that library sees the result. Do this deliberately, not as a
 side effect of another task:

--- a/@kiva/kv-components/docs/code-connect.md
+++ b/@kiva/kv-components/docs/code-connect.md
@@ -202,9 +202,7 @@ to touch it to map a component — it's here for maintenance.
 - **Figma plan**: Org or Enterprise (Code Connect publish is gated on this).
 - **A published component** in a Figma team library — Code Connect maps to a published
   component's `node-id`, not a local/unpublished frame.
-- **`FIGMA_ACCESS_TOKEN`** with Code Connect write scope, as a local/CI environment
-  variable. **Never commit this token.** It's only required for `publish`; `parse` needs
-  no token.
+- **`FIGMA_ACCESS_TOKEN`** with Code Connect write scope, as a local environment variable (Code Connect write can't run in CI — see the `publish-code-connect` skill for why). **Never commit this token.** It's only required for `publish`; `parse` needs no token.
 - **A way to read the component's real property names/values** before writing or
   reconciling a mapping — the **Figma MCP server** (`get_context_for_code_connect` /
   `get_code_connect_suggestions`) preferred, or the `figma connect create <node-url>` CLI

--- a/@kiva/kv-skills/design-to-code/.claude-plugin/plugin.json
+++ b/@kiva/kv-skills/design-to-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kiva-design-to-code",
   "description": "Turning Kiva designs into compliant code: the Kiva Tailwind preset, plus audits/migrations that bring consuming repos into design-system alignment.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": ["kiva", "tailwind", "css", "migration", "audit", "design-to-code"]
 }

--- a/@kiva/kv-skills/design-to-code/.codex-plugin/plugin.json
+++ b/@kiva/kv-skills/design-to-code/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kiva-design-to-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Turning Kiva designs into compliant code: the Kiva Tailwind preset, plus audits/migrations that bring consuming repos into design-system alignment.",
   "author": {
     "name": "Kiva"

--- a/@kiva/kv-skills/design-to-code/.codex-plugin/plugin.json
+++ b/@kiva/kv-skills/design-to-code/.codex-plugin/plugin.json
@@ -10,7 +10,7 @@
   "interface": {
     "displayName": "Kiva Design to Code",
     "shortDescription": "Kiva Tailwind preset plus design-system audits and migrations",
-    "longDescription": "Developer tooling for translating Kiva's design system into compliant code: how the @kiva/kv-tokens Tailwind preset changes stock Tailwind, and a page-design audit that brings a route's typography and spacing into design-system alignment with before/after screenshots.",
+    "longDescription": "Developer tooling for translating Kiva's design system into compliant code: how the @kiva/kv-tokens Tailwind preset changes stock Tailwind, a page-design audit that brings a route's typography and spacing into design-system alignment with before/after screenshots, and a workflow to publish @kiva/kv-components Figma Code Connect mappings to Figma.",
     "developerName": "Kiva",
     "category": "Development",
     "capabilities": ["Read", "Write"]

--- a/@kiva/kv-skills/design-to-code/README.md
+++ b/@kiva/kv-skills/design-to-code/README.md
@@ -13,6 +13,7 @@ Code / Codex, not the Claude app.
 |-------|--------------|
 | `kiva-tailwind-css` | How the `@kiva/kv-tokens` Tailwind preset changes stock Tailwind. |
 | `audit-page-design` | Audit a page against the design system one dimension at a time (typography, then spacing), apply in-repo fixes, and capture before/after screenshots. |
+| `publish-code-connect` | Detect changed Code Connect mappings in `@kiva/kv-components` and publish them to Figma — validate, reconcile, publish, verify. |
 
 > **Depends on `kiva-design-system`.** `audit-page-design` judges against the
 > design-system token sub-skills, so install the

--- a/@kiva/kv-skills/design-to-code/skills/publish-code-connect/SKILL.md
+++ b/@kiva/kv-skills/design-to-code/skills/publish-code-connect/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: publish-code-connect
+description: Detect changed Figma Code Connect mappings in @kiva/kv-components and publish them to the shared Figma org library — validate, optionally reconcile property names against the live node, then publish and verify in Dev Mode. Wholesale idempotent publish; no CI path (Figma allows only a 90-day user token for Code Connect write).
+when_to_use: When a @kiva/kv-components Code Connect mapping (src/vue/code-connect/*.figma.ts) has been added or changed and needs to go live in Figma, or when someone asks to "publish code connect", "push the KvButton mapping to Figma", "sync Dev Mode snippets", or "why isn't the updated mapping showing in Figma". For how to AUTHOR or RECONCILE a mapping, defer to @kiva/kv-components/docs/code-connect.md.
+---
+
+# Publish Code Connect
+
+## Purpose
+
+Take Code Connect mappings that already exist in `@kiva/kv-components`
+(`src/vue/code-connect/<Name>.figma.ts`) and get the changed ones live in the
+shared Figma org library — safely and deliberately. This skill owns the
+**publish workflow**: detect what changed, validate, reconcile if the Figma node
+may have drifted, publish, verify.
+
+It is **not** the authoring guide. For how a mapping is written and how property
+names are reconciled against the real node, the canonical reference is
+[`@kiva/kv-components/docs/code-connect.md`](../../../../kv-components/docs/code-connect.md).
+Read it before writing or fixing a `.figma.ts` file; come here to publish one.
+
+## Before you start: the token reality
+
+Publishing writes to the shared org library, so it needs a Figma token — and
+Figma constrains which token works:
+
+- Use a **personal access token (PAT)** with scopes **`file_code_connect:write`**
+  and **`file_content:read`**. Create it at Figma → Settings → Security →
+  Personal access tokens.
+- The PAT has a **90-day maximum expiry** and is **tied to your user account**.
+- There is **no plan/service-account token** for Code Connect write — Figma's
+  org-level "plan access tokens" explicitly exclude `file_code_connect:write`.
+  That is why this is a deliberate local action and **not** a CI job: any
+  automation would need a user PAT rotated every ~90 days.
+- **Never commit the token.** Export it for the publish run only:
+
+  ```bash
+  export FIGMA_ACCESS_TOKEN="figd_..."
+  ```
+
+If a publish ever fails with a 401/403, the token has almost certainly expired —
+regenerate it (same two scopes) and re-export.
+
+## Workflow
+
+Run every command from the repo root of `kv-ui-elements` unless noted.
+
+### 1. Preflight
+
+```bash
+nvm use
+```
+
+Confirm the token is set (prints only whether it is present, never the value):
+
+```bash
+[ -n "$FIGMA_ACCESS_TOKEN" ] && echo "token set" || echo "TOKEN MISSING — see 'the token reality' above"
+```
+
+`figma.config.json` at `@kiva/kv-components/` already scopes discovery — no config
+change is ever needed per component.
+
+### 2. Detect what changed
+
+List Code Connect mappings that differ from `main` (adjust the ref if you are
+publishing from a different base):
+
+```bash
+git fetch origin main --quiet
+git diff --name-only origin/main...HEAD -- '@kiva/kv-components/src/vue/code-connect/*.figma.ts'
+```
+
+- **No output** → nothing to publish. Stop unless you are intentionally
+  re-publishing to repair the Figma side.
+- **One or more files** → note the component(s); you will verify each in step 5.
+
+> **Important — publish is wholesale.** `figma connect publish` re-uploads **all**
+> mappings matched by `figma.config.json`, every run. There is **no
+> per-component publish flag** under the `html` parser. This detection step tells
+> you *whether* to publish and *which* components to verify afterward — it does
+> **not** produce a partial upload. Re-publishing unchanged mappings is
+> harmless (idempotent).
+
+### 3. Validate (no network write)
+
+```bash
+npm run codeconnect:parse --workspace @kiva/kv-components
+```
+
+Expect a clean JSON array and exit code 0. `parse` is **structural only** — it
+has no live component, so it does not catch property name/case mismatches. Those
+surface only when Figma renders the published mapping (step 5).
+
+### 4. Reconcile if the node may have drifted (conditional)
+
+Skip this if the change was code-only (e.g. a slot rename that doesn't touch
+Figma) and you are confident the Figma component's property names/values are
+unchanged. Otherwise, confirm names **before** publishing:
+
+- **Figma MCP (preferred):** call `get_context_for_code_connect` against the
+  component's node (the `fileKey` + `node-id` from the `url=` comment atop the
+  `.figma.ts` file). It returns every property's name, type, and variant options
+  plus nested `TEXT` layers.
+- **Fallbacks** (`figma connect create <node-url>` diff, or Dev Mode Properties
+  panel) and the full reconciliation loop are documented in
+  [`code-connect.md`](../../../../kv-components/docs/code-connect.md#reading-the-real-figma-property-names).
+
+Update the `.figma.ts` file for any mismatch, then re-run step 3.
+
+### 5. Publish
+
+```bash
+npm run codeconnect:publish --workspace @kiva/kv-components
+```
+
+This parses and publishes to the shared org. Requires `FIGMA_ACCESS_TOKEN` in the
+environment (step 1).
+
+### 6. Verify in Dev Mode
+
+For **each** component flagged in step 2, open it in Figma Dev Mode and confirm:
+
+- the `@kiva/kv-components` snippet renders (not generated markup), and
+- **no "Property not found"** appears on any mapped prop.
+
+A "Property not found" means a name/case mismatch that `parse` cannot catch — go
+back to step 4, fix the `.figma.ts`, and re-publish.
+
+## Guardrails
+
+- **Publish deliberately.** Never run `codeconnect:publish` as a side effect of
+  unrelated repo work (adding a component, fixing a build). Only publish a
+  mapping that has been validated and, if needed, reconciled against the real
+  node.
+- **Keep the token out of git.** Export it in the shell for the run; do not add
+  it to a committed file.
+- **Whoever reconciled it, publishes it.** The person who confirmed the
+  property names against the live node is best placed to run the publish and
+  verify Dev Mode.
+- **No CI shortcut exists today.** If someone asks to automate this in GitHub
+  Actions, the blocker is the 90-day user-scoped PAT (see "the token reality") —
+  raise the rotation/robot-seat tradeoff rather than wiring a long-lived token
+  into CI.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -62,7 +62,7 @@ restart Codex (or reload the session) so it picks up the updated plugin cache.
 | Category (folder) | Plugin | Skills |
 |---|---|---|
 | `@kiva/kv-skills/design-system` | `kiva-design-system` | `kiva-design-system` (router + color, typography, spacing, radius, layout, color-themes) |
-| `@kiva/kv-skills/design-to-code` | `kiva-design-to-code` | `kiva-tailwind-css`, `audit-page-design` |
+| `@kiva/kv-skills/design-to-code` | `kiva-design-to-code` | `kiva-tailwind-css`, `audit-page-design`, `publish-code-connect` |
 | `@kiva/kv-skills/skill-builder-utils` | `kiva-skill-builder-utils` | `figma-design-system-to-skill` |
 
 ## Adding a skill (to an existing category)


### PR DESCRIPTION
Documentation and Skill for  publishing Figma Code Connect mappings

The new `publish-code-connect` skill in the `@kiva/kv-skills/design-to-code` plugin, which provides a safe, manual process for publishing mapping changes to the shared Figma organization library. Supporting documentation has been updated to describe the workflow, clarify token requirements, and ensure users understand the manual nature of the process due to Figma's token limitations.